### PR TITLE
🎬박스오피스 II [STEP 1]  goat, songjun

### DIFF
--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		5817F45829C8483500C8595C /* ParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5817F45729C8483500C8595C /* ParserTests.swift */; };
 		5817F45F29C98B7100C8595C /* MovieDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5817F45E29C98B7100C8595C /* MovieDetail.swift */; };
 		58570C4B29DD0FEA00A936B4 /* ImageSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58570C4A29DD0FEA00A936B4 /* ImageSearchService.swift */; };
+		58570C4D29DD53DA00A936B4 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58570C4C29DD53DA00A936B4 /* String+Extension.swift */; };
 		63DF20EF2970E1A0005DF7D1 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DF20EE2970E1A0005DF7D1 /* AppDelegate.swift */; };
 		63DF20F12970E1A0005DF7D1 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DF20F02970E1A0005DF7D1 /* SceneDelegate.swift */; };
 		63DF20F32970E1A0005DF7D1 /* BoxOfficeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DF20F22970E1A0005DF7D1 /* BoxOfficeViewController.swift */; };
@@ -67,6 +68,7 @@
 		5817F45729C8483500C8595C /* ParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParserTests.swift; sourceTree = "<group>"; };
 		5817F45E29C98B7100C8595C /* MovieDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieDetail.swift; sourceTree = "<group>"; };
 		58570C4A29DD0FEA00A936B4 /* ImageSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageSearchService.swift; sourceTree = "<group>"; };
+		58570C4C29DD53DA00A936B4 /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
 		63DF20EB2970E1A0005DF7D1 /* BoxOffice.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BoxOffice.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		63DF20EE2970E1A0005DF7D1 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		63DF20F02970E1A0005DF7D1 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -130,6 +132,7 @@
 			children = (
 				1CB8C00F29D2AF70006203E4 /* NSMutableAttributedString+Extension.swift */,
 				1CC64F7B29DD3CE000C38876 /* Int+Extension.swift */,
+				58570C4C29DD53DA00A936B4 /* String+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -323,6 +326,7 @@
 				1CC64F7A29DD3CC900C38876 /* CalendarView.swift in Sources */,
 				5817F45029C82C4500C8595C /* Parser.swift in Sources */,
 				1C5263DE29CC24AC00B57C6A /* BoxOfficeListCell.swift in Sources */,
+				58570C4D29DD53DA00A936B4 /* String+Extension.swift in Sources */,
 				63DF20EF2970E1A0005DF7D1 /* AppDelegate.swift in Sources */,
 				1C5CAA8229DA9F460053F19A /* ImageSearchEndpoint.swift in Sources */,
 				5817F45F29C98B7100C8595C /* MovieDetail.swift in Sources */,

--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -20,6 +20,9 @@
 		1CB8C01329D2C115006203E4 /* EndpointMakeable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CB8C01229D2C115006203E4 /* EndpointMakeable.swift */; };
 		1CB8C01529D2C11C006203E4 /* Provider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CB8C01429D2C11C006203E4 /* Provider.swift */; };
 		1CC64F7629DD040000C38876 /* BoxOfficeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CC64F7529DD03FF00C38876 /* BoxOfficeService.swift */; };
+		1CC64F7829DD3CB400C38876 /* CalendarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CC64F7729DD3CB400C38876 /* CalendarViewController.swift */; };
+		1CC64F7A29DD3CC900C38876 /* CalendarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CC64F7929DD3CC900C38876 /* CalendarView.swift */; };
+		1CC64F7C29DD3CE000C38876 /* Int+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CC64F7B29DD3CE000C38876 /* Int+Extension.swift */; };
 		5817F45029C82C4500C8595C /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5817F44F29C82C4500C8595C /* Parser.swift */; };
 		5817F45829C8483500C8595C /* ParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5817F45729C8483500C8595C /* ParserTests.swift */; };
 		5817F45F29C98B7100C8595C /* MovieDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5817F45E29C98B7100C8595C /* MovieDetail.swift */; };
@@ -56,6 +59,9 @@
 		1CB8C01229D2C115006203E4 /* EndpointMakeable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndpointMakeable.swift; sourceTree = "<group>"; };
 		1CB8C01429D2C11C006203E4 /* Provider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Provider.swift; sourceTree = "<group>"; };
 		1CC64F7529DD03FF00C38876 /* BoxOfficeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxOfficeService.swift; sourceTree = "<group>"; };
+		1CC64F7729DD3CB400C38876 /* CalendarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewController.swift; sourceTree = "<group>"; };
+		1CC64F7929DD3CC900C38876 /* CalendarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarView.swift; sourceTree = "<group>"; };
+		1CC64F7B29DD3CE000C38876 /* Int+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+Extension.swift"; sourceTree = "<group>"; };
 		5817F44F29C82C4500C8595C /* Parser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Parser.swift; sourceTree = "<group>"; };
 		5817F45529C8483500C8595C /* BoxOfficeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BoxOfficeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5817F45729C8483500C8595C /* ParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParserTests.swift; sourceTree = "<group>"; };
@@ -94,6 +100,7 @@
 			children = (
 				63DF20F22970E1A0005DF7D1 /* BoxOfficeViewController.swift */,
 				1C5CAA7B29DA9EE60053F19A /* MovieDetailViewController.swift */,
+				1CC64F7729DD3CB400C38876 /* CalendarViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -104,6 +111,7 @@
 				63DF20F42970E1A0005DF7D1 /* Main.storyboard */,
 				1C5263DD29CC24AC00B57C6A /* BoxOfficeListCell.swift */,
 				1C5CAA7F29DA9F1C0053F19A /* MovieDetailView.swift */,
+				1CC64F7929DD3CC900C38876 /* CalendarView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -121,6 +129,7 @@
 			isa = PBXGroup;
 			children = (
 				1CB8C00F29D2AF70006203E4 /* NSMutableAttributedString+Extension.swift */,
+				1CC64F7B29DD3CE000C38876 /* Int+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -302,13 +311,16 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1CC64F7829DD3CB400C38876 /* CalendarViewController.swift in Sources */,
 				58570C4B29DD0FEA00A936B4 /* ImageSearchService.swift in Sources */,
 				63DF20F32970E1A0005DF7D1 /* BoxOfficeViewController.swift in Sources */,
 				1C5CAA7C29DA9EE60053F19A /* MovieDetailViewController.swift in Sources */,
 				1CB8C01029D2AF70006203E4 /* NSMutableAttributedString+Extension.swift in Sources */,
+				1CC64F7C29DD3CE000C38876 /* Int+Extension.swift in Sources */,
 				1CB8C01529D2C11C006203E4 /* Provider.swift in Sources */,
 				1C5CAA7E29DA9F020053F19A /* ImageSearch.swift in Sources */,
 				1CB8C01329D2C115006203E4 /* EndpointMakeable.swift in Sources */,
+				1CC64F7A29DD3CC900C38876 /* CalendarView.swift in Sources */,
 				5817F45029C82C4500C8595C /* Parser.swift in Sources */,
 				1C5263DE29CC24AC00B57C6A /* BoxOfficeListCell.swift in Sources */,
 				63DF20EF2970E1A0005DF7D1 /* AppDelegate.swift in Sources */,
@@ -526,7 +538,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -554,7 +566,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -117,8 +117,6 @@ final class BoxOfficeViewController: UIViewController, CalendarDateDelegate {
     
     private func createYesterDate() -> String {
         let formatter = DateFormatter()
-        formatter.dateStyle = .long
-        formatter.timeStyle = .medium
         formatter.dateFormat = "yyyyMMdd"
         let yesterDate = formatter.string(from: Date(timeIntervalSinceNow: -86400))
         return yesterDate

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -15,7 +15,7 @@ final class BoxOfficeViewController: UIViewController, CalendarDateDelegate {
     let boxOfficeService = BoxOfficeService()
     private var provider = Provider()
     let calendarViewController = CalendarViewController()
-    var choosenDate: String = ""{
+    var choosenDate: String = "" {
         didSet {
             fetchDailyBoxOffice()
             setNavigationBarTitle()            
@@ -33,6 +33,9 @@ final class BoxOfficeViewController: UIViewController, CalendarDateDelegate {
     }
     
     private func fetchDailyBoxOffice() {
+        if choosenDate == "" {
+            choosenDate = self.createYesterDate()
+        }
         boxOfficeService.fetchDailyBoxOfficeAPI(date: choosenDate) {
             DispatchQueue.main.async {
                 self.boxOfficeListCollectionView.reloadData()
@@ -110,6 +113,15 @@ final class BoxOfficeViewController: UIViewController, CalendarDateDelegate {
     
     private func setNavigationBarTitle() {
         self.title = choosenDate
+    }
+    
+    private func createYesterDate() -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .long
+        formatter.timeStyle = .medium
+        formatter.dateFormat = "yyyyMMdd"
+        let yesterDate = formatter.string(from: Date(timeIntervalSinceNow: -86400))
+        return yesterDate
     }
 }
 

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -108,7 +108,7 @@ final class BoxOfficeViewController: UIViewController {
     }
     
     private func setNavigationBarTitle() {
-        self.title = choosenDate.insertDashFormatter()
+        self.title = choosenDate.insertDash()
     }
     
     private func getYesterdayDescription() -> String {

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -34,7 +34,7 @@ final class BoxOfficeViewController: UIViewController {
     
     private func fetchDailyBoxOffice() {
         if choosenDate == "" {
-            choosenDate = self.getYesterDate()
+            choosenDate = self.getYesterdayDescription()
         }
         
         boxOfficeService.fetchDailyBoxOfficeAPI(date: choosenDate) {
@@ -111,7 +111,7 @@ final class BoxOfficeViewController: UIViewController {
         self.title = choosenDate.insertDashFormatter()
     }
     
-    private func getYesterDate() -> String {
+    private func getYesterdayDescription() -> String {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyyMMdd"
         let yesterDate = formatter.string(from: Date(timeIntervalSinceNow: -86400))

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -36,7 +36,8 @@ final class BoxOfficeViewController: UIViewController, CalendarDateDelegate {
         if choosenDate == "" {
             choosenDate = self.createYesterDate()
         }
-        boxOfficeService.fetchDailyBoxOfficeAPI(date: choosenDate) {
+        let dateValue = choosenDate.removeDashFromDate()
+        boxOfficeService.fetchDailyBoxOfficeAPI(date: dateValue) {
             DispatchQueue.main.async {
                 self.boxOfficeListCollectionView.reloadData()
                 self.activityIndicator.stopAnimating()
@@ -107,7 +108,7 @@ final class BoxOfficeViewController: UIViewController, CalendarDateDelegate {
     }
     
     func receiveDate(date: String) {
-        choosenDate = date
+        choosenDate = date.insertDashFromDate()
         print(choosenDate)
     }
     
@@ -117,7 +118,7 @@ final class BoxOfficeViewController: UIViewController, CalendarDateDelegate {
     
     private func createYesterDate() -> String {
         let formatter = DateFormatter()
-        formatter.dateFormat = "yyyyMMdd"
+        formatter.dateFormat = "yyyy-MM-dd"
         let yesterDate = formatter.string(from: Date(timeIntervalSinceNow: -86400))
         return yesterDate
     }

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -7,9 +7,20 @@
 
 import UIKit
 
-final class BoxOfficeViewController: UIViewController {
+protocol CalendarDateDelegate: AnyObject {
+    func receiveDate(date: String)
+}
+
+final class BoxOfficeViewController: UIViewController, CalendarDateDelegate {
     let boxOfficeService = BoxOfficeService()
     private var provider = Provider()
+    let calendarViewController = CalendarViewController()
+    var choosenDate: String = ""{
+        didSet {
+            fetchDailyBoxOffice()
+            setNavigationBarTitle()            
+        }
+    }
     
     @IBOutlet weak var boxOfficeListCollectionView: UICollectionView!
     lazy var activityIndicator = UIActivityIndicatorView()
@@ -18,10 +29,11 @@ final class BoxOfficeViewController: UIViewController {
         super.viewDidLoad()
         fetchDailyBoxOffice()
         setUpView()
+        setCalendarViewDelegate()
     }
     
     private func fetchDailyBoxOffice() {
-        boxOfficeService.fetchDailyBoxOfficeAPI() {
+        boxOfficeService.fetchDailyBoxOfficeAPI(date: choosenDate) {
             DispatchQueue.main.async {
                 self.boxOfficeListCollectionView.reloadData()
                 self.activityIndicator.stopAnimating()
@@ -30,15 +42,20 @@ final class BoxOfficeViewController: UIViewController {
     }
     
     private func setUpView() {
-        setTitle()
+        setNavigationBar()
         setActivityIndicator()
         setBoxOfficeListCollectionView()
         configureRefreshControl()
         configureUI()
     }
     
-    private func setTitle() {
-        self.title = "2302323"
+    private func setNavigationBar() {
+        self.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "날짜선택", style: .plain, target: self, action: #selector(tabRightBarButton))
+    }
+    
+    @objc
+    func tabRightBarButton() {
+        self.present(calendarViewController, animated: true, completion: nil)
     }
     
     private func setActivityIndicator() {
@@ -80,6 +97,19 @@ final class BoxOfficeViewController: UIViewController {
             boxOfficeListCollectionView.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor),
             boxOfficeListCollectionView.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor)
         ])
+    }
+    
+    private func setCalendarViewDelegate() {
+        calendarViewController.delegate = self
+    }
+    
+    func receiveDate(date: String) {
+        choosenDate = date
+        print(choosenDate)
+    }
+    
+    private func setNavigationBarTitle() {
+        self.title = choosenDate
     }
 }
 

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -11,7 +11,7 @@ protocol CalendarDateDelegate: AnyObject {
     func receiveDate(date: String)
 }
 
-final class BoxOfficeViewController: UIViewController, CalendarDateDelegate {
+final class BoxOfficeViewController: UIViewController {
     let boxOfficeService = BoxOfficeService()
     private var provider = Provider()
     let calendarViewController = CalendarViewController()
@@ -34,7 +34,7 @@ final class BoxOfficeViewController: UIViewController, CalendarDateDelegate {
     
     private func fetchDailyBoxOffice() {
         if choosenDate == "" {
-            choosenDate = self.createYesterDate()
+            choosenDate = self.getYesterDate()
         }
         let dateValue = choosenDate.removeDashFromDate()
         boxOfficeService.fetchDailyBoxOfficeAPI(date: dateValue) {
@@ -58,7 +58,7 @@ final class BoxOfficeViewController: UIViewController, CalendarDateDelegate {
     }
     
     @objc
-    func tabRightBarButton() {
+    private func tabRightBarButton() {
         self.present(calendarViewController, animated: true, completion: nil)
     }
     
@@ -83,7 +83,7 @@ final class BoxOfficeViewController: UIViewController, CalendarDateDelegate {
     }
     
     @objc
-    func handleRefreshControl() {
+    private func handleRefreshControl() {
         DispatchQueue.main.async {
             self.boxOfficeListCollectionView.reloadData()
             self.boxOfficeListCollectionView.refreshControl?.endRefreshing()
@@ -107,16 +107,11 @@ final class BoxOfficeViewController: UIViewController, CalendarDateDelegate {
         calendarViewController.delegate = self
     }
     
-    func receiveDate(date: String) {
-        choosenDate = date.insertDashFromDate()
-        print(choosenDate)
-    }
-    
     private func setNavigationBarTitle() {
         self.title = choosenDate
     }
     
-    private func createYesterDate() -> String {
+    private func getYesterDate() -> String {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd"
         let yesterDate = formatter.string(from: Date(timeIntervalSinceNow: -86400))
@@ -194,5 +189,12 @@ extension BoxOfficeViewController {
             return section
         }
         return layout
+    }
+}
+
+extension BoxOfficeViewController:  CalendarDateDelegate {
+    func receiveDate(date: String) {
+        choosenDate = date.insertDashFromDate()
+        print(choosenDate)
     }
 }

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -36,8 +36,8 @@ final class BoxOfficeViewController: UIViewController {
         if choosenDate == "" {
             choosenDate = self.getYesterDate()
         }
-        let dateValue = choosenDate.removeDashFromDate()
-        boxOfficeService.fetchDailyBoxOfficeAPI(date: dateValue) {
+        
+        boxOfficeService.fetchDailyBoxOfficeAPI(date: choosenDate) {
             DispatchQueue.main.async {
                 self.boxOfficeListCollectionView.reloadData()
                 self.activityIndicator.stopAnimating()
@@ -108,12 +108,12 @@ final class BoxOfficeViewController: UIViewController {
     }
     
     private func setNavigationBarTitle() {
-        self.title = choosenDate
+        self.title = choosenDate.insertDashFormatter()
     }
     
     private func getYesterDate() -> String {
         let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.dateFormat = "yyyyMMdd"
         let yesterDate = formatter.string(from: Date(timeIntervalSinceNow: -86400))
         return yesterDate
     }
@@ -192,9 +192,9 @@ extension BoxOfficeViewController {
     }
 }
 
-extension BoxOfficeViewController:  CalendarDateDelegate {
+extension BoxOfficeViewController: CalendarDateDelegate {
     func receiveDate(date: String) {
-        choosenDate = date.insertDashFromDate()
+        choosenDate = date
         print(choosenDate)
     }
 }

--- a/BoxOffice/Controller/CalendarViewController.swift
+++ b/BoxOffice/Controller/CalendarViewController.swift
@@ -1,0 +1,34 @@
+//
+//  CalendarViewController.swift
+//  BoxOffice
+//
+//  Created by goat, songjun on 2023/04/04.
+//
+
+import UIKit
+
+class CalendarViewController: UIViewController {
+    private var calendarView = CalendarView()
+    var choosenDate = ""
+    weak var delegate: CalendarDateDelegate?
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view = calendarView
+        let selection = UICalendarSelectionSingleDate(delegate: self)
+        calendarView.selectionBehavior = selection
+    }
+}
+
+extension CalendarViewController: UICalendarSelectionSingleDateDelegate {
+    func dateSelection(_ selection: UICalendarSelectionSingleDate, didSelectDate dateComponents: DateComponents?) {
+        guard let year = dateComponents?.year?.convertIntToString() else { return }
+        guard let month = dateComponents?.month?.convertIntToString() else { return }
+        guard let day = dateComponents?.day?.convertIntToString() else { return }
+        choosenDate += year + month + day
+        delegate?.receiveDate(date: choosenDate)
+        choosenDate = ""
+        self.dismiss(animated: true)
+        return
+    }
+}

--- a/BoxOffice/Controller/CalendarViewController.swift
+++ b/BoxOffice/Controller/CalendarViewController.swift
@@ -15,6 +15,10 @@ class CalendarViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view = calendarView
+        setCalendarViewSelectionBehavior()
+    }
+    
+    private func setCalendarViewSelectionBehavior() {
         let selection = UICalendarSelectionSingleDate(delegate: self)
         calendarView.selectionBehavior = selection
     }

--- a/BoxOffice/Controller/CalendarViewController.swift
+++ b/BoxOffice/Controller/CalendarViewController.swift
@@ -26,13 +26,13 @@ class CalendarViewController: UIViewController {
 
 extension CalendarViewController: UICalendarSelectionSingleDateDelegate {
     func dateSelection(_ selection: UICalendarSelectionSingleDate, didSelectDate dateComponents: DateComponents?) {
-        guard let year = dateComponents?.year?.convertIntToString() else { return }
-        guard let month = dateComponents?.month?.convertIntToString() else { return }
-        guard let day = dateComponents?.day?.convertIntToString() else { return }
+        guard let year = dateComponents?.year?.addZeroAndConvertToString() else { return }
+        guard let month = dateComponents?.month?.addZeroAndConvertToString() else { return }
+        guard let day = dateComponents?.day?.addZeroAndConvertToString() else { return }
         choosenDate += year + month + day
         delegate?.receiveDate(date: choosenDate)
         choosenDate = ""
         self.dismiss(animated: true)
-        return
     }
 }
+

--- a/BoxOffice/Controller/MovieDetailViewController.swift
+++ b/BoxOffice/Controller/MovieDetailViewController.swift
@@ -37,7 +37,8 @@ class MovieDetailViewController: UIViewController {
     
     func fetchMoiveDetail() {
         boxOfficeService.fetchMovieDetailAPI {
-            DispatchQueue.main.async {
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
                 self.setMovieDetailLabel()
                 self.fetchImage()
                 self.activityIndicator.stopAnimating()

--- a/BoxOffice/Controller/MovieDetailViewController.swift
+++ b/BoxOffice/Controller/MovieDetailViewController.swift
@@ -12,19 +12,35 @@ class MovieDetailViewController: UIViewController {
     private let imageSearchService = ImageSearchService()
     private let movieDetailView = MovieDetailView()
     private let provider = Provider()
+    private let activityIndicator: UIActivityIndicatorView = {
+        let activityIndicator = UIActivityIndicatorView()
+        activityIndicator.style = UIActivityIndicatorView.Style.large
+        activityIndicator.translatesAutoresizingMaskIntoConstraints = false
+        return activityIndicator
+    }()
     
     override func viewDidLoad() {
         super.viewDidLoad()
         view = movieDetailView
+        setActivityIndicator()
         fetchMoiveDetail()
+        }
+    
+    private func setActivityIndicator() {
+        view.addSubview(activityIndicator)
+        activityIndicator.startAnimating()
+        NSLayoutConstraint.activate([
+            activityIndicator.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            activityIndicator.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+        ])
     }
     
     func fetchMoiveDetail() {
         boxOfficeService.fetchMovieDetailAPI {
             DispatchQueue.main.async {
-                
                 self.setMovieDetailLabel()
                 self.fetchImage()
+                self.activityIndicator.stopAnimating()
             }
         }
     }

--- a/BoxOffice/Controller/MovieDetailViewController.swift
+++ b/BoxOffice/Controller/MovieDetailViewController.swift
@@ -53,7 +53,7 @@ class MovieDetailViewController: UIViewController {
        
         self.movieDetailView.openDayTitleLabel.text = "개봉일"
         self.movieDetailView.openDayDataLabel.text =
-        boxOfficeService.movieDetail?.movieInformationResult.movieInformation.openDate
+        boxOfficeService.movieDetail?.movieInformationResult.movieInformation.openDate.insertDashFormatter()
         
         self.movieDetailView.showTimeTitleLabel.text = "상영시간"
         self.movieDetailView.showTimeDataLabel.text = boxOfficeService.movieDetail?.movieInformationResult.movieInformation.showTime

--- a/BoxOffice/Controller/MovieDetailViewController.swift
+++ b/BoxOffice/Controller/MovieDetailViewController.swift
@@ -53,7 +53,7 @@ class MovieDetailViewController: UIViewController {
        
         self.movieDetailView.openDayTitleLabel.text = "개봉일"
         self.movieDetailView.openDayDataLabel.text =
-        boxOfficeService.movieDetail?.movieInformationResult.movieInformation.openDate.insertDashFormatter()
+        boxOfficeService.movieDetail?.movieInformationResult.movieInformation.openDate.insertDash()
         
         self.movieDetailView.showTimeTitleLabel.text = "상영시간"
         self.movieDetailView.showTimeDataLabel.text = boxOfficeService.movieDetail?.movieInformationResult.movieInformation.showTime

--- a/BoxOffice/Extension/Int+Extension.swift
+++ b/BoxOffice/Extension/Int+Extension.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension Int {
-    func convertIntToString() -> String {
+    func addZeroAndConvertToString() -> String {
         var result = ""
         
         if self < 10 {

--- a/BoxOffice/Extension/Int+Extension.swift
+++ b/BoxOffice/Extension/Int+Extension.swift
@@ -1,0 +1,22 @@
+//
+//  Int+Exntension.swift
+//  BoxOffice
+//
+//  Created by goat, songjun on 2023/04/04.
+//
+
+import Foundation
+
+extension Int {
+    func convertIntToString() -> String {
+        var result = ""
+        
+        if self < 10 {
+            result = "0" + String(self)
+        } else {
+            return String(self)
+        }
+        
+        return result
+    }
+}

--- a/BoxOffice/Extension/String+Extension.swift
+++ b/BoxOffice/Extension/String+Extension.swift
@@ -7,8 +7,6 @@
 
 import Foundation
 
-
-
 extension String {
     func removeDashFromDate() -> String {
         let result = self.components(separatedBy: "-").joined()
@@ -19,9 +17,6 @@ extension String {
         var result = self
         result.insert("-", at: result.index(result.startIndex, offsetBy: 4))
         result.insert("-", at: result.index(result.endIndex, offsetBy: -2))
-        
         return result
     }
 }
-
-

--- a/BoxOffice/Extension/String+Extension.swift
+++ b/BoxOffice/Extension/String+Extension.swift
@@ -8,15 +8,17 @@
 import Foundation
 
 extension String {
-    func removeDashFromDate() -> String {
-        let result = self.components(separatedBy: "-").joined()
-        return result
-    }
-
-    func insertDashFromDate() -> String {
-        var result = self
-        result.insert("-", at: result.index(result.startIndex, offsetBy: 4))
-        result.insert("-", at: result.index(result.endIndex, offsetBy: -2))
-        return result
+    func insertDashFormatter() -> String {
+        let previousDateFormatter = DateFormatter()
+        previousDateFormatter.dateFormat = "yyyyMMdd"
+        
+        guard let convertDate = previousDateFormatter.date(from: self) else { return ""}
+        
+        let currentDateFormatter = DateFormatter()
+        currentDateFormatter.dateFormat = "yyyy-MM-dd"
+        
+        let convertString = currentDateFormatter.string(from: convertDate)
+        
+        return convertString
     }
 }

--- a/BoxOffice/Extension/String+Extension.swift
+++ b/BoxOffice/Extension/String+Extension.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension String {
-    func insertDashFormatter() -> String {
+    func insertDash() -> String {
         let previousDateFormatter = DateFormatter()
         previousDateFormatter.dateFormat = "yyyyMMdd"
         
@@ -20,5 +20,14 @@ extension String {
         let convertString = currentDateFormatter.string(from: convertDate)
         
         return convertString
+    }
+    
+    func insertComma() -> String {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .decimal
+        
+        guard let value = Double(self), let result = numberFormatter.string(from: NSNumber(value: value)) else { return "" }
+        
+        return result
     }
 }

--- a/BoxOffice/Extension/String+Extension.swift
+++ b/BoxOffice/Extension/String+Extension.swift
@@ -1,0 +1,27 @@
+//
+//  String+Extension.swift
+//  BoxOffice
+//
+//  Created by goat, songjun on 2023/04/05.
+//
+
+import Foundation
+
+
+
+extension String {
+    func removeDashFromDate() -> String {
+        let result = self.components(separatedBy: "-").joined()
+        return result
+    }
+
+    func insertDashFromDate() -> String {
+        var result = self
+        result.insert("-", at: result.index(result.startIndex, offsetBy: 4))
+        result.insert("-", at: result.index(result.endIndex, offsetBy: -2))
+        
+        return result
+    }
+}
+
+

--- a/BoxOffice/Model/BoxOfficeService.swift
+++ b/BoxOffice/Model/BoxOfficeService.swift
@@ -13,9 +13,9 @@ class BoxOfficeService {
     var movieDetail: MovieDetail?
     var movieCode = ""
     
-    func fetchDailyBoxOfficeAPI(completion: @escaping () -> Void) {
+    func fetchDailyBoxOfficeAPI(date: String,completion: @escaping () -> Void) {
         var dailyBoxOfficeEndpoint = DailyBoxOfficeEndpoint()
-        dailyBoxOfficeEndpoint.insertDateQueryValue(date: "20230327")
+        dailyBoxOfficeEndpoint.insertDateQueryValue(date: date)
         
         provider.loadBoxOfficeAPI(endpoint: dailyBoxOfficeEndpoint,
                                   parser: Parser<DailyBoxOffice>()) { parsedData in

--- a/BoxOffice/Model/BoxOfficeService.swift
+++ b/BoxOffice/Model/BoxOfficeService.swift
@@ -31,7 +31,6 @@ class BoxOfficeService {
         provider.loadBoxOfficeAPI(endpoint: movieDetailEndpoint,
                                   parser: Parser<MovieDetail>()) { parsedData in
             self.movieDetail = parsedData
-//            self.fetchImage()
             completion()
         }
     }
@@ -40,21 +39,3 @@ class BoxOfficeService {
         self.movieCode = movieCode
     }
 }
-
-
-//DispatchQueue.main.async {
-//    self.boxOfficeListCollectionView.reloadData()
-//    self.activityIndicator.stopAnimating()
-//}
-
-//boxOfficeService.fetchMovieDetailAPI {
-//                DispatchQueue.main.async {
-//                    self.setMovieDetailLabel()
-//                }
-//}
-
-//boxOfficeService.fetchMovieDetailAPI {
-//    DispatchQueue.main.async {
-//        self.setMovieDetailLabel()
-//    }
-//}

--- a/BoxOffice/View/BoxOfficeListCell.swift
+++ b/BoxOffice/View/BoxOfficeListCell.swift
@@ -54,6 +54,8 @@ class BoxOfficeListCell: UICollectionViewListCell  {
         titleAndAudienceStackView.addArrangedSubview(audienceCountLabel)
         
         NSLayoutConstraint.activate([
+            rankGapLabel.widthAnchor.constraint(equalToConstant: 30),
+            
             rankStackView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 20),
             rankStackView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
             
@@ -64,10 +66,13 @@ class BoxOfficeListCell: UICollectionViewListCell  {
     }
     
     private func setUpLabelStyle() {
-        rankNumberLabel.font = UIFont.preferredFont(forTextStyle: .title1)
+        rankNumberLabel.font = UIFont.preferredFont(forTextStyle: .largeTitle)
         rankGapLabel.font = UIFont.preferredFont(forTextStyle: .subheadline)
         movieTitleLabel.font = UIFont.preferredFont(forTextStyle: .title3)
         audienceCountLabel.font = UIFont.preferredFont(forTextStyle: .subheadline)
+        
+        rankGapLabel.textAlignment = .center
+        
     }
     
     func setUpLabel(by dailyBoxOffice: DailyBoxOffice, indexPath: IndexPath) {

--- a/BoxOffice/View/BoxOfficeListCell.swift
+++ b/BoxOffice/View/BoxOfficeListCell.swift
@@ -77,7 +77,7 @@ class BoxOfficeListCell: UICollectionViewListCell  {
         self.rankNumberLabel.text = dailyBoxOffice.boxOfficeResult.dailyBoxOfficeList[indexPath.row].rank
         self.rankGapLabel.attributedText = convertRankGapPresentation(dailyBoxOffice: dailyBoxOffice, indexPath: indexPath)
         self.movieTitleLabel.text = dailyBoxOffice.boxOfficeResult.dailyBoxOfficeList[indexPath.row].movieName
-        self.audienceCountLabel.text = "오늘 " + audienceCount + " / 총 " + audienceAccumulation
+        self.audienceCountLabel.text = "오늘 " + audienceCount.insertComma() + " / 총 " + audienceAccumulation.insertComma()
     }
     
     private func convertRankGapPresentation(dailyBoxOffice: DailyBoxOffice, indexPath: IndexPath) -> NSMutableAttributedString {

--- a/BoxOffice/View/CalendarView.swift
+++ b/BoxOffice/View/CalendarView.swift
@@ -13,6 +13,7 @@ class CalendarView: UICalendarView {
         super.init(frame: frame)
 
         self.backgroundColor = .white
+        self.availableDateRange = DateInterval(start: Date(timeIntervalSinceReferenceDate: 0), end: Date(timeIntervalSinceNow: -86400))
     }
     
     required init?(coder: NSCoder) {

--- a/BoxOffice/View/CalendarView.swift
+++ b/BoxOffice/View/CalendarView.swift
@@ -1,0 +1,42 @@
+//
+//  CalendarView.swift
+//  BoxOffice
+//
+//  Created by goat songjun on 2023/04/04.
+//
+
+import UIKit
+
+class CalendarView: UICalendarView {
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        self.backgroundColor = .white
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+
+
+
+//    func makeCalendarView() {
+//        let calendarView =  UICalendarView()
+//        calendarView.translatesAutoresizingMaskIntoConstraints = false
+//        calendarView.calendar = .current
+//        calendarView.locale = .current
+//        calendarView.fontDesign = .rounded
+//
+//        let safeArea = safeAreaLayoutGuide
+//        self.addSubview(calendarView)
+//
+//        NSLayoutConstraint.activate([
+//            calendarView.topAnchor.constraint(equalTo: safeArea.topAnchor),
+//            calendarView.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor),
+//            calendarView.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor),
+//            calendarView.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor)
+//        ])
+//    }

--- a/BoxOffice/View/CalendarView.swift
+++ b/BoxOffice/View/CalendarView.swift
@@ -8,7 +8,6 @@
 import UIKit
 
 class CalendarView: UICalendarView {
-    
     override init(frame: CGRect) {
         super.init(frame: frame)
 
@@ -20,24 +19,3 @@ class CalendarView: UICalendarView {
         fatalError("init(coder:) has not been implemented")
     }
 }
-
-
-
-
-//    func makeCalendarView() {
-//        let calendarView =  UICalendarView()
-//        calendarView.translatesAutoresizingMaskIntoConstraints = false
-//        calendarView.calendar = .current
-//        calendarView.locale = .current
-//        calendarView.fontDesign = .rounded
-//
-//        let safeArea = safeAreaLayoutGuide
-//        self.addSubview(calendarView)
-//
-//        NSLayoutConstraint.activate([
-//            calendarView.topAnchor.constraint(equalTo: safeArea.topAnchor),
-//            calendarView.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor),
-//            calendarView.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor),
-//            calendarView.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor)
-//        ])
-//    }

--- a/BoxOffice/View/MovieDetailView.swift
+++ b/BoxOffice/View/MovieDetailView.swift
@@ -168,9 +168,6 @@ class MovieDetailView: UIView {
             nationTitleLabel.widthAnchor.constraint(equalToConstant: 70),
             genreTitleLabel.widthAnchor.constraint(equalToConstant: 70),
             actorTitleLabel.widthAnchor.constraint(equalToConstant: 70)
-            
         ])
     }
 }
-
-

--- a/BoxOffice/View/MovieDetailView.swift
+++ b/BoxOffice/View/MovieDetailView.swift
@@ -23,6 +23,7 @@ class MovieDetailView: UIView {
     
     let imageView: UIImageView = {
         let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFit
         imageView.translatesAutoresizingMaskIntoConstraints = false
         return imageView
     }()
@@ -151,6 +152,8 @@ class MovieDetailView: UIView {
             imageView.topAnchor.constraint(equalTo: contentView.topAnchor),
             imageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor,constant: 14),
             imageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor,constant: -14),
+            
+            imageView.heightAnchor.constraint(equalToConstant: 400),
             
             verticalStackView.topAnchor.constraint(equalTo: imageView.bottomAnchor),
             verticalStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),


### PR DESCRIPTION
# 🎬박스오피스 II [STEP1] 
@forestjae
안녕하세요 숲재! 
박스오피스 II [STEP1] PR입니다.
저번 박스오피스1 step4 코멘트사항(imageView 비율처리 + acivityIndicator)도 반영해서 이번스텝 진행했습니다.
이번 리뷰도 잘 부탁드리겠습니다. 감사합니다😁😁

    
### 구현내용
1. default형태의 CalendarView 구현
2. CalendarView에서 선택한 날짜를 Delegate 패턴을 통해 BoxOfficeViewController로 전달
3. 전달된 날짜를 바탕으로 해당 날짜의 박스오피스 랭킹 표현

### :fire: DateFormattter를 활용해서 새로운 endPoint data value 생성 및 navigationTitle 구현
* 캘린더에서 `YYYYMMdd`포맷의 날짜를 받아와 해당 `value`로 DailyBoxOfficeView를 새로 그리고 `navigationTitle`에는 `YYYY-MM-dd`포맷의 날짜를 업로드 하는 과정이 필요했습니다.
* 따라서 extension Srtring으로 dash를 추가하는 매서드, 삭제하는 매서드를 만들어 로직을 구현했습니다
```swift
extension String {
    func removeDashFromDate() -> String {
        let result = self.components(separatedBy: "-").joined()
        return result
    }
    // YYYY-MM-dd -> YYYYMMdd

    func insertDashFromDate() -> String {
        var result = self
        result.insert("-", at: result.index(result.startIndex, offsetBy: 4))
        result.insert("-", at: result.index(result.endIndex, offsetBy: -2))
        return result
    }
    // YYYYMMdd -> YYYY-MM-dd
}
```

### :fire: CalendarView에서 선택 가능한 날짜 범위 생성
- `availableDateRange`라는 프로퍼티를 통해 선택 가능 날짜를 구현해주었습니다.
- 그 과정 속에서 어제의 날짜를 가져오기 위해 `Date(timeIntervalSinceNow: -86400)`와 같은 표현을 사용하였습니다.
![](https://i.imgur.com/yc95BCb.png)


```swift
self.availableDateRange = DateInterval(start: Date(timeIntervalSinceReferenceDate: 0), end: Date(timeIntervalSinceNow: -86400))
```