### PR TITLE
박스오피스 II [STEP 2] 레옹아범, Andrew

### DIFF
--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		7180BC3A29C9547A00C9E70B /* Bundle+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7180BC3929C9547A00C9E70B /* Bundle+extension.swift */; };
 		71A0A45929C98E64006D3932 /* APIType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71A0A45829C98E64006D3932 /* APIType.swift */; };
 		71A0A45B29C9931B006D3932 /* BoxofficeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71A0A45A29C9931B006D3932 /* BoxofficeError.swift */; };
+		71A6140629E3D82D00D820D6 /* RankingViewType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71A6140529E3D82D00D820D6 /* RankingViewType.swift */; };
 		71C59E3729D41B440016E247 /* MovieRankingListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71C59E3629D41B440016E247 /* MovieRankingListCell.swift */; };
 		71D8B04A29D56CC80005A625 /* Date+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71D8B04929D56CC80005A625 /* Date+extension.swift */; };
 		71E6434F29DAA38C001F733E /* MovieImageObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71E6434E29DAA38C001F733E /* MovieImageObject.swift */; };
@@ -102,6 +103,7 @@
 		7180BC3929C9547A00C9E70B /* Bundle+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+extension.swift"; sourceTree = "<group>"; };
 		71A0A45829C98E64006D3932 /* APIType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIType.swift; sourceTree = "<group>"; };
 		71A0A45A29C9931B006D3932 /* BoxofficeError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxofficeError.swift; sourceTree = "<group>"; };
+		71A6140529E3D82D00D820D6 /* RankingViewType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RankingViewType.swift; sourceTree = "<group>"; };
 		71C59E3629D41B440016E247 /* MovieRankingListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieRankingListCell.swift; sourceTree = "<group>"; };
 		71D8B04929D56CC80005A625 /* Date+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+extension.swift"; sourceTree = "<group>"; };
 		71E6434E29DAA38C001F733E /* MovieImageObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieImageObject.swift; sourceTree = "<group>"; };
@@ -275,6 +277,7 @@
 				71A0A45829C98E64006D3932 /* APIType.swift */,
 				7122D85829CABAB50039DEFB /* NetworkModel.swift */,
 				715553E029D30E8200B7FC3D /* BoxofficeInfo.swift */,
+				71A6140529E3D82D00D820D6 /* RankingViewType.swift */,
 				26F9105B29DC23FD0042B22C /* Manager */,
 				26F9105A29DC23F60042B22C /* UIModel */,
 				26B6853F29C98B0E001580FF /* DTO */,
@@ -481,6 +484,7 @@
 				26B6853A29C986C5001580FF /* MovieInfoObject.swift in Sources */,
 				71A0A45B29C9931B006D3932 /* BoxofficeError.swift in Sources */,
 				7180BC3A29C9547A00C9E70B /* Bundle+extension.swift in Sources */,
+				71A6140629E3D82D00D820D6 /* RankingViewType.swift in Sources */,
 				7139126629C821BF00E54F5E /* InfoObject.swift in Sources */,
 				71C59E3729D41B440016E247 /* MovieRankingListCell.swift in Sources */,
 				63DF20F12970E1A0005DF7D1 /* SceneDelegate.swift in Sources */,

--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		71A0A45929C98E64006D3932 /* APIType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71A0A45829C98E64006D3932 /* APIType.swift */; };
 		71A0A45B29C9931B006D3932 /* BoxofficeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71A0A45A29C9931B006D3932 /* BoxofficeError.swift */; };
 		71A6140629E3D82D00D820D6 /* RankingViewType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71A6140529E3D82D00D820D6 /* RankingViewType.swift */; };
+		71A6140A29E3F24700D820D6 /* UILabel+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71A6140929E3F24700D820D6 /* UILabel+extension.swift */; };
 		71C59E3729D41B440016E247 /* MovieRankingListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71C59E3629D41B440016E247 /* MovieRankingListCell.swift */; };
 		71D8B04A29D56CC80005A625 /* Date+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71D8B04929D56CC80005A625 /* Date+extension.swift */; };
 		71E6434F29DAA38C001F733E /* MovieImageObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71E6434E29DAA38C001F733E /* MovieImageObject.swift */; };
@@ -104,6 +105,7 @@
 		71A0A45829C98E64006D3932 /* APIType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIType.swift; sourceTree = "<group>"; };
 		71A0A45A29C9931B006D3932 /* BoxofficeError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxofficeError.swift; sourceTree = "<group>"; };
 		71A6140529E3D82D00D820D6 /* RankingViewType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RankingViewType.swift; sourceTree = "<group>"; };
+		71A6140929E3F24700D820D6 /* UILabel+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+extension.swift"; sourceTree = "<group>"; };
 		71C59E3629D41B440016E247 /* MovieRankingListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieRankingListCell.swift; sourceTree = "<group>"; };
 		71D8B04929D56CC80005A625 /* Date+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+extension.swift"; sourceTree = "<group>"; };
 		71E6434E29DAA38C001F733E /* MovieImageObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieImageObject.swift; sourceTree = "<group>"; };
@@ -145,6 +147,7 @@
 				7180BC3929C9547A00C9E70B /* Bundle+extension.swift */,
 				71D8B04929D56CC80005A625 /* Date+extension.swift */,
 				71EDC4A129DC0CE800510E15 /* ViewController+extension.swift */,
+				71A6140929E3F24700D820D6 /* UILabel+extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -486,6 +489,7 @@
 				7180BC3A29C9547A00C9E70B /* Bundle+extension.swift in Sources */,
 				71A6140629E3D82D00D820D6 /* RankingViewType.swift in Sources */,
 				7139126629C821BF00E54F5E /* InfoObject.swift in Sources */,
+				71A6140A29E3F24700D820D6 /* UILabel+extension.swift in Sources */,
 				71C59E3729D41B440016E247 /* MovieRankingListCell.swift in Sources */,
 				63DF20F12970E1A0005DF7D1 /* SceneDelegate.swift in Sources */,
 				26B1733729C845CD0086B7CA /* String+extension.swift in Sources */,

--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		7122D85929CABAB50039DEFB /* NetworkModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7122D85829CABAB50039DEFB /* NetworkModel.swift */; };
 		7122D85B29CAC5CB0039DEFB /* StubBoxoffice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7122D85A29CAC5CB0039DEFB /* StubBoxoffice.swift */; };
 		7139126629C821BF00E54F5E /* InfoObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7139126529C821BF00E54F5E /* InfoObject.swift */; };
+		714E043929DFFDF8002564C5 /* MovieRankingIconCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 714E043829DFFDF8002564C5 /* MovieRankingIconCell.swift */; };
 		715553DF29D30E6300B7FC3D /* NetworkingProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715553DE29D30E6300B7FC3D /* NetworkingProtocol.swift */; };
 		715553E129D30E8200B7FC3D /* BoxofficeInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715553E029D30E8200B7FC3D /* BoxofficeInfo.swift */; };
 		71741B1C29DD160800FA9FE4 /* CalendarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71741B1B29DD160800FA9FE4 /* CalendarViewController.swift */; };
@@ -38,7 +39,7 @@
 		7180BC3A29C9547A00C9E70B /* Bundle+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7180BC3929C9547A00C9E70B /* Bundle+extension.swift */; };
 		71A0A45929C98E64006D3932 /* APIType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71A0A45829C98E64006D3932 /* APIType.swift */; };
 		71A0A45B29C9931B006D3932 /* BoxofficeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71A0A45A29C9931B006D3932 /* BoxofficeError.swift */; };
-		71C59E3729D41B440016E247 /* MovieRankingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71C59E3629D41B440016E247 /* MovieRankingCell.swift */; };
+		71C59E3729D41B440016E247 /* MovieRankingListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71C59E3629D41B440016E247 /* MovieRankingListCell.swift */; };
 		71D8B04A29D56CC80005A625 /* Date+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71D8B04929D56CC80005A625 /* Date+extension.swift */; };
 		71E6434F29DAA38C001F733E /* MovieImageObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71E6434E29DAA38C001F733E /* MovieImageObject.swift */; };
 		71E6435529DAC832001F733E /* ContentStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71E6435429DAC832001F733E /* ContentStackView.swift */; };
@@ -93,6 +94,7 @@
 		7122D85829CABAB50039DEFB /* NetworkModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkModel.swift; sourceTree = "<group>"; };
 		7122D85A29CAC5CB0039DEFB /* StubBoxoffice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubBoxoffice.swift; sourceTree = "<group>"; };
 		7139126529C821BF00E54F5E /* InfoObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoObject.swift; sourceTree = "<group>"; };
+		714E043829DFFDF8002564C5 /* MovieRankingIconCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieRankingIconCell.swift; sourceTree = "<group>"; };
 		715553DE29D30E6300B7FC3D /* NetworkingProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkingProtocol.swift; sourceTree = "<group>"; };
 		715553E029D30E8200B7FC3D /* BoxofficeInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxofficeInfo.swift; sourceTree = "<group>"; };
 		71741B1B29DD160800FA9FE4 /* CalendarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewController.swift; sourceTree = "<group>"; };
@@ -100,7 +102,7 @@
 		7180BC3929C9547A00C9E70B /* Bundle+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+extension.swift"; sourceTree = "<group>"; };
 		71A0A45829C98E64006D3932 /* APIType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIType.swift; sourceTree = "<group>"; };
 		71A0A45A29C9931B006D3932 /* BoxofficeError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxofficeError.swift; sourceTree = "<group>"; };
-		71C59E3629D41B440016E247 /* MovieRankingCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieRankingCell.swift; sourceTree = "<group>"; };
+		71C59E3629D41B440016E247 /* MovieRankingListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieRankingListCell.swift; sourceTree = "<group>"; };
 		71D8B04929D56CC80005A625 /* Date+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+extension.swift"; sourceTree = "<group>"; };
 		71E6434E29DAA38C001F733E /* MovieImageObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieImageObject.swift; sourceTree = "<group>"; };
 		71E6435429DAC832001F733E /* ContentStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentStackView.swift; sourceTree = "<group>"; };
@@ -313,7 +315,8 @@
 			isa = PBXGroup;
 			children = (
 				26F9105D29DC24290042B22C /* UIStackView */,
-				71C59E3629D41B440016E247 /* MovieRankingCell.swift */,
+				71C59E3629D41B440016E247 /* MovieRankingListCell.swift */,
+				714E043829DFFDF8002564C5 /* MovieRankingIconCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -461,6 +464,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				714E043929DFFDF8002564C5 /* MovieRankingIconCell.swift in Sources */,
 				71741B1C29DD160800FA9FE4 /* CalendarViewController.swift in Sources */,
 				71EDC4A029DBEE2900510E15 /* MovieInfoUIModel.swift in Sources */,
 				71A0A45929C98E64006D3932 /* APIType.swift in Sources */,
@@ -478,7 +482,7 @@
 				71A0A45B29C9931B006D3932 /* BoxofficeError.swift in Sources */,
 				7180BC3A29C9547A00C9E70B /* Bundle+extension.swift in Sources */,
 				7139126629C821BF00E54F5E /* InfoObject.swift in Sources */,
-				71C59E3729D41B440016E247 /* MovieRankingCell.swift in Sources */,
+				71C59E3729D41B440016E247 /* MovieRankingListCell.swift in Sources */,
 				63DF20F12970E1A0005DF7D1 /* SceneDelegate.swift in Sources */,
 				26B1733729C845CD0086B7CA /* String+extension.swift in Sources */,
 				269BFC9829D6A9E800263E4C /* CellUIModel.swift in Sources */,

--- a/BoxOffice/Extension/UILabel+extension.swift
+++ b/BoxOffice/Extension/UILabel+extension.swift
@@ -8,15 +8,13 @@
 import UIKit
 
 extension UILabel {
-    
-    convenience init(fontStyle: UIFont.TextStyle, numberOfLine: Int = 1) {
+    convenience init(fontStyle: UIFont, numberOfLine: Int = 1) {
         self.init()
         
         numberOfLines = numberOfLine
-        font = .preferredFont(forTextStyle: fontStyle)
+        font = fontStyle
         translatesAutoresizingMaskIntoConstraints = false
         adjustsFontSizeToFitWidth = true
         adjustsFontForContentSizeCategory = true
     }
-    
 }

--- a/BoxOffice/Extension/UILabel+extension.swift
+++ b/BoxOffice/Extension/UILabel+extension.swift
@@ -1,0 +1,22 @@
+//
+//  DynamicType.swift
+//  BoxOffice
+//
+//  Created by Andrew on 2023/04/10.
+//
+
+import UIKit
+
+extension UILabel {
+    
+    convenience init(fontStyle: UIFont.TextStyle, numberOfLine: Int = 1) {
+        self.init()
+        
+        numberOfLines = numberOfLine
+        font = .preferredFont(forTextStyle: fontStyle)
+        translatesAutoresizingMaskIntoConstraints = false
+        adjustsFontSizeToFitWidth = true
+        adjustsFontForContentSizeCategory = true
+    }
+    
+}

--- a/BoxOffice/Model/APIType.swift
+++ b/BoxOffice/Model/APIType.swift
@@ -6,7 +6,7 @@
 //
 import Foundation
 
-enum APIType: Hashable {
+enum APIType {
     case movie(String)
     case boxoffice(String)
     case movieImage(String)

--- a/BoxOffice/Model/RankingViewType.swift
+++ b/BoxOffice/Model/RankingViewType.swift
@@ -27,5 +27,4 @@ enum RankingViewType {
             self = .list
         }
     }
-    
 }

--- a/BoxOffice/Model/RankingViewType.swift
+++ b/BoxOffice/Model/RankingViewType.swift
@@ -18,13 +18,4 @@ enum RankingViewType {
             return "리스트"
         }
     }
-    
-    mutating func toggle() {
-        switch self {
-        case .list:
-            self = .icon
-        case .icon:
-            self = .list
-        }
-    }
 }

--- a/BoxOffice/Model/RankingViewType.swift
+++ b/BoxOffice/Model/RankingViewType.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum RankingViewType {
+enum RankingViewType: Hashable {
     case list, icon
     
     var anotherTitle: String {

--- a/BoxOffice/Model/RankingViewType.swift
+++ b/BoxOffice/Model/RankingViewType.swift
@@ -1,0 +1,31 @@
+//
+//  RankingViewType.swift
+//  BoxOffice
+//
+//  Created by Andrew on 2023/04/10.
+//
+
+import Foundation
+
+enum RankingViewType {
+    case list, icon
+    
+    var anotherTitle: String {
+        switch self {
+        case .list:
+            return "아이콘"
+        case .icon:
+            return "리스트"
+        }
+    }
+    
+    mutating func toggle() {
+        switch self {
+        case .list:
+            self = .icon
+        case .icon:
+            self = .list
+        }
+    }
+    
+}

--- a/BoxOffice/SceneDelegate.swift
+++ b/BoxOffice/SceneDelegate.swift
@@ -15,8 +15,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         
+        let navigationController = UINavigationController(rootViewController: MovieRankingViewController())
+        navigationController.view.maximumContentSizeCategory = .accessibilityExtraExtraLarge
+        
         window = UIWindow(windowScene: windowScene)
-        window?.rootViewController = UINavigationController(rootViewController: MovieRankingViewController())
+        window?.rootViewController = navigationController
         window?.makeKeyAndVisible()
     }
 

--- a/Controller/CalendarViewController.swift
+++ b/Controller/CalendarViewController.swift
@@ -14,6 +14,7 @@ final class CalendarViewController: UIViewController {
     
     private let calendarView = {
         let calendarView = UICalendarView()
+        
         calendarView.translatesAutoresizingMaskIntoConstraints = false
         calendarView.calendar = Calendar(identifier: .gregorian)
         calendarView.locale = Locale(identifier: "ko_KR")
@@ -56,18 +57,6 @@ final class CalendarViewController: UIViewController {
         calendarView.selectionBehavior = selection
         selection.selectedDate = DateComponents(calendar: calendar, year: selectedYear, month: selectedMonth, day: selectedDay)
     }
-    
-    private func configureUI() {
-        view.backgroundColor = .systemBackground
-        view.addSubview(calendarView)
-        
-        NSLayoutConstraint.activate([
-            calendarView.topAnchor.constraint(equalTo: view.topAnchor),
-            calendarView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            calendarView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            calendarView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
-        ])
-    }
 }
 
 //MARK: - UICalendarSelectionSingleDateDelegate
@@ -78,5 +67,20 @@ extension CalendarViewController: UICalendarSelectionSingleDateDelegate {
         delegate?.changeDate(selectedDate)
         
         dismiss(animated: true)
+    }
+}
+
+//MARK: - UI
+extension CalendarViewController {
+    private func configureUI() {
+        view.backgroundColor = .systemBackground
+        view.addSubview(calendarView)
+        
+        NSLayoutConstraint.activate([
+            calendarView.topAnchor.constraint(equalTo: view.topAnchor),
+            calendarView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            calendarView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            calendarView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
     }
 }

--- a/Controller/MovieDetailViewController.swift
+++ b/Controller/MovieDetailViewController.swift
@@ -83,14 +83,7 @@ final class MovieDetailViewController: UIViewController {
             }
         }
     }
-    
-    private func configureImageWidthConstraint(size: CGSize) {
-        let width = CGFloat(size.width)
-        let height = CGFloat(size.height)
         
-        posterImageView.heightAnchor.constraint(equalTo: posterImageView.widthAnchor, multiplier: height / width).isActive = true
-    }
-    
     private func startLoading() {
         loadingView.startAnimating()
         posterImageView.isHidden = true
@@ -108,6 +101,13 @@ final class MovieDetailViewController: UIViewController {
 
 // MARK: - UI
 extension MovieDetailViewController {
+    private func configureImageWidthConstraint(size: CGSize) {
+        let width = CGFloat(size.width)
+        let height = CGFloat(size.height)
+        
+        posterImageView.heightAnchor.constraint(equalTo: posterImageView.widthAnchor, multiplier: height / width).isActive = true
+    }
+    
     private func configureUI() {
         view.backgroundColor = .systemBackground
         navigationItem.title = movieName

--- a/Controller/MovieRankingViewController.swift
+++ b/Controller/MovieRankingViewController.swift
@@ -143,11 +143,11 @@ extension MovieRankingViewController {
     }
     
     private func makeCollectionViewIconLayout() -> UICollectionViewCompositionalLayout {
-        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.5), heightDimension: .estimated(1000))
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.5), heightDimension: .estimated( view.frame.height / 4))
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
         item.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 10, bottom: 0, trailing: 10)
         
-        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(1000))
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(view.frame.height / 4))
         let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
 
         let section = NSCollectionLayoutSection(group: group)

--- a/Controller/MovieRankingViewController.swift
+++ b/Controller/MovieRankingViewController.swift
@@ -79,6 +79,10 @@ final class MovieRankingViewController: UIViewController {
         calendarVC.selectedDate = boxofficeDate
         present(calendarVC, animated: true)
     }
+    
+    @objc private func didTapPresentButton() {
+        
+    }
 }
 
 // MARK: Changeable
@@ -133,6 +137,7 @@ extension MovieRankingViewController {
         configureLoadingView()
         configureNavigationItems()
         configureRefreshController()
+        makeToolbar()
         makeDataSource()
     }
     
@@ -141,6 +146,15 @@ extension MovieRankingViewController {
         loadingView.style = .large
         
         view.addSubview(loadingView)
+    }
+    
+    private func makeToolbar() {
+        navigationController?.setToolbarHidden(false, animated: true)
+        
+        let flexibleItem = UIBarButtonItem(systemItem: .flexibleSpace)
+        let barButtonItem = UIBarButtonItem(title: "화면 전환", style: .plain, target: self, action: #selector(didTapPresentButton))
+        
+        setToolbarItems([flexibleItem, barButtonItem, flexibleItem], animated: true)
     }
     
     private func makeCollectionViewListLayout() -> UICollectionViewCompositionalLayout {

--- a/Controller/MovieRankingViewController.swift
+++ b/Controller/MovieRankingViewController.swift
@@ -183,7 +183,7 @@ extension MovieRankingViewController {
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
         item.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 10, bottom: 10, trailing: 10)
         
-        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(0.35))
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(0.27))
         let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
         
         let section = NSCollectionLayoutSection(group: group)

--- a/Controller/MovieRankingViewController.swift
+++ b/Controller/MovieRankingViewController.swift
@@ -84,7 +84,12 @@ final class MovieRankingViewController: UIViewController {
         let alert = UIAlertController(title: "화면모드변경",
                                       message: nil,
                                       preferredStyle: .actionSheet)
-        alert.addAction(UIAlertAction(title: "아이콘", style: .default))
+        alert.addAction(UIAlertAction(title: "아이콘", style: .default, handler: { [weak self] _ in
+            guard let iconLayout = self?.makeCollectionViewIconLayout() else { return }
+            self?.makeIconDataSource()
+            self?.changeCollectionViewLayout(layout: iconLayout)
+            self?.fetchBoxofficeData()
+        }))
         alert.addAction(UIAlertAction(title: "취소", style: .cancel))
         present(alert, animated: true)
     }
@@ -136,14 +141,18 @@ extension MovieRankingViewController {
         view.backgroundColor = .systemBackground
         
         let layout = makeCollectionViewListLayout()
-        
         collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        
         configureCollectionViewLayout()
         configureLoadingView()
         configureNavigationItems()
         configureRefreshController()
         makeToolbar()
-        makeDataSource()
+        makeListDataSource()
+    }
+    
+    private func changeCollectionViewLayout(layout: UICollectionViewCompositionalLayout) {
+        collectionView?.setCollectionViewLayout(layout, animated: true)
     }
     
     private func configureLoadingView() {
@@ -172,8 +181,9 @@ extension MovieRankingViewController {
     private func makeCollectionViewIconLayout() -> UICollectionViewCompositionalLayout {
         let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.5), heightDimension: .fractionalHeight(1.0))
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        item.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 10, bottom: 10, trailing: 10)
         
-        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(0.25))
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(0.35))
         let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
         
         let section = NSCollectionLayoutSection(group: group)
@@ -183,7 +193,7 @@ extension MovieRankingViewController {
         return layout
     }
     
-    private func makeDataSource() {
+    private func makeListDataSource() {
         guard let collectionView = collectionView else { return }
         
         dataSource = UICollectionViewDiffableDataSource<APIType, InfoObject>(collectionView: collectionView, cellProvider: { collectionView, indexPath, itemIdentifier in
@@ -193,6 +203,20 @@ extension MovieRankingViewController {
             
             cell.updateLabelText(for: uiModel)
             
+            return cell
+        })
+    }
+    
+    private func makeIconDataSource() {
+        guard let collectionView = collectionView else { return }
+
+        dataSource = UICollectionViewDiffableDataSource<APIType, InfoObject>(collectionView: collectionView, cellProvider: { collectionView, indexPath, itemIdentifier in
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MovieRankingIconCell.identifier, for: indexPath) as? MovieRankingIconCell else { return UICollectionViewCell() }
+
+            let uiModel = CellUIModel(data: itemIdentifier)
+
+            cell.updateLabelText(for: uiModel)
+
             return cell
         })
     }

--- a/Controller/MovieRankingViewController.swift
+++ b/Controller/MovieRankingViewController.swift
@@ -80,8 +80,13 @@ final class MovieRankingViewController: UIViewController {
         present(calendarVC, animated: true)
     }
     
-    @objc private func didTapPresentButton() {
-        
+    @objc private func didTapChangedScreenButton() {
+        let alert = UIAlertController(title: "화면모드변경",
+                                      message: nil,
+                                      preferredStyle: .actionSheet)
+        alert.addAction(UIAlertAction(title: "아이콘", style: .default))
+        alert.addAction(UIAlertAction(title: "취소", style: .cancel))
+        present(alert, animated: true)
     }
 }
 
@@ -152,7 +157,7 @@ extension MovieRankingViewController {
         navigationController?.setToolbarHidden(false, animated: true)
         
         let flexibleItem = UIBarButtonItem(systemItem: .flexibleSpace)
-        let barButtonItem = UIBarButtonItem(title: "화면 전환", style: .plain, target: self, action: #selector(didTapPresentButton))
+        let barButtonItem = UIBarButtonItem(title: "화면 전환", style: .plain, target: self, action: #selector(didTapChangedScreenButton))
         
         setToolbarItems([flexibleItem, barButtonItem, flexibleItem], animated: true)
     }
@@ -168,7 +173,7 @@ extension MovieRankingViewController {
         guard let collectionView = collectionView else { return }
         
         dataSource = UICollectionViewDiffableDataSource<APIType, InfoObject>(collectionView: collectionView, cellProvider: { collectionView, indexPath, itemIdentifier in
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MovieRankingCell.identifier, for: indexPath) as? MovieRankingCell else { return UICollectionViewListCell() }
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MovieRankingListCell.identifier, for: indexPath) as? MovieRankingListCell else { return UICollectionViewListCell() }
             
             let uiModel = CellUIModel(data: itemIdentifier)
             
@@ -196,7 +201,7 @@ extension MovieRankingViewController {
         
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         collectionView.delegate = self
-        collectionView.register(MovieRankingCell.self, forCellWithReuseIdentifier: MovieRankingCell.identifier)
+        collectionView.register(MovieRankingListCell.self, forCellWithReuseIdentifier: MovieRankingListCell.identifier)
         
         NSLayoutConstraint.activate([
             collectionView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),

--- a/Controller/MovieRankingViewController.swift
+++ b/Controller/MovieRankingViewController.swift
@@ -169,6 +169,20 @@ extension MovieRankingViewController {
         return layout
     }
     
+    private func makeCollectionViewIconLayout() -> UICollectionViewCompositionalLayout {
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.5), heightDimension: .fractionalHeight(1.0))
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(0.25))
+        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
+        
+        let section = NSCollectionLayoutSection(group: group)
+        
+        let layout = UICollectionViewCompositionalLayout(section: section)
+        
+        return layout
+    }
+    
     private func makeDataSource() {
         guard let collectionView = collectionView else { return }
         
@@ -202,6 +216,7 @@ extension MovieRankingViewController {
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         collectionView.delegate = self
         collectionView.register(MovieRankingListCell.self, forCellWithReuseIdentifier: MovieRankingListCell.identifier)
+        collectionView.register(MovieRankingIconCell.self, forCellWithReuseIdentifier: MovieRankingIconCell.identifier)
         
         NSLayoutConstraint.activate([
             collectionView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),

--- a/Controller/MovieRankingViewController.swift
+++ b/Controller/MovieRankingViewController.swift
@@ -85,16 +85,17 @@ final class MovieRankingViewController: UIViewController {
             switch self?.rankingViewType {
             case .list:
                 guard let iconLayout = self?.makeCollectionViewIconLayout() else { return }
+                self?.rankingViewType = .icon
                 self?.createIconDataSource()
                 self?.changeCollectionViewLayout(layout: iconLayout)
             case .icon:
                 guard let listLayout = self?.makeCollectionViewListLayout() else { return }
+                self?.rankingViewType = .list
                 self?.createListDataSource()
                 self?.changeCollectionViewLayout(layout: listLayout)
             default:
                 return
             }
-            self?.rankingViewType.toggle()
             self?.applySnapshot()
         })
         let cancelAction = UIAlertAction(title: "취소", style: .cancel)

--- a/Controller/MovieRankingViewController.swift
+++ b/Controller/MovieRankingViewController.swift
@@ -96,7 +96,7 @@ final class MovieRankingViewController: UIViewController {
                 self?.changeCollectionViewLayout(layout: listLayout)
             }
             self?.rankingViewType.toggle()
-            self?.fetchBoxofficeData()
+            self?.applySnapshot()
         })
         let cancelAction = UIAlertAction(title: "취소", style: .cancel)
         

--- a/Controller/MovieRankingViewController.swift
+++ b/Controller/MovieRankingViewController.swift
@@ -190,14 +190,16 @@ extension MovieRankingViewController {
     }
     
     private func makeCollectionViewIconLayout() -> UICollectionViewCompositionalLayout {
-        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.5), heightDimension: .fractionalHeight(1.0))
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.5), heightDimension: .estimated(1000))
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
-        item.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 10, bottom: 10, trailing: 10)
+        item.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 10, bottom: 0, trailing: 10)
         
-        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(0.27))
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(1000))
         let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
+
         
         let section = NSCollectionLayoutSection(group: group)
+        section.interGroupSpacing = 10
         
         let layout = UICollectionViewCompositionalLayout(section: section)
         

--- a/Controller/MovieRankingViewController.swift
+++ b/Controller/MovieRankingViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 final class MovieRankingViewController: UIViewController {
     
     // MARK: Propertie
+    private var rankingViewType: RankingViewType = .list
     private var dataManager: RankingManager?
     private var boxofficeDate = {
         guard let boxofficeDate = Date.yesterday else {
@@ -84,13 +85,23 @@ final class MovieRankingViewController: UIViewController {
         let alert = UIAlertController(title: "화면모드변경",
                                       message: nil,
                                       preferredStyle: .actionSheet)
-        alert.addAction(UIAlertAction(title: "아이콘", style: .default, handler: { [weak self] _ in
-            guard let iconLayout = self?.makeCollectionViewIconLayout() else { return }
-            self?.makeIconDataSource()
-            self?.changeCollectionViewLayout(layout: iconLayout)
+        let alertAction = UIAlertAction(title: rankingViewType.anotherTitle, style: .default, handler: { [weak self] _ in
+            if self?.rankingViewType == .list {
+                guard let iconLayout = self?.makeCollectionViewIconLayout() else { return }
+                self?.makeIconDataSource()
+                self?.changeCollectionViewLayout(layout: iconLayout)
+            } else {
+                guard let listLayout = self?.makeCollectionViewListLayout() else { return }
+                self?.makeListDataSource()
+                self?.changeCollectionViewLayout(layout: listLayout)
+            }
+            self?.rankingViewType.toggle()
             self?.fetchBoxofficeData()
-        }))
-        alert.addAction(UIAlertAction(title: "취소", style: .cancel))
+        })
+        let cancelAction = UIAlertAction(title: "취소", style: .cancel)
+        
+        alert.addAction(alertAction)
+        alert.addAction(cancelAction)
         present(alert, animated: true)
     }
 }

--- a/View/MovieRankingIconCell.swift
+++ b/View/MovieRankingIconCell.swift
@@ -11,13 +11,11 @@ class MovieRankingIconCell: UICollectionViewCell {
     static let identifier = "MovieRankingIconCell"
     
     // MARK: UI Properties
-    private let rankStatusLabel = UILabel()
-    private let audienceLabel = UILabel()
-    
     private let rankLabel = {
         let label = UILabel()
         
         label.font = .preferredFont(forTextStyle: .largeTitle)
+        label.textAlignment = .center
         
         return label
     }()
@@ -27,6 +25,25 @@ class MovieRankingIconCell: UICollectionViewCell {
         
         label.numberOfLines = 0
         label.font = .preferredFont(forTextStyle: .title3)
+        label.textAlignment = .center
+        label.adjustsFontSizeToFitWidth = true
+        
+        return label
+    }()
+    
+    private let rankStatusLabel = {
+        let label = UILabel()
+        
+        label.font = .preferredFont(forTextStyle: .body)
+        
+        return label
+    }()
+    
+    private let audienceLabel = {
+        let label = UILabel()
+        
+        label.font = .preferredFont(forTextStyle: .largeTitle)
+        label.adjustsFontSizeToFitWidth = true
         
         return label
     }()
@@ -55,20 +72,41 @@ extension MovieRankingIconCell {
     private func configureUI() {
         self.layer.borderWidth = 0.5
         
-        let mainStackView = UIStackView(arrangedSubviews: [rankLabel, movieNameLabel, rankStatusLabel, audienceLabel])
+        let mainStackView = UIStackView()
         
         mainStackView.translatesAutoresizingMaskIntoConstraints = false
         mainStackView.axis = .vertical
-        mainStackView.spacing = 8
+        mainStackView.distribution = .fillEqually
         mainStackView.alignment = .center
         
         contentView.addSubview(mainStackView)
         
         NSLayoutConstraint.activate([
             mainStackView.topAnchor.constraint(equalTo: contentView.topAnchor),
-            mainStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-            mainStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            mainStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -10),
+            mainStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 5),
+            mainStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -5),
+            mainStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -5),
         ])
+        
+        let rankStackView = UIStackView(arrangedSubviews: [rankLabel])
+        
+        rankStackView.translatesAutoresizingMaskIntoConstraints = false
+        
+        mainStackView.addArrangedSubview(rankStackView)
+        
+        let movieNameStackView = UIStackView(arrangedSubviews: [movieNameLabel])
+        
+        movieNameStackView.translatesAutoresizingMaskIntoConstraints = false
+        
+        mainStackView.addArrangedSubview(movieNameStackView)
+        
+        let statusStackView = UIStackView(arrangedSubviews: [rankStatusLabel, audienceLabel])
+        
+        statusStackView.axis = .vertical
+        statusStackView.spacing = 1
+        statusStackView.alignment = .center
+        statusStackView.distribution = .fillEqually
+        
+        mainStackView.addArrangedSubview(statusStackView)
     }
 }

--- a/View/MovieRankingIconCell.swift
+++ b/View/MovieRankingIconCell.swift
@@ -64,10 +64,10 @@ extension MovieRankingIconCell {
         contentView.addSubview(mainStackView)
         
         NSLayoutConstraint.activate([
-            mainStackView.topAnchor.constraint(equalTo: topAnchor),
-            mainStackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 5),
-            mainStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -5),
-            mainStackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -5),
+            mainStackView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            mainStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 5),
+            mainStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -5),
+            mainStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
         ])
     }
     
@@ -75,7 +75,6 @@ extension MovieRankingIconCell {
         let rankStackView = UIStackView(arrangedSubviews: [rankLabel])
         
         rankStackView.translatesAutoresizingMaskIntoConstraints = false
-        
         mainStackView.addArrangedSubview(rankStackView)
     }
     
@@ -83,7 +82,6 @@ extension MovieRankingIconCell {
         let movieNameStackView = UIStackView(arrangedSubviews: [movieNameLabel])
         
         movieNameStackView.translatesAutoresizingMaskIntoConstraints = false
-        
         mainStackView.addArrangedSubview(movieNameStackView)
     }
     
@@ -93,7 +91,6 @@ extension MovieRankingIconCell {
         statusStackView.axis = .vertical
         statusStackView.spacing = 1
         statusStackView.alignment = .center
-        statusStackView.distribution = .fillEqually
         
         mainStackView.addArrangedSubview(statusStackView)
     }

--- a/View/MovieRankingIconCell.swift
+++ b/View/MovieRankingIconCell.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class MovieRankingIconCell: UICollectionViewCell {
+final class MovieRankingIconCell: UICollectionViewCell {
     static let identifier = "MovieRankingIconCell"
     
     // MARK: UI Properties

--- a/View/MovieRankingIconCell.swift
+++ b/View/MovieRankingIconCell.swift
@@ -12,7 +12,7 @@ class MovieRankingIconCell: UICollectionViewCell {
     
     // MARK: UI Properties
     private let rankLabel = UILabel(fontStyle: .preferredFont(forTextStyle: .largeTitle))
-    private let movieNameLabel = UILabel(fontStyle: .preferredFont(forTextStyle: .title3), numberOfLine: 0)
+    private let movieNameLabel = UILabel(fontStyle: .preferredFont(forTextStyle: .title3), numberOfLine: 2)
     private let rankStatusLabel = UILabel(fontStyle: .preferredFont(forTextStyle: .body))
     private let audienceLabel = UILabel(fontStyle: .preferredFont(forTextStyle: .largeTitle))
     
@@ -91,6 +91,7 @@ extension MovieRankingIconCell {
         statusStackView.axis = .vertical
         statusStackView.spacing = 1
         statusStackView.alignment = .center
+        statusStackView.setContentCompressionResistancePriority(.required, for: .vertical)
         
         mainStackView.addArrangedSubview(statusStackView)
     }

--- a/View/MovieRankingIconCell.swift
+++ b/View/MovieRankingIconCell.swift
@@ -11,10 +11,10 @@ class MovieRankingIconCell: UICollectionViewCell {
     static let identifier = "MovieRankingIconCell"
     
     // MARK: UI Properties
-    private let rankLabel = UILabel(fontStyle: .largeTitle)
-    private let movieNameLabel = UILabel(fontStyle: .title3, numberOfLine: 0)
-    private let rankStatusLabel = UILabel(fontStyle: .body)
-    private let audienceLabel = UILabel(fontStyle: .largeTitle)
+    private let rankLabel = UILabel(fontStyle: .preferredFont(forTextStyle: .largeTitle))
+    private let movieNameLabel = UILabel(fontStyle: .preferredFont(forTextStyle: .title3), numberOfLine: 0)
+    private let rankStatusLabel = UILabel(fontStyle: .preferredFont(forTextStyle: .body))
+    private let audienceLabel = UILabel(fontStyle: .preferredFont(forTextStyle: .largeTitle))
     
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/View/MovieRankingIconCell.swift
+++ b/View/MovieRankingIconCell.swift
@@ -8,8 +8,6 @@
 import UIKit
 
 final class MovieRankingIconCell: UICollectionViewCell {
-    static let identifier = "MovieRankingIconCell"
-    
     // MARK: UI Properties
     private let mainStackView = UIStackView()
     

--- a/View/MovieRankingIconCell.swift
+++ b/View/MovieRankingIconCell.swift
@@ -53,7 +53,10 @@ class MovieRankingIconCell: UICollectionViewCell {
 extension MovieRankingIconCell {
     
     private func configureUI() {
+        self.layer.borderWidth = 0.5
+        
         let mainStackView = UIStackView(arrangedSubviews: [rankLabel, movieNameLabel, rankStatusLabel, audienceLabel])
+        
         mainStackView.translatesAutoresizingMaskIntoConstraints = false
         mainStackView.axis = .vertical
         mainStackView.spacing = 8
@@ -65,7 +68,7 @@ extension MovieRankingIconCell {
             mainStackView.topAnchor.constraint(equalTo: contentView.topAnchor),
             mainStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             mainStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
-            mainStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
+            mainStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -10),
         ])
     }
 }

--- a/View/MovieRankingIconCell.swift
+++ b/View/MovieRankingIconCell.swift
@@ -1,0 +1,71 @@
+//
+//  MovieRankingIconCell.swift
+//  BoxOffice
+//
+//  Created by Andrew on 2023/04/07.
+//
+
+import UIKit
+
+class MovieRankingIconCell: UICollectionViewCell {
+    static let identifier = "MovieRankingIconCell"
+    
+    // MARK: UI Properties
+    private let rankStatusLabel = UILabel()
+    private let audienceLabel = UILabel()
+    
+    private let rankLabel = {
+        let label = UILabel()
+        
+        label.font = .preferredFont(forTextStyle: .largeTitle)
+        
+        return label
+    }()
+    
+    private let movieNameLabel = {
+        let label = UILabel()
+        
+        label.numberOfLines = 0
+        label.font = .preferredFont(forTextStyle: .title3)
+        
+        return label
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func updateLabelText(for manager: CellUIModel) {
+        self.rankLabel.text = manager.rank
+        self.rankStatusLabel.attributedText = manager.rankStatusAttributedText
+        self.movieNameLabel.text = manager.name
+        self.audienceLabel.text = manager.audienceInfoText
+    }
+}
+
+
+// MARK: UI
+extension MovieRankingIconCell {
+    
+    private func configureUI() {
+        let mainStackView = UIStackView(arrangedSubviews: [rankLabel, movieNameLabel, rankStatusLabel, audienceLabel])
+        mainStackView.translatesAutoresizingMaskIntoConstraints = false
+        mainStackView.axis = .vertical
+        mainStackView.spacing = 8
+        mainStackView.alignment = .center
+        
+        contentView.addSubview(mainStackView)
+        
+        NSLayoutConstraint.activate([
+            mainStackView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            mainStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            mainStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            mainStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
+        ])
+    }
+}

--- a/View/MovieRankingIconCell.swift
+++ b/View/MovieRankingIconCell.swift
@@ -11,42 +11,10 @@ class MovieRankingIconCell: UICollectionViewCell {
     static let identifier = "MovieRankingIconCell"
     
     // MARK: UI Properties
-    private let rankLabel = {
-        let label = UILabel()
-        
-        label.font = .preferredFont(forTextStyle: .largeTitle)
-        label.textAlignment = .center
-        
-        return label
-    }()
-    
-    private let movieNameLabel = {
-        let label = UILabel()
-        
-        label.numberOfLines = 0
-        label.font = .preferredFont(forTextStyle: .title3)
-        label.textAlignment = .center
-        label.adjustsFontSizeToFitWidth = true
-        
-        return label
-    }()
-    
-    private let rankStatusLabel = {
-        let label = UILabel()
-        
-        label.font = .preferredFont(forTextStyle: .body)
-        
-        return label
-    }()
-    
-    private let audienceLabel = {
-        let label = UILabel()
-        
-        label.font = .preferredFont(forTextStyle: .largeTitle)
-        label.adjustsFontSizeToFitWidth = true
-        
-        return label
-    }()
+    private let rankLabel = UILabel(fontStyle: .largeTitle)
+    private let movieNameLabel = UILabel(fontStyle: .title3, numberOfLine: 0)
+    private let rankStatusLabel = UILabel(fontStyle: .body)
+    private let audienceLabel = UILabel(fontStyle: .largeTitle)
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -82,10 +50,10 @@ extension MovieRankingIconCell {
         contentView.addSubview(mainStackView)
         
         NSLayoutConstraint.activate([
-            mainStackView.topAnchor.constraint(equalTo: contentView.topAnchor),
-            mainStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 5),
-            mainStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -5),
-            mainStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -5),
+            mainStackView.topAnchor.constraint(equalTo: topAnchor),
+            mainStackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 5),
+            mainStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -5),
+            mainStackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -5),
         ])
         
         let rankStackView = UIStackView(arrangedSubviews: [rankLabel])

--- a/View/MovieRankingIconCell.swift
+++ b/View/MovieRankingIconCell.swift
@@ -16,6 +16,8 @@ class MovieRankingIconCell: UICollectionViewCell {
     private let rankStatusLabel = UILabel(fontStyle: .preferredFont(forTextStyle: .body))
     private let audienceLabel = UILabel(fontStyle: .preferredFont(forTextStyle: .largeTitle))
     
+    private let mainStackView = UIStackView()
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         configureUI()
@@ -40,8 +42,20 @@ extension MovieRankingIconCell {
     private func configureUI() {
         self.layer.borderWidth = 0.5
         
-        let mainStackView = UIStackView()
-        
+        configureLabelTextAlignment()
+        configureMainStackView()
+        configureRankStackView()
+        configureMovieNameStackView()
+        configureStatusStackView()
+    }
+    
+    private func configureLabelTextAlignment() {
+        [rankLabel, movieNameLabel, movieNameLabel, audienceLabel].forEach { label in
+            label.textAlignment = .center
+        }
+    }
+    
+    private func configureMainStackView() {
         mainStackView.translatesAutoresizingMaskIntoConstraints = false
         mainStackView.axis = .vertical
         mainStackView.distribution = .fillEqually
@@ -55,19 +69,25 @@ extension MovieRankingIconCell {
             mainStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -5),
             mainStackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -5),
         ])
-        
+    }
+    
+    private func configureRankStackView() {
         let rankStackView = UIStackView(arrangedSubviews: [rankLabel])
         
         rankStackView.translatesAutoresizingMaskIntoConstraints = false
         
         mainStackView.addArrangedSubview(rankStackView)
-        
+    }
+    
+    private func configureMovieNameStackView() {
         let movieNameStackView = UIStackView(arrangedSubviews: [movieNameLabel])
         
         movieNameStackView.translatesAutoresizingMaskIntoConstraints = false
         
         mainStackView.addArrangedSubview(movieNameStackView)
-        
+    }
+    
+    private func configureStatusStackView() {
         let statusStackView = UIStackView(arrangedSubviews: [rankStatusLabel, audienceLabel])
         
         statusStackView.axis = .vertical
@@ -77,4 +97,5 @@ extension MovieRankingIconCell {
         
         mainStackView.addArrangedSubview(statusStackView)
     }
+    
 }

--- a/View/MovieRankingIconCell.swift
+++ b/View/MovieRankingIconCell.swift
@@ -11,12 +11,12 @@ class MovieRankingIconCell: UICollectionViewCell {
     static let identifier = "MovieRankingIconCell"
     
     // MARK: UI Properties
+    private let mainStackView = UIStackView()
+    
     private let rankLabel = UILabel(fontStyle: .preferredFont(forTextStyle: .largeTitle))
     private let movieNameLabel = UILabel(fontStyle: .preferredFont(forTextStyle: .title3), numberOfLine: 2)
     private let rankStatusLabel = UILabel(fontStyle: .preferredFont(forTextStyle: .body))
     private let audienceLabel = UILabel(fontStyle: .preferredFont(forTextStyle: .largeTitle))
-    
-    private let mainStackView = UIStackView()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -35,10 +35,8 @@ class MovieRankingIconCell: UICollectionViewCell {
     }
 }
 
-
 // MARK: UI
 extension MovieRankingIconCell {
-    
     private func configureUI() {
         self.layer.borderWidth = 0.5
         
@@ -95,5 +93,4 @@ extension MovieRankingIconCell {
         
         mainStackView.addArrangedSubview(statusStackView)
     }
-    
 }

--- a/View/MovieRankingListCell.swift
+++ b/View/MovieRankingListCell.swift
@@ -8,9 +8,6 @@
 import UIKit
 
 final class MovieRankingListCell: UICollectionViewListCell {
-        
-    static let identifier = "MovieRankingListCell"
-    
     // MARK: UI Properties
     private let rankStackView = UIStackView()
     private let movieInfoStackView = UIStackView()

--- a/View/MovieRankingListCell.swift
+++ b/View/MovieRankingListCell.swift
@@ -12,14 +12,35 @@ final class MovieRankingListCell: UICollectionViewListCell {
     static let identifier = "MovieRankingListCell"
     
     // MARK: UI Properties
-    private let rankStatusLabel = UILabel()
-    private let audienceLabel = UILabel()
     private let rankStackView = UIStackView()
     private let movieInfoStackView = UIStackView()
+    
+    private let rankStatusLabel = {
+        let label = UILabel()
+        
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.adjustsFontForContentSizeCategory = true
+        label.font = .preferredFont(forTextStyle: .body)
+        
+        return label
+    }()
+    
+    private let audienceLabel = {
+        let label = UILabel()
+        
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.adjustsFontForContentSizeCategory = true
+        label.font = .preferredFont(forTextStyle: .body)
+        label.adjustsFontSizeToFitWidth = true
+        
+        return label
+    }()
     
     private let rankLabel = {
         let label = UILabel()
         
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.adjustsFontForContentSizeCategory = true
         label.font = .preferredFont(forTextStyle: .largeTitle)
         
         return label
@@ -28,8 +49,11 @@ final class MovieRankingListCell: UICollectionViewListCell {
     private let movieNameLabel = {
         let label = UILabel()
         
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 0
         label.font = .preferredFont(forTextStyle: .title3)
+        label.adjustsFontSizeToFitWidth = true
         
         return label
     }()
@@ -69,7 +93,9 @@ extension MovieRankingListCell {
             
             movieInfoStackView.centerYAnchor.constraint(equalTo: centerYAnchor),
             movieInfoStackView.leadingAnchor.constraint(equalTo: rankStackView.trailingAnchor),
-            movieInfoStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -30)
+            movieInfoStackView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -30),
+            movieInfoStackView.topAnchor.constraint(equalTo: topAnchor, constant: 15),
+            movieInfoStackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -15)
         ])
     }
     

--- a/View/MovieRankingListCell.swift
+++ b/View/MovieRankingListCell.swift
@@ -7,9 +7,9 @@
 
 import UIKit
 
-final class MovieRankingCell: UICollectionViewListCell {
+final class MovieRankingListCell: UICollectionViewListCell {
         
-    static let identifier = "MovieRankingCell"
+    static let identifier = "MovieRankingListCell"
     
     // MARK: UI Properties
     private let rankStatusLabel = UILabel()
@@ -54,7 +54,7 @@ final class MovieRankingCell: UICollectionViewListCell {
 }
 
 // MARK: UI
-extension MovieRankingCell {
+extension MovieRankingListCell {
     private func configureUI() {
         self.accessories = [.disclosureIndicator()]
         

--- a/View/MovieRankingListCell.swift
+++ b/View/MovieRankingListCell.swift
@@ -15,10 +15,10 @@ final class MovieRankingListCell: UICollectionViewListCell {
     private let rankStackView = UIStackView()
     private let movieInfoStackView = UIStackView()
     
-    private let rankStatusLabel = UILabel(fontStyle: .body)
-    private let audienceLabel = UILabel(fontStyle: .body)
-    private let rankLabel = UILabel(fontStyle: .largeTitle)
-    private let movieNameLabel = UILabel(fontStyle: .title3, numberOfLine: 0)
+    private let rankStatusLabel = UILabel(fontStyle: .preferredFont(forTextStyle: .body))
+    private let audienceLabel = UILabel(fontStyle: .preferredFont(forTextStyle: .body))
+    private let rankLabel = UILabel(fontStyle: .preferredFont(forTextStyle: .largeTitle))
+    private let movieNameLabel = UILabel(fontStyle: .preferredFont(forTextStyle: .title3), numberOfLine: 0)
     
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/View/MovieRankingListCell.swift
+++ b/View/MovieRankingListCell.swift
@@ -15,48 +15,10 @@ final class MovieRankingListCell: UICollectionViewListCell {
     private let rankStackView = UIStackView()
     private let movieInfoStackView = UIStackView()
     
-    private let rankStatusLabel = {
-        let label = UILabel()
-        
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.adjustsFontForContentSizeCategory = true
-        label.font = .preferredFont(forTextStyle: .body)
-        
-        return label
-    }()
-    
-    private let audienceLabel = {
-        let label = UILabel()
-        
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.adjustsFontForContentSizeCategory = true
-        label.font = .preferredFont(forTextStyle: .body)
-        label.adjustsFontSizeToFitWidth = true
-        
-        return label
-    }()
-    
-    private let rankLabel = {
-        let label = UILabel()
-        
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.adjustsFontForContentSizeCategory = true
-        label.font = .preferredFont(forTextStyle: .largeTitle)
-        
-        return label
-    }()
-    
-    private let movieNameLabel = {
-        let label = UILabel()
-        
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.adjustsFontForContentSizeCategory = true
-        label.numberOfLines = 0
-        label.font = .preferredFont(forTextStyle: .title3)
-        label.adjustsFontSizeToFitWidth = true
-        
-        return label
-    }()
+    private let rankStatusLabel = UILabel(fontStyle: .body)
+    private let audienceLabel = UILabel(fontStyle: .body)
+    private let rankLabel = UILabel(fontStyle: .largeTitle)
+    private let movieNameLabel = UILabel(fontStyle: .title3, numberOfLine: 0)
     
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/View/MovieRankingListCell.swift
+++ b/View/MovieRankingListCell.swift
@@ -44,20 +44,20 @@ extension MovieRankingListCell {
     private func configureUI() {
         self.accessories = [.disclosureIndicator()]
         
-        addSubview(rankStackView)
-        addSubview(movieInfoStackView)
+        contentView.addSubview(rankStackView)
+        contentView.addSubview(movieInfoStackView)
         
         NSLayoutConstraint.activate([
-            rankStackView.widthAnchor.constraint(equalTo: widthAnchor , multiplier: 0.25),
-            rankStackView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            rankStackView.topAnchor.constraint(equalTo: topAnchor, constant: 15),
-            rankStackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -15),
+            rankStackView.widthAnchor.constraint(equalTo: contentView.widthAnchor , multiplier: 0.25),
+            rankStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            rankStackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 15),
+            rankStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -15),
             
-            movieInfoStackView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            movieInfoStackView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
             movieInfoStackView.leadingAnchor.constraint(equalTo: rankStackView.trailingAnchor),
-            movieInfoStackView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -30),
-            movieInfoStackView.topAnchor.constraint(equalTo: topAnchor, constant: 15),
-            movieInfoStackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -15),
+            movieInfoStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -30),
+            movieInfoStackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 15),
+            movieInfoStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -15),
 
         ])
     }
@@ -68,6 +68,8 @@ extension MovieRankingListCell {
         rankStackView.translatesAutoresizingMaskIntoConstraints = false
         rankStackView.axis = .vertical
         rankStackView.alignment = .center
+        
+        rankLabel.heightAnchor.constraint(equalTo: rankStackView.heightAnchor, multiplier: 0.5).isActive = true
     }
     
     private func configureMovieInfoStackView() {
@@ -75,5 +77,7 @@ extension MovieRankingListCell {
         movieInfoStackView.addArrangedSubview(audienceLabel)
         movieInfoStackView.translatesAutoresizingMaskIntoConstraints = false
         movieInfoStackView.axis = .vertical
+        
+        movieNameLabel.heightAnchor.constraint(equalTo: movieInfoStackView.heightAnchor, multiplier: 0.5).isActive = true
     }
 }

--- a/View/MovieRankingListCell.swift
+++ b/View/MovieRankingListCell.swift
@@ -57,7 +57,8 @@ extension MovieRankingListCell {
             movieInfoStackView.leadingAnchor.constraint(equalTo: rankStackView.trailingAnchor),
             movieInfoStackView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -30),
             movieInfoStackView.topAnchor.constraint(equalTo: topAnchor, constant: 15),
-            movieInfoStackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -15)
+            movieInfoStackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -15),
+
         ])
     }
     

--- a/View/MovieRankingListCell.swift
+++ b/View/MovieRankingListCell.swift
@@ -15,10 +15,10 @@ final class MovieRankingListCell: UICollectionViewListCell {
     private let rankStackView = UIStackView()
     private let movieInfoStackView = UIStackView()
     
-    private let rankStatusLabel = UILabel(fontStyle: .preferredFont(forTextStyle: .body))
-    private let audienceLabel = UILabel(fontStyle: .preferredFont(forTextStyle: .body))
     private let rankLabel = UILabel(fontStyle: .preferredFont(forTextStyle: .largeTitle))
+    private let rankStatusLabel = UILabel(fontStyle: .preferredFont(forTextStyle: .body))
     private let movieNameLabel = UILabel(fontStyle: .preferredFont(forTextStyle: .title3), numberOfLine: 0)
+    private let audienceLabel = UILabel(fontStyle: .preferredFont(forTextStyle: .body))
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -41,27 +41,6 @@ final class MovieRankingListCell: UICollectionViewListCell {
 
 // MARK: UI
 extension MovieRankingListCell {
-    private func configureUI() {
-        self.accessories = [.disclosureIndicator()]
-        
-        contentView.addSubview(rankStackView)
-        contentView.addSubview(movieInfoStackView)
-        
-        NSLayoutConstraint.activate([
-            rankStackView.widthAnchor.constraint(equalTo: contentView.widthAnchor , multiplier: 0.25),
-            rankStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-            rankStackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 15),
-            rankStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -15),
-            
-            movieInfoStackView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-            movieInfoStackView.leadingAnchor.constraint(equalTo: rankStackView.trailingAnchor),
-            movieInfoStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -30),
-            movieInfoStackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 15),
-            movieInfoStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -15),
-
-        ])
-    }
-    
     private func configureRankStackView() {
         rankStackView.addArrangedSubview(rankLabel)
         rankStackView.addArrangedSubview(rankStatusLabel)
@@ -79,5 +58,25 @@ extension MovieRankingListCell {
         movieInfoStackView.axis = .vertical
         
         movieNameLabel.heightAnchor.constraint(equalTo: movieInfoStackView.heightAnchor, multiplier: 0.5).isActive = true
+    }
+    
+    private func configureUI() {
+        self.accessories = [.disclosureIndicator()]
+        
+        contentView.addSubview(rankStackView)
+        contentView.addSubview(movieInfoStackView)
+        
+        NSLayoutConstraint.activate([
+            rankStackView.widthAnchor.constraint(equalTo: contentView.widthAnchor , multiplier: 0.25),
+            rankStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            rankStackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 15),
+            rankStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -15),
+            
+            movieInfoStackView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            movieInfoStackView.leadingAnchor.constraint(equalTo: rankStackView.trailingAnchor),
+            movieInfoStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -30),
+            movieInfoStackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 15),
+            movieInfoStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -15),
+        ])
     }
 }

--- a/View/UIStackView/ContentStackView.swift
+++ b/View/UIStackView/ContentStackView.swift
@@ -14,8 +14,8 @@ final class ContentStackView: UIStackView {
     private let categoryLabel = {
         let font = UIFont.systemFont(ofSize: 12, weight: .bold)
         let fontMatrics = UIFontMetrics(forTextStyle: .headline).scaledFont(for: font)
-        
         let label = UILabel(fontStyle: fontMatrics)
+        
         label.textAlignment = .center
         
         return label
@@ -24,7 +24,6 @@ final class ContentStackView: UIStackView {
     private let contentLabel = {
         let font = UIFont.systemFont(ofSize: 12)
         let fontMatrics = UIFontMetrics(forTextStyle: .headline).scaledFont(for: font)
-        
         let label = UILabel(fontStyle: fontMatrics, numberOfLine: 0)
         
         return label
@@ -47,20 +46,6 @@ final class ContentStackView: UIStackView {
     
     func updateLabelText(_ contentText: String) {
         contentLabel.text = contentText
-    }
-    
-    private func configure() {
-        translatesAutoresizingMaskIntoConstraints = false
-        addArrangedSubview(categoryLabel)
-        addArrangedSubview(contentLabel)
-        spacing = 5
-        
-        let mutiplierValue = makeWidthMultiplier()
-        
-        labelWidthLayout = categoryLabel.widthAnchor.constraint(equalTo: widthAnchor, multiplier: mutiplierValue)
-        labelWidthLayout?.isActive = true
-        
-        NotificationCenter.default.addObserver(self, selector: #selector(changeWidthMultiplier), name: UIContentSizeCategory.didChangeNotification, object: nil)
     }
     
     private func changeWidth(by multiplier: CGFloat) {
@@ -90,5 +75,22 @@ final class ContentStackView: UIStackView {
     @objc private func changeWidthMultiplier() {
         let mutiplierValue = makeWidthMultiplier()
         changeWidth(by: mutiplierValue)
+    }
+}
+
+// MARK: UI
+extension ContentStackView {
+    private func configure() {
+        translatesAutoresizingMaskIntoConstraints = false
+        addArrangedSubview(categoryLabel)
+        addArrangedSubview(contentLabel)
+        spacing = 5
+        
+        let mutiplierValue = makeWidthMultiplier()
+        
+        labelWidthLayout = categoryLabel.widthAnchor.constraint(equalTo: widthAnchor, multiplier: mutiplierValue)
+        labelWidthLayout?.isActive = true
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(changeWidthMultiplier), name: UIContentSizeCategory.didChangeNotification, object: nil)
     }
 }

--- a/View/UIStackView/ContentStackView.swift
+++ b/View/UIStackView/ContentStackView.swift
@@ -10,22 +10,19 @@ import UIKit
 final class ContentStackView: UIStackView {
 
     private let categoryLabel = {
-        let label = UILabel()
+        let font = UIFont.systemFont(ofSize: 12, weight: .bold)
+        let fontMatrics = UIFontMetrics(forTextStyle: .headline).scaledFont(for: font)
         
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.textAlignment = .center
-        label.numberOfLines = 1
-        label.font = .systemFont(ofSize: 12, weight: .bold)
+        let label = UILabel(fontStyle: .preferredFont(forTextStyle: .title3))
         
         return label
     }()
     
     private let contentLabel = {
-        let label = UILabel()
+        let font = UIFont.systemFont(ofSize: 12)
+        let fontMatrics = UIFontMetrics(forTextStyle: .headline).scaledFont(for: font)
         
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.numberOfLines = 0
-        label.font = .systemFont(ofSize: 12)
+        let label = UILabel(fontStyle: .preferredFont(forTextStyle: .title3))
         
         return label
     }()

--- a/View/UIStackView/ContentStackView.swift
+++ b/View/UIStackView/ContentStackView.swift
@@ -13,7 +13,7 @@ final class ContentStackView: UIStackView {
         let font = UIFont.systemFont(ofSize: 12, weight: .bold)
         let fontMatrics = UIFontMetrics(forTextStyle: .headline).scaledFont(for: font)
         
-        let label = UILabel(fontStyle: .preferredFont(forTextStyle: .title3))
+        let label = UILabel(fontStyle: fontMatrics)
         
         return label
     }()
@@ -22,7 +22,7 @@ final class ContentStackView: UIStackView {
         let font = UIFont.systemFont(ofSize: 12)
         let fontMatrics = UIFontMetrics(forTextStyle: .headline).scaledFont(for: font)
         
-        let label = UILabel(fontStyle: .preferredFont(forTextStyle: .title3))
+        let label = UILabel(fontStyle: fontMatrics)
         
         return label
     }()

--- a/View/UIStackView/ContentStackView.swift
+++ b/View/UIStackView/ContentStackView.swift
@@ -8,12 +8,15 @@
 import UIKit
 
 final class ContentStackView: UIStackView {
+    
+    private var labelWidthLayout: NSLayoutConstraint?
 
     private let categoryLabel = {
         let font = UIFont.systemFont(ofSize: 12, weight: .bold)
         let fontMatrics = UIFontMetrics(forTextStyle: .headline).scaledFont(for: font)
         
         let label = UILabel(fontStyle: fontMatrics)
+        label.textAlignment = .center
         
         return label
     }()
@@ -22,7 +25,7 @@ final class ContentStackView: UIStackView {
         let font = UIFont.systemFont(ofSize: 12)
         let fontMatrics = UIFontMetrics(forTextStyle: .headline).scaledFont(for: font)
         
-        let label = UILabel(fontStyle: fontMatrics)
+        let label = UILabel(fontStyle: fontMatrics, numberOfLine: 0)
         
         return label
     }()
@@ -31,7 +34,7 @@ final class ContentStackView: UIStackView {
         self.init(frame: CGRect.zero)
         configure()
         
-        self.categoryLabel.text = categoryText
+        categoryLabel.text = categoryText
     }
     
     override init(frame: CGRect) {
@@ -47,12 +50,45 @@ final class ContentStackView: UIStackView {
     }
     
     private func configure() {
-        self.translatesAutoresizingMaskIntoConstraints = false
-        self.addArrangedSubview(categoryLabel)
-        self.addArrangedSubview(contentLabel)
-        self.spacing = 5
+        translatesAutoresizingMaskIntoConstraints = false
+        addArrangedSubview(categoryLabel)
+        addArrangedSubview(contentLabel)
+        spacing = 5
         
-        categoryLabel.widthAnchor.constraint(equalTo: self.widthAnchor, multiplier: 0.15).isActive = true
+        let mutiplierValue = makeWidthMultiplier()
+        
+        labelWidthLayout = categoryLabel.widthAnchor.constraint(equalTo: widthAnchor, multiplier: mutiplierValue)
+        labelWidthLayout?.isActive = true
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(changeWidthMultiplier), name: UIContentSizeCategory.didChangeNotification, object: nil)
     }
-
+    
+    private func changeWidth(by multiplier: CGFloat) {
+        guard let previousWidthLayout = labelWidthLayout else { return }
+        
+        NSLayoutConstraint.deactivate([
+            previousWidthLayout
+        ])
+        
+        labelWidthLayout = categoryLabel.widthAnchor.constraint(equalTo: widthAnchor, multiplier: multiplier)
+        labelWidthLayout?.isActive = true
+    }
+    
+    private func makeWidthMultiplier() -> CGFloat {
+        switch traitCollection.preferredContentSizeCategory {
+        case .accessibilityExtraExtraExtraLarge:
+            return 0.3
+        case .accessibilityExtraExtraLarge,
+             .accessibilityExtraLarge,
+             .accessibilityLarge:
+            return 0.25
+        default:
+            return 0.15
+        }
+    }
+    
+    @objc private func changeWidthMultiplier() {
+        let mutiplierValue = makeWidthMultiplier()
+        changeWidth(by: mutiplierValue)
+    }
 }

--- a/View/UIStackView/DescStackView.swift
+++ b/View/UIStackView/DescStackView.swift
@@ -27,6 +27,26 @@ final class DescStackView: UIStackView {
     required init(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+        
+    func updateTextLabel(_ data: MovieInfoUIModel) {
+        directorStackView.updateLabelText(data.directors)
+        productedYearStackView.updateLabelText(data.productedYear)
+        openDateStackView.updateLabelText(data.openDate)
+        showTimeStackView.updateLabelText(data.showTime)
+        auditStackView.updateLabelText(data.audits)
+        nationStackView.updateLabelText(data.nations)
+        genreStackView.updateLabelText(data.genre)
+        actorsStackView.updateLabelText(data.actors)
+    }
+}
+
+// MARK: UI
+extension DescStackView {
+    private func configure() {
+        self.translatesAutoresizingMaskIntoConstraints = false
+        self.axis = .vertical
+        self.spacing = 3
+    }
     
     private func addArrangedSubviews() {
         self.addArrangedSubview(directorStackView)
@@ -37,22 +57,5 @@ final class DescStackView: UIStackView {
         self.addArrangedSubview(nationStackView)
         self.addArrangedSubview(genreStackView)
         self.addArrangedSubview(actorsStackView)
-    }
-    
-    private func configure() {
-        self.translatesAutoresizingMaskIntoConstraints = false
-        self.axis = .vertical
-        self.spacing = 3
-    }
-    
-    func updateTextLabel(_ data: MovieInfoUIModel) {
-        directorStackView.updateLabelText(data.directors)
-        productedYearStackView.updateLabelText(data.productedYear)
-        openDateStackView.updateLabelText(data.openDate)
-        showTimeStackView.updateLabelText(data.showTime)
-        auditStackView.updateLabelText(data.audits)
-        nationStackView.updateLabelText(data.nations)
-        genreStackView.updateLabelText(data.genre)
-        actorsStackView.updateLabelText(data.actors)
     }
 }


### PR DESCRIPTION
@1Consumption 
안녕하세요 올라프! 박스오피스 &#8545; STEP2 PR 보내드립니다.
다이나믹타입때문에 조금 오래걸렸던것 같습니다
이번 스텝도 잘 부탁드립니다!!!

---

# 고민했던점

### 1️⃣ 리스트 <-> 아이콘 UI변경
* 리스트<->아이콘으로 UI변경시 `CollectionView`의 레이아웃 변경뿐만이 아니라 새로운 `Cell`에 기존 데이터도 입력을 해주도록 만들었습니다.
* `collectionView`의 레이아웃을 만들어주는 작업, `DiffableDataSource`를 만드는 작업, `DataSource`의 apply메소드를 통해 서버에서 새로운 데이터를 받지 않고 UI를 다시 그려주도록 만들었습니다.

### 2️⃣ 런타임 중에 Text Size 크기 감지

#### ❓문제점
- Dynamic Type을 적용함으로써 Text 크기가 일정 이상 커지면 StackView의 width값의 비율이 변경되어야 했습니다.
- 일괄적으로 width값의 비율을 적용해버리면 Text 크기가 가장 클 때는 자연스러웠지만 Text width값 비율이 고정되다보니 크기가 작을 때는 부자연스러운 UI가 출력되었습니다.

#### 📖해결법
```swift
NotificationCenter.default.addObserver(self, selector: #selector(changeWidthMultiplier), 
                                       name: UIContentSizeCategory.didChangeNotification, object: nil)

private func makeWidthMultiplier() -> CGFloat {
        switch traitCollection.preferredContentSizeCategory {
        case .accessibilityExtraExtraExtraLarge:
            return 0.3
        case .accessibilityExtraExtraLarge,
             .accessibilityExtraLarge,
             .accessibilityLarge:
            return 0.25
        default:
            return 0.15
        }
    }
```
- `UIContentSizeCategory.didChangeNotification`을 사용하여 Text 크기를 변경할 때마다 감지할 수 있게 구현하였습니다.
- 감지를 하여 traitCollection.preferredContentSizeCategory을 사용하여 각각의 text 크기마다 width 비율을 대응하도록 구현하였습니다.

### 3️⃣ IconCollectionView의 Dynamic Height 구현하기

#### ❓문제점
* 기존 `IconCell`의 높이가 고정되어있을 경우 글자 크기가 커질 때 다른 라벨이 작아지거나, 사라지는 등의 문제가 있었습니다.
* 이를 해결하기 위해 `IceonCell`의 높이를 Dynamic하게 변경할 수 있도록 만들었습니다.

#### 📖해결법
```swift
let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.5), heightDimension: .estimated(view.frame.height / 4))
let item = NSCollectionLayoutItem(layoutSize: itemSize)

let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(view.frame.height / 4))
```
* `estimated`메소드를 이용하여 `IconCell`안의 컨텐츠의 크기에 따라 높이가 설정되도록 `Item`과 `Group`의 높이가 변경되도록 만들어주었습니다.

### 4️⃣ cell width 값보다 Label width값이 작음으로써 나오는 Text 잘림 현상

#### ❓문제점
![](https://i.imgur.com/LC47vBk.png)
- 크기가 작을 때는 모든 Text가 표시가 되었습니다.
- 하지만 일정 이상 Text 크기가 커지면 Text 잘림현상이 발생했습니다

#### 📖해결법
![](https://i.imgur.com/TKbAFUB.png)
- label의 `adjustsFontSizeToFitWidth = true` 옵션을 사용하여 width 값에 맞게 텍스트 크기가 변경되도록 하였습니다

# 조언을 얻고싶은 부분
### 1️⃣ 오토레이아웃 오류
![](https://i.imgur.com/Z6nOqls.png)

* 다이나믹타입을 최대치로 준 상태에서 영화 상세정보 뷰 컨트롤러로 이동할 시 아래와 같은 오토레이아웃 오류가 발생합니다

```
Will attempt to recover by breaking constraint 
<NSLayoutConstraint:0x6000027fef80 UIImageView:0x13d936780.centerY == _UIModernBarButton:0x15c01f110.centerY   (active)>
```

* 저희가 디버깅 해본 결과 `UIImageView`와 `UIModerBarButton`은 `NavigationBar`의 뒤로가기 버튼 쪽인것을 확인했습니다.

|UIImageView View|UIImageView Object|ModerBarButton View|ModerBarButton Object|
|:--:|:--:|:--:|:--:|
|![](https://i.imgur.com/RdilIpy.png)|![](https://i.imgur.com/zdG501n.png)|![](https://i.imgur.com/g3gGj2V.png)|![](https://i.imgur.com/erwzoYu.png)|

* 위와 관련하여 나름대로 여러부분을 찾아봤는데 마땅한 정보가 나오지않아 혹시 알고계신 키워드 혹은 방법이 있으시다면 알려주시면 감사하겠습니다😭