### PR TITLE
박스오피스II [STEP 2] goat, 송준

### DIFF
--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -174,13 +174,24 @@ extension BoxOfficeViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cellId = String(describing: BoxOfficeListCell.self)
         let cell = boxOfficeListCollectionView.dequeueReusableCell(withReuseIdentifier: cellId, for: indexPath) as! BoxOfficeListCell
-        if isCurrentListLayout == true {
+//        if isCurrentListLayout == true {
+//            cell.configureListCellUI()
+//            cell.accessories = [.disclosureIndicator()]
+//            self.boxOfficeListCollectionView.reloadData()
+//        } else if isCurrentListLayout == false {
+//            cell.configureIconCellUI()
+//            cell.accessories = []
+//        }
+        
+        switch isCurrentListLayout {
+        case true:
             cell.configureListCellUI()
             cell.accessories = [.disclosureIndicator()]
-        } else {
+        case false:
             cell.configureIconCellUI()
             cell.accessories = []
         }
+        
         
         guard let validDailyBoxOffice = boxOfficeService.dailyBoxOffice else {
             return cell

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -162,8 +162,6 @@ final class BoxOfficeViewController: UIViewController {
         alertToListLayout.addAction(UIAlertAction(title: "취소", style: .cancel, handler: { _ in print("알럿 취소") }))
         present(alertToListLayout, animated: true)
     }
-    
-    
 }
 
 extension BoxOfficeViewController: UICollectionViewDataSource {
@@ -174,30 +172,20 @@ extension BoxOfficeViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cellId = String(describing: BoxOfficeListCell.self)
         let cell = boxOfficeListCollectionView.dequeueReusableCell(withReuseIdentifier: cellId, for: indexPath) as! BoxOfficeListCell
-//        if isCurrentListLayout == true {
-//            cell.configureListCellUI()
-//            cell.accessories = [.disclosureIndicator()]
-//            self.boxOfficeListCollectionView.reloadData()
-//        } else if isCurrentListLayout == false {
-//            cell.configureIconCellUI()
-//            cell.accessories = []
-//        }
         
         switch isCurrentListLayout {
         case true:
             cell.configureListCellUI()
-            cell.accessories = [.disclosureIndicator()]
         case false:
             cell.configureIconCellUI()
-            cell.accessories = []
         }
-        
         
         guard let validDailyBoxOffice = boxOfficeService.dailyBoxOffice else {
             return cell
         }
 
         cell.setUpLabel(by: validDailyBoxOffice, indexPath: indexPath)
+        
         return cell
     }
     
@@ -235,21 +223,9 @@ extension BoxOfficeViewController: UICollectionViewDelegate {
 
 extension BoxOfficeViewController {
     private func setUpCompositionalListLayout() -> UICollectionViewLayout {
-        let layout = UICollectionViewCompositionalLayout {
-            (sectionIndex: Int, layoutEnvironment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection? in
-            
-            let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(1.0))
-            let item = NSCollectionLayoutItem(layoutSize: itemSize)
-            
-            item.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
-            
-            let groupHeight =  NSCollectionLayoutDimension.fractionalWidth(1/4)
-            let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: groupHeight)
-            let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitem: item, count: 1)
-            let section = NSCollectionLayoutSection(group: group)
-            
-            return section
-        }
+        let configuration = UICollectionLayoutListConfiguration(appearance: .plain)
+        let layout = UICollectionViewCompositionalLayout.list(using: configuration)
+        
         return layout
     }
     
@@ -279,3 +255,5 @@ extension BoxOfficeViewController: CalendarDateDelegate {
         print(choosenDate)
     }
 }
+
+

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -251,7 +251,7 @@ extension BoxOfficeViewController {
             
             item.contentInsets = NSDirectionalEdgeInsets(top: 5, leading: 5, bottom: 5, trailing: 5)
             
-            let groupHeight =  NSCollectionLayoutDimension.fractionalWidth(1/2.3)
+            let groupHeight =  NSCollectionLayoutDimension.fractionalWidth(1/2)
             let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: groupHeight)
             let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitem: item, count: 2)
             let section = NSCollectionLayoutSection(group: group)

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -174,15 +174,19 @@ extension BoxOfficeViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cellId = String(describing: BoxOfficeListCell.self)
         let cell = boxOfficeListCollectionView.dequeueReusableCell(withReuseIdentifier: cellId, for: indexPath) as! BoxOfficeListCell
+        if isCurrentListLayout == true {
+            cell.configureListCellUI()
+            cell.accessories = [.disclosureIndicator()]
+        } else {
+            cell.configureIconCellUI()
+            cell.accessories = []
+        }
         
         guard let validDailyBoxOffice = boxOfficeService.dailyBoxOffice else {
             return cell
         }
-        
-        cell.setUpBoxOffcieCellUI()
+
         cell.setUpLabel(by: validDailyBoxOffice, indexPath: indexPath)
-        cell.accessories = [.disclosureIndicator()]
-    
         return cell
     }
     

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -14,6 +14,7 @@ protocol CalendarDateDelegate: AnyObject {
 final class BoxOfficeViewController: UIViewController {
     let boxOfficeService = BoxOfficeService()
     private var provider = Provider()
+    private var isCurrentListLayout: Bool = true
     let calendarViewController = CalendarViewController()
     var choosenDate: String = "" {
         didSet {
@@ -51,6 +52,7 @@ final class BoxOfficeViewController: UIViewController {
         setBoxOfficeListCollectionView()
         configureRefreshControl()
         configureUI()
+        setNavigationToolBar()
     }
     
     private func setNavigationBar() {
@@ -72,7 +74,7 @@ final class BoxOfficeViewController: UIViewController {
     private func setBoxOfficeListCollectionView() {
         boxOfficeListCollectionView.dataSource = self
         boxOfficeListCollectionView.delegate = self
-        self.boxOfficeListCollectionView.collectionViewLayout = self.setUpCompositionalLayout()
+        self.boxOfficeListCollectionView.collectionViewLayout = self.setUpCompositionalListLayout()
     }
     
     private func configureRefreshControl() {
@@ -117,6 +119,51 @@ final class BoxOfficeViewController: UIViewController {
         let yesterDate = formatter.string(from: Date(timeIntervalSinceNow: -86400))
         return yesterDate
     }
+    
+    private func setNavigationToolBar() {
+        let flexibleSpace: UIBarButtonItem
+        let changeModeButton: UIBarButtonItem
+        
+        changeModeButton = UIBarButtonItem(title: "화면 모드 변경", style: .plain, target: self, action: #selector(convertAlertMode))
+        flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: self, action: nil)
+        
+        toolbarItems = [flexibleSpace, changeModeButton, flexibleSpace]
+        self.navigationController?.isToolbarHidden = false
+    }
+    
+    @objc func convertAlertMode() {
+        switch self.isCurrentListLayout {
+        case true:
+            return changeToIconAlert()
+        case false:
+            return changeToListAlert()
+        }
+    }
+    
+    private func changeToIconAlert() {
+        let alertToIconLayout = UIAlertController(title: "화면 모드 변경", message: "", preferredStyle: .actionSheet)
+        
+        alertToIconLayout.addAction(UIAlertAction(title: "아이콘", style: .default, handler: { _ in
+            self.boxOfficeListCollectionView.collectionViewLayout = self.setUpCompositionalIconLayout()
+            self.boxOfficeListCollectionView.reloadData()
+            self.isCurrentListLayout = false
+        }))
+        alertToIconLayout.addAction(UIAlertAction(title: "취소", style: .cancel, handler: { _ in print("알럿 취소") }))
+        present(alertToIconLayout, animated: true)
+    }
+    
+    private func changeToListAlert() {
+        let alertToListLayout = UIAlertController(title: "화면 모드 변경", message: "", preferredStyle: .actionSheet)
+        alertToListLayout.addAction(UIAlertAction(title: "리스트", style: .default, handler: { _ in
+            self.boxOfficeListCollectionView.collectionViewLayout = self.setUpCompositionalListLayout()
+            self.boxOfficeListCollectionView.reloadData()
+            self.isCurrentListLayout = true
+        }))
+        alertToListLayout.addAction(UIAlertAction(title: "취소", style: .cancel, handler: { _ in print("알럿 취소") }))
+        present(alertToListLayout, animated: true)
+    }
+    
+    
 }
 
 extension BoxOfficeViewController: UICollectionViewDataSource {
@@ -172,7 +219,7 @@ extension BoxOfficeViewController: UICollectionViewDelegate {
 }
 
 extension BoxOfficeViewController {
-    private func setUpCompositionalLayout() -> UICollectionViewLayout {
+    private func setUpCompositionalListLayout() -> UICollectionViewLayout {
         let layout = UICollectionViewCompositionalLayout {
             (sectionIndex: Int, layoutEnvironment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection? in
             
@@ -184,6 +231,25 @@ extension BoxOfficeViewController {
             let groupHeight =  NSCollectionLayoutDimension.fractionalWidth(1/4)
             let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: groupHeight)
             let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitem: item, count: 1)
+            let section = NSCollectionLayoutSection(group: group)
+            
+            return section
+        }
+        return layout
+    }
+    
+    private func setUpCompositionalIconLayout() -> UICollectionViewLayout {
+        let layout = UICollectionViewCompositionalLayout {
+            (sectionIndex: Int, layoutEnvironment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection? in
+            
+            let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(1.0))
+            let item = NSCollectionLayoutItem(layoutSize: itemSize)
+            
+            item.contentInsets = NSDirectionalEdgeInsets(top: 5, leading: 5, bottom: 5, trailing: 5)
+            
+            let groupHeight =  NSCollectionLayoutDimension.fractionalWidth(1/2.3)
+            let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: groupHeight)
+            let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitem: item, count: 2)
             let section = NSCollectionLayoutSection(group: group)
             
             return section

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -132,32 +132,20 @@ final class BoxOfficeViewController: UIViewController {
     }
     
     @objc func convertAlertMode() {
-        switch self.isCurrentListLayout {
-        case true:
-            return changeToIconAlert()
-        case false:
-            return changeToListAlert()
+        if isCurrentListLayout == true {
+            makeAlert(presentType: "아이콘", layoutType: setUpCompositionalIconLayout)
+            isCurrentListLayout = false
+        } else {
+            makeAlert(presentType: "리스트", layoutType: setUpCompositionalListLayout)
+            isCurrentListLayout = true
         }
     }
-    
-    private func changeToIconAlert() {
-        let alertToIconLayout = UIAlertController(title: "화면 모드 변경", message: "", preferredStyle: .actionSheet)
-        
-        alertToIconLayout.addAction(UIAlertAction(title: "아이콘", style: .default, handler: { _ in
-            self.boxOfficeListCollectionView.collectionViewLayout = self.setUpCompositionalIconLayout()
-            self.boxOfficeListCollectionView.reloadData()
-            self.isCurrentListLayout = false
-        }))
-        alertToIconLayout.addAction(UIAlertAction(title: "취소", style: .cancel, handler: { _ in print("알럿 취소") }))
-        present(alertToIconLayout, animated: true)
-    }
-    
-    private func changeToListAlert() {
+
+    private func makeAlert(presentType: String, layoutType: @escaping () -> UICollectionViewLayout) {
         let alertToListLayout = UIAlertController(title: "화면 모드 변경", message: "", preferredStyle: .actionSheet)
-        alertToListLayout.addAction(UIAlertAction(title: "리스트", style: .default, handler: { _ in
-            self.boxOfficeListCollectionView.collectionViewLayout = self.setUpCompositionalListLayout()
+        alertToListLayout.addAction(UIAlertAction(title: presentType, style: .default, handler: { _ in
+            self.boxOfficeListCollectionView.collectionViewLayout = layoutType()
             self.boxOfficeListCollectionView.reloadData()
-            self.isCurrentListLayout = true
         }))
         alertToListLayout.addAction(UIAlertAction(title: "취소", style: .cancel, handler: { _ in print("알럿 취소") }))
         present(alertToListLayout, animated: true)
@@ -252,7 +240,6 @@ extension BoxOfficeViewController {
 extension BoxOfficeViewController: CalendarDateDelegate {
     func receiveDate(date: String) {
         choosenDate = date
-        print(choosenDate)
     }
 }
 

--- a/BoxOffice/View/Base.lproj/Main.storyboard
+++ b/BoxOffice/View/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="js7-li-jPB">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="js7-li-jPB">
     <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
@@ -50,7 +50,7 @@
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="movieTitle" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="p94-o5-wdp">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="movieTitle" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="p94-o5-wdp">
                                                     <rect key="frame" x="137" y="28" width="77" height="21"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>

--- a/BoxOffice/View/Base.lproj/Main.storyboard
+++ b/BoxOffice/View/Base.lproj/Main.storyboard
@@ -36,28 +36,28 @@
                                             <rect key="frame" x="0.0" y="0.0" width="390" height="104"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="rankNumber" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jdy-bl-BiS">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="rankNumber" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jdy-bl-BiS">
                                                     <rect key="frame" x="26" y="29" width="95" height="21"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="rankGap" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3zi-ng-y2c">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="rankGap" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3zi-ng-y2c">
                                                     <rect key="frame" x="26" y="67" width="65" height="21"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="movieTitle" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="p94-o5-wdp">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="movieTitle" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="p94-o5-wdp">
                                                     <rect key="frame" x="137" y="28" width="77" height="21"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="audienceCount" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7c6-dZ-oUh">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="audienceCount" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7c6-dZ-oUh">
                                                     <rect key="frame" x="137" y="66" width="116" height="21"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>

--- a/BoxOffice/View/BoxOfficeListCell.swift
+++ b/BoxOffice/View/BoxOfficeListCell.swift
@@ -14,7 +14,6 @@ class BoxOfficeListCell: UICollectionViewListCell  {
     @IBOutlet weak var movieTitleLabel: UILabel!
     @IBOutlet weak var audienceCountLabel: UILabel!
     
-    
     private let rankStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.translatesAutoresizingMaskIntoConstraints = false
@@ -29,7 +28,8 @@ class BoxOfficeListCell: UICollectionViewListCell  {
         let stackView = UIStackView()
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .vertical
-        stackView.distribution = .fillEqually
+        stackView.distribution = .fillProportionally
+        
         return stackView
     }()
     
@@ -40,11 +40,13 @@ class BoxOfficeListCell: UICollectionViewListCell  {
         stackView.alignment = .center
         stackView.distribution = .equalSpacing
         stackView.spacing = 6
+        
         return stackView
     }()
     
     func configureListCellUI() {
         setUpLabelStyle()
+        self.accessories = [.disclosureIndicator(displayed: .always, options: .init(isHidden: false, reservedLayoutWidth: .custom(30)) )]
         self.layer.borderWidth = 0.2
         self.layer.borderColor = UIColor.lightGray.cgColor
         
@@ -68,13 +70,15 @@ class BoxOfficeListCell: UICollectionViewListCell  {
             rankStackView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
             
             titleAndAudienceStackView.leadingAnchor.constraint(equalTo: rankStackView.trailingAnchor,constant: 20),
-            titleAndAudienceStackView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
-            titleAndAudienceStackView.trailingAnchor.constraint(lessThanOrEqualTo: self.trailingAnchor, constant: -20)
+            titleAndAudienceStackView.trailingAnchor.constraint(lessThanOrEqualTo: self.trailingAnchor, constant: -50),
+            titleAndAudienceStackView.topAnchor.constraint(equalTo: self.topAnchor, constant: 15),
+            titleAndAudienceStackView.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -15),
         ])
     }
     
     func configureIconCellUI() {
         setUpLabelStyle()
+        self.accessories = []
         self.layer.borderWidth = 1
         self.layer.borderColor = UIColor.black.cgColor
         self.addSubview(iconTypeStackView)
@@ -97,9 +101,7 @@ class BoxOfficeListCell: UICollectionViewListCell  {
         rankGapLabel.font = UIFont.preferredFont(forTextStyle: .subheadline)
         movieTitleLabel.font = UIFont.preferredFont(forTextStyle: .title3)
         audienceCountLabel.font = UIFont.preferredFont(forTextStyle: .subheadline)
-        
         rankGapLabel.textAlignment = .center
-        
     }
     
     func setUpLabel(by dailyBoxOffice: DailyBoxOffice, indexPath: IndexPath) {

--- a/BoxOffice/View/BoxOfficeListCell.swift
+++ b/BoxOffice/View/BoxOfficeListCell.swift
@@ -33,12 +33,20 @@ class BoxOfficeListCell: UICollectionViewListCell  {
         return stackView
     }()
     
-    func setUpBoxOffcieCellUI() {
-        configureUI()
-        setUpLabelStyle()
-    }
+    private let iconTypeStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        stackView.alignment = .center
+        stackView.spacing = 10
+        return stackView
+    }()
     
-    private func configureUI() {
+    func configureListCellUI() {
+        setUpLabelStyle()
+        self.layer.borderWidth = 0.2
+        self.layer.borderColor = UIColor.lightGray.cgColor
+        
         rankNumberLabel.translatesAutoresizingMaskIntoConstraints = false
         rankGapLabel.translatesAutoresizingMaskIntoConstraints = false
         movieTitleLabel.translatesAutoresizingMaskIntoConstraints = false
@@ -54,14 +62,32 @@ class BoxOfficeListCell: UICollectionViewListCell  {
         titleAndAudienceStackView.addArrangedSubview(audienceCountLabel)
         
         NSLayoutConstraint.activate([
-            rankGapLabel.widthAnchor.constraint(equalToConstant: 30),
-            
             rankStackView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 20),
             rankStackView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
             
             titleAndAudienceStackView.leadingAnchor.constraint(equalTo: rankStackView.trailingAnchor,constant: 20),
             titleAndAudienceStackView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
             titleAndAudienceStackView.trailingAnchor.constraint(lessThanOrEqualTo: self.trailingAnchor, constant: -20)
+        ])
+    }
+    
+    func configureIconCellUI() {
+        setUpLabelStyle()
+        self.layer.borderWidth = 1
+        self.layer.borderColor = UIColor.black.cgColor
+        self.addSubview(iconTypeStackView)
+        
+        iconTypeStackView.addArrangedSubview(rankNumberLabel)
+        iconTypeStackView.addArrangedSubview(movieTitleLabel)
+        iconTypeStackView.addArrangedSubview(rankGapLabel)
+        iconTypeStackView.addArrangedSubview(audienceCountLabel)
+        
+        NSLayoutConstraint.activate([
+            iconTypeStackView.topAnchor.constraint(equalTo: self.topAnchor),
+            iconTypeStackView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            iconTypeStackView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            iconTypeStackView.bottomAnchor.constraint(equalTo: self.bottomAnchor,constant: -10)
+            
         ])
     }
     

--- a/BoxOffice/View/BoxOfficeListCell.swift
+++ b/BoxOffice/View/BoxOfficeListCell.swift
@@ -70,7 +70,6 @@ class BoxOfficeListCell: UICollectionViewListCell  {
             titleAndAudienceStackView.leadingAnchor.constraint(equalTo: rankStackView.trailingAnchor,constant: 20),
             titleAndAudienceStackView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
             titleAndAudienceStackView.trailingAnchor.constraint(lessThanOrEqualTo: self.trailingAnchor, constant: -20)
-            
         ])
     }
     
@@ -86,19 +85,13 @@ class BoxOfficeListCell: UICollectionViewListCell  {
         iconTypeStackView.addArrangedSubview(audienceCountLabel)
         
         NSLayoutConstraint.activate([
-            iconTypeStackView.topAnchor.constraint(equalTo: self.topAnchor),
+            iconTypeStackView.topAnchor.constraint(equalTo: self.topAnchor, constant: 10),
             iconTypeStackView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
             iconTypeStackView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
             iconTypeStackView.bottomAnchor.constraint(equalTo: self.bottomAnchor,constant: -10)
         ])
     }
-    
-    func clearConstraint() {
-        NSLayoutConstraint.activate([
-           
-            ])
-    }
-    
+
     private func setUpLabelStyle() {
         rankNumberLabel.font = UIFont.preferredFont(forTextStyle: .largeTitle)
         rankGapLabel.font = UIFont.preferredFont(forTextStyle: .subheadline)

--- a/BoxOffice/View/BoxOfficeListCell.swift
+++ b/BoxOffice/View/BoxOfficeListCell.swift
@@ -14,6 +14,7 @@ class BoxOfficeListCell: UICollectionViewListCell  {
     @IBOutlet weak var movieTitleLabel: UILabel!
     @IBOutlet weak var audienceCountLabel: UILabel!
     
+    
     private let rankStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.translatesAutoresizingMaskIntoConstraints = false
@@ -29,7 +30,6 @@ class BoxOfficeListCell: UICollectionViewListCell  {
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .vertical
         stackView.distribution = .fillEqually
-        
         return stackView
     }()
     
@@ -63,12 +63,14 @@ class BoxOfficeListCell: UICollectionViewListCell  {
         titleAndAudienceStackView.addArrangedSubview(audienceCountLabel)
         
         NSLayoutConstraint.activate([
+            rankStackView.widthAnchor.constraint(greaterThanOrEqualToConstant: 50),
             rankStackView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 20),
             rankStackView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
             
             titleAndAudienceStackView.leadingAnchor.constraint(equalTo: rankStackView.trailingAnchor,constant: 20),
             titleAndAudienceStackView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
             titleAndAudienceStackView.trailingAnchor.constraint(lessThanOrEqualTo: self.trailingAnchor, constant: -20)
+            
         ])
     }
     
@@ -83,16 +85,18 @@ class BoxOfficeListCell: UICollectionViewListCell  {
         iconTypeStackView.addArrangedSubview(rankGapLabel)
         iconTypeStackView.addArrangedSubview(audienceCountLabel)
         
-        
-        
         NSLayoutConstraint.activate([
             iconTypeStackView.topAnchor.constraint(equalTo: self.topAnchor),
             iconTypeStackView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
             iconTypeStackView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
-            iconTypeStackView.bottomAnchor.constraint(equalTo: self.bottomAnchor,constant: -10),
-            
-            movieTitleLabel.centerXAnchor.constraint(equalTo: self.centerXAnchor)
+            iconTypeStackView.bottomAnchor.constraint(equalTo: self.bottomAnchor,constant: -10)
         ])
+    }
+    
+    func clearConstraint() {
+        NSLayoutConstraint.activate([
+           
+            ])
     }
     
     private func setUpLabelStyle() {

--- a/BoxOffice/View/BoxOfficeListCell.swift
+++ b/BoxOffice/View/BoxOfficeListCell.swift
@@ -38,7 +38,8 @@ class BoxOfficeListCell: UICollectionViewListCell  {
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .vertical
         stackView.alignment = .center
-        stackView.spacing = 10
+        stackView.distribution = .equalSpacing
+        stackView.spacing = 6
         return stackView
     }()
     
@@ -82,12 +83,15 @@ class BoxOfficeListCell: UICollectionViewListCell  {
         iconTypeStackView.addArrangedSubview(rankGapLabel)
         iconTypeStackView.addArrangedSubview(audienceCountLabel)
         
+        
+        
         NSLayoutConstraint.activate([
             iconTypeStackView.topAnchor.constraint(equalTo: self.topAnchor),
             iconTypeStackView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
             iconTypeStackView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
-            iconTypeStackView.bottomAnchor.constraint(equalTo: self.bottomAnchor,constant: -10)
+            iconTypeStackView.bottomAnchor.constraint(equalTo: self.bottomAnchor,constant: -10),
             
+            movieTitleLabel.centerXAnchor.constraint(equalTo: self.centerXAnchor)
         ])
     }
     

--- a/BoxOffice/View/MovieDetailView.swift
+++ b/BoxOffice/View/MovieDetailView.swift
@@ -45,32 +45,28 @@ class MovieDetailView: UIView {
     lazy var actorStackView = makeHorizontalStackView()
 
     lazy var directorTitleLabel = makeTitleLabel()
-    let directorDataLabel = UILabel()
+    lazy var directorDataLabel = makeDataLabel()
 
     lazy var  productYearTitleLabel = makeTitleLabel()
-    let productYearDataLabel = UILabel()
+    lazy var productYearDataLabel = makeDataLabel()
    
     lazy var  openDayTitleLabel = makeTitleLabel()
-    let openDayDataLabel = UILabel()
+    lazy var openDayDataLabel = makeDataLabel()
     
     lazy var showTimeTitleLabel = makeTitleLabel()
-    let showTimeDataLabel = UILabel()
+    lazy var showTimeDataLabel = makeDataLabel()
     
     lazy var auditsTitleLabel = makeTitleLabel()
-    let auditsDataLabel = UILabel()
+    lazy var auditsDataLabel = makeDataLabel()
     
     lazy var nationTitleLabel = makeTitleLabel()
-    let nationDataLabel = UILabel()
+    lazy var nationDataLabel = makeDataLabel()
     
     lazy var genreTitleLabel = makeTitleLabel()
-    let genreDataLabel = UILabel()
+    lazy var genreDataLabel = makeDataLabel()
     
-    lazy var actorTitleLabel: UILabel = makeTitleLabel()
-    let actorDataLabel: UILabel = {
-        let label = UILabel()
-        label.numberOfLines = 0
-        return label
-    }()
+    lazy var actorTitleLabel = makeTitleLabel()
+    lazy var actorDataLabel = makeDataLabel()
    
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -86,13 +82,24 @@ class MovieDetailView: UIView {
         let stackView = UIStackView()
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .horizontal
+        stackView.spacing = 6
         return stackView
     }
     
     private func makeTitleLabel() -> UILabel {
         let label = UILabel()
         label.textAlignment = .center
-        label.font = UIFont.boldSystemFont(ofSize: 16)
+        label.adjustsFontForContentSizeCategory = true
+        label.font = UIFont.preferredFont(forTextStyle: .headline)
+        return label
+    }
+    
+    private func makeDataLabel() -> UILabel {
+        let label = UILabel()
+        label.textAlignment = .left
+        label.numberOfLines = 0
+        label.adjustsFontForContentSizeCategory = true
+        label.font = UIFont.preferredFont(forTextStyle: .callout)
         return label
     }
     
@@ -160,14 +167,16 @@ class MovieDetailView: UIView {
             verticalStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
             verticalStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
             
-            directorTitleLabel.widthAnchor.constraint(equalToConstant: 70),
-            productYearTitleLabel.widthAnchor.constraint(equalToConstant: 70),
-            openDayTitleLabel.widthAnchor.constraint(equalToConstant: 70),
-            showTimeTitleLabel.widthAnchor.constraint(equalToConstant: 70),
-            auditsTitleLabel.widthAnchor.constraint(equalToConstant: 70),
-            nationTitleLabel.widthAnchor.constraint(equalToConstant: 70),
-            genreTitleLabel.widthAnchor.constraint(equalToConstant: 70),
-            actorTitleLabel.widthAnchor.constraint(equalToConstant: 70)
+            directorTitleLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 70),
+            productYearTitleLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 70),
+            openDayTitleLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 70),
+            showTimeTitleLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 70),
+            auditsTitleLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 70),
+            nationTitleLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 70),
+            genreTitleLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 70),
+            actorTitleLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 70)
+           
         ])
     }
 }
+

--- a/BoxOffice/View/MovieDetailView.swift
+++ b/BoxOffice/View/MovieDetailView.swift
@@ -168,13 +168,13 @@ class MovieDetailView: UIView {
             verticalStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
             
             directorTitleLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 70),
-            productYearTitleLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 70),
-            openDayTitleLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 70),
-            showTimeTitleLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 70),
-            auditsTitleLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 70),
-            nationTitleLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 70),
-            genreTitleLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 70),
-            actorTitleLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 70)
+            productYearTitleLabel.widthAnchor.constraint(equalTo: directorTitleLabel.widthAnchor),
+            openDayTitleLabel.widthAnchor.constraint(equalTo: directorTitleLabel.widthAnchor),
+            showTimeTitleLabel.widthAnchor.constraint(equalTo: directorTitleLabel.widthAnchor),
+            auditsTitleLabel.widthAnchor.constraint(equalTo: directorTitleLabel.widthAnchor),
+            nationTitleLabel.widthAnchor.constraint(equalTo: directorTitleLabel.widthAnchor),
+            genreTitleLabel.widthAnchor.constraint(equalTo: directorTitleLabel.widthAnchor),
+            actorTitleLabel.widthAnchor.constraint(equalTo: directorTitleLabel.widthAnchor)
            
         ])
     }


### PR DESCRIPTION
# 🎬박스오피스 II [STEP2] 
@forestjae
안녕하세요 숲재! 
박스오피스 II [STEP2] PR입니다.
UI 작업이 이렇게 힘들다는 것을 또 한번 깨닫는 스텝이였습니다..ㅎ
이번 리뷰도 잘 부탁드리겠습니다!!!

### 구현한 점
- Dynamic Type 적용
- ToolBar를 통해 영화 순위 표현 형태 변경 기능 구현


### 고민한 점

### :fire: icon layer - stackview distribution
* icon layer 모드일때 내부 요소들을  하나의`vertical stackview`로 묶어주게끔 UI를 구성했습니다.
* 내부 `label`들의 간격이나 너비가 일정하지않아 고민하다 `stackView Distribution`옵션을 eqaulSpacing으로 줌으로써 해결했습니다.

```swift!
 private let iconTypeStackView: UIStackView = {
        let stackView = UIStackView()
        stackView.translatesAutoresizingMaskIntoConstraints = false
        stackView.axis = .vertical
        stackView.alignment = .center
        stackView.distribution = .equalSpacing
        stackView.spacing = 6
        return stackView
    }()
```

* distribution 옵션

|fillequally|default|equalspacing|
|:----:|:----:|:----:|
|<img src = "https://i.imgur.com/7WFJvVB.png" width = 200> |<img src = "https://i.imgur.com/UprJZrP.png" width = 200>|<img src = "https://i.imgur.com/SIOCuL7.png" width = 200>|


<br/>


### :fire: Modern CollectionView 구현 방식

|변경 전|변경 후|
|---|---|
|<img src = "https://i.imgur.com/jWGxJJ2.png" width = 300>|<img src = "https://i.imgur.com/huopzpF.png" width = 300>|

- 변경 전
    - 전체적인 Cell(item)의 크기를 잡아주어 Dynamic Type을 사용할 때, Cell의 크기가 변하지 않는 문제점 발생합니다.

```swift
private func setUpCompositionalLayout() -> UICollectionViewLayout {
        let layout = UICollectionViewCompositionalLayout {
            (sectionIndex: Int, layoutEnvironment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection? in
            
            let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(1.0))
            let item = NSCollectionLayoutItem(layoutSize: itemSize)
            
            item.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
            
            let groupHeight =  NSCollectionLayoutDimension.fractionalWidth(1/4)
            let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: groupHeight)
            let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitem: item, count: 1)
            let section = NSCollectionLayoutSection(group: group)
            
            return section
        }
        return layout
    }
```

- 변경 후
    - ModernCollectionView의 Layout 중에 `list`라는 메서드를 사용하면 테이블뷰 형태로 생성이 가능합니다.
    - Cell들 내부 요소의 크기만큼 Cell의 크기가 정해지기 때문에 Dynamic Type을 사용하여도 문제가 생기지 않습니다.
```swift
private func setUpCompositionalListLayout() -> UICollectionViewLayout {
        let configuration = UICollectionLayoutListConfiguration(appearance: .plain)
        let layout = UICollectionViewCompositionalLayout.list(using: configuration)
        
        return layout
    }
```

<br/>

### :question: 해결하지 못한 부분
### MovieDetailViewController의 Dynamic Type 적용시 label alignment 문제

* movieDetailViewController에서 내부 UI요소들이 큰`vertical Stackview`안에 카테고리별로 `horizontal Stackview`로 담겨있는 형식으로 구성되있습니다. 
* 왼쪽 카테고리 `Title Label`들과 오른쪽 `불러온 Data Label`들이 일정한 간격을 가지고 정렬된상태를 유지하기위해 왼쪽 `Title Label`들은 **일정 너비`greaterThanEqaul, width = 70`을 갖는 방식**으로 정렬을 유지하게끔 설정했습니다.
* 문제는 `Dynamic Type`을 적용시 `width = 70`을 넘어가게되면서 모든 alignment가 무너지고 label들이 오른쪽 사진과같이 붙어버리는 현상이 발생합니다.
* `horizontal Stackview` 간의 `spacing`아니면 `horizontal Stackview`를 사용하지않고 label간 오토레이아웃 잡는 방식 등 여러가지방법을 고민해봤지만 해결책이 떠오르지않아서 해결못한 부분으로 질문드리려고합니다

<img src = "https://i.imgur.com/qccJJjo.jpg" width = 300> <img src = "https://i.imgur.com/p3q0vCW.jpg" width = 300>

### Icon 모드의 Dynamic Type
- Icon 모드에서 Dynamic Type 사용 시
    - Icon 모드에서의 Dynamic Type 표현을 어떻게 하면 좋을지 고민했습니다.
    - Cell 크기를 늘려서 Dynamic Type을 적용시키는 방법이 좋은건지, 아니면 cell의 크기를 늘리지 않고도 Dynamic Type을 적용시킬 수 있는 방법이 있는지 궁금합니다.
<img src = "https://i.imgur.com/AzqAkMS.png" width = 200>