### PR TITLE
박스오피스 II [STEP 3] vetto, brody

### DIFF
--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		984BFCD129CA940300CA8495 /* BoxOfficeProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 984BFCD029CA940300CA8495 /* BoxOfficeProviderTests.swift */; };
 		984BFCD829CA943400CA8495 /* MockURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 984BFCD729CA943400CA8495 /* MockURLSession.swift */; };
 		984BFCDA29CA965100CA8495 /* JsonLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 984BFCD929CA965100CA8495 /* JsonLoader.swift */; };
+		987C5D0A29E5452B00403E8E /* URLCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 987C5D0929E5452B00403E8E /* URLCacheManager.swift */; };
 		98B4905229DA964A004CD40C /* MovieInformationStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B4905129DA964A004CD40C /* MovieInformationStackView.swift */; };
 		98B4905D29DD1825004CD40C /* BoxOfficeGridCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B4905C29DD1825004CD40C /* BoxOfficeGridCell.swift */; };
 		98C948F529D55BBF00D3B282 /* DaumAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C948F429D55BBF00D3B282 /* DaumAPI.swift */; };
@@ -112,6 +113,7 @@
 		984BFCD029CA940300CA8495 /* BoxOfficeProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxOfficeProviderTests.swift; sourceTree = "<group>"; };
 		984BFCD729CA943400CA8495 /* MockURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLSession.swift; sourceTree = "<group>"; };
 		984BFCD929CA965100CA8495 /* JsonLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JsonLoader.swift; sourceTree = "<group>"; };
+		987C5D0929E5452B00403E8E /* URLCacheManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLCacheManager.swift; sourceTree = "<group>"; };
 		98B4905129DA964A004CD40C /* MovieInformationStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieInformationStackView.swift; sourceTree = "<group>"; };
 		98B4905C29DD1825004CD40C /* BoxOfficeGridCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxOfficeGridCell.swift; sourceTree = "<group>"; };
 		98C948F429D55BBF00D3B282 /* DaumAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaumAPI.swift; sourceTree = "<group>"; };
@@ -293,6 +295,7 @@
 				625164BC29CA93300094711C /* URLSessionDataTaskProtocol.swift */,
 				98C948F429D55BBF00D3B282 /* DaumAPI.swift */,
 				98C948F629D55C4600D3B282 /* HttpMethod.swift */,
+				987C5D0929E5452B00403E8E /* URLCacheManager.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -484,6 +487,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				987C5D0A29E5452B00403E8E /* URLCacheManager.swift in Sources */,
 				98C948F529D55BBF00D3B282 /* DaumAPI.swift in Sources */,
 				6252F8C029CDD8E10067DF7B /* Requestable.swift in Sources */,
 				6240795929DAB93D006C462F /* AlertManager.swift in Sources */,

--- a/BoxOffice/Network/BoxOfficeAPI.swift
+++ b/BoxOffice/Network/BoxOfficeAPI.swift
@@ -18,7 +18,7 @@ extension BoxOfficeAPI: Requestable {
         components?.path = self.path
         
         var queriesItem: [URLQueryItem] = []
-        self.queries.forEach { queryItem in
+        self.queries.sorted(by: <).forEach { queryItem in
             let queryItem = URLQueryItem(name: queryItem.key, value: queryItem.value)
             queriesItem.append(queryItem)
         }

--- a/BoxOffice/Network/BoxOfficeProvider.swift
+++ b/BoxOffice/Network/BoxOfficeProvider.swift
@@ -31,35 +31,38 @@ final class BoxOfficeProvider<Target: Requestable>: Provider {
         }
         
         if let cachedData = URLCache.shared.cachedResponse(for: request) {
-            print("저장된 데이터가 있음")
             do {
                 let decodeData = try JSONDecoder().decode(type, from: cachedData.data)
                 completion(.success(decodeData))
             } catch {
                 completion(.failure(NetworkError.failToParse))
             }
-        }
-        
-        let task = session.dataTask(with: request) { data, response, error in
-            let result = self.checkError(with: data, response, error)
-            switch result {
-            case .success(let data):
-                do {
-                    let cachedResponse = try URLCacheManager.shared.createCachedResponse(response: response, data: data)
-                    URLCacheManager.shared.storeCachedResponse(for: cachedResponse, request: request)
-                    let decodedData = try JSONDecoder().decode(type, from: data)
-                    completion(.success(decodedData))
-                } catch NetworkError.invalidResponseError {
-                    completion(.failure(NetworkError.invalidResponseError))
-                } catch {
-                    completion(.failure(NetworkError.failToParse))
+            return
+        } else {
+            let task = session.dataTask(with: request) { data, response, error in
+                let result = self.checkError(with: data, response, error)
+                switch result {
+                case .success(let data):
+                    do {
+                        let cachedResponse = try URLCacheManager.shared.createCachedResponse(
+                            response: response,
+                            data: data)
+                        URLCacheManager.shared.storeCachedResponse(for: cachedResponse, request: request)
+                        
+                        let decodedData = try JSONDecoder().decode(type, from: data)
+                        completion(.success(decodedData))
+                    } catch NetworkError.invalidResponseError {
+                        completion(.failure(NetworkError.invalidResponseError))
+                    } catch {
+                        completion(.failure(NetworkError.failToParse))
+                    }
+                case .failure(let error):
+                    completion(.failure(error))
                 }
-            case .failure(let error):
-                completion(.failure(error))
             }
+            
+            task.resume()
         }
-        
-        task.resume()
     }
     
     

--- a/BoxOffice/Network/BoxOfficeProvider.swift
+++ b/BoxOffice/Network/BoxOfficeProvider.swift
@@ -30,7 +30,7 @@ final class BoxOfficeProvider<Target: Requestable>: Provider {
             return
         }
         
-        if let cachedData = URLCache.shared.cachedResponse(for: request) {
+        if let cachedData = URLCacheManager.shared.cachedResponse(for: request) {
             do {
                 let decodeData = try JSONDecoder().decode(type, from: cachedData.data)
                 completion(.success(decodeData))

--- a/BoxOffice/Network/DaumAPI.swift
+++ b/BoxOffice/Network/DaumAPI.swift
@@ -17,7 +17,7 @@ extension DaumAPI: Requestable {
         components?.path = self.path
         
         var queriesItem: [URLQueryItem] = []
-        self.queries.forEach { queryItem in
+        self.queries.sorted(by:<).forEach { queryItem in
             let queryItem = URLQueryItem(name: queryItem.key, value: queryItem.value)
             queriesItem.append(queryItem)
         }

--- a/BoxOffice/Network/URLCacheManager.swift
+++ b/BoxOffice/Network/URLCacheManager.swift
@@ -15,6 +15,14 @@ struct URLCacheManager {
         urlCache = URLCache(memoryCapacity: 0, diskCapacity: 100 * 1024 * 1024)
     }
     
+    func cachedResponse(for request: URLRequest) -> CachedURLResponse? {
+        guard let response = urlCache.cachedResponse(for: request) else {
+            return nil
+        }
+        
+        return response
+    }
+    
     func createCachedResponse(response: URLResponse?, data: Data) throws -> CachedURLResponse {
         guard let response else {
             throw NetworkError.invalidResponseError

--- a/BoxOffice/Network/URLCacheManager.swift
+++ b/BoxOffice/Network/URLCacheManager.swift
@@ -1,0 +1,32 @@
+//
+//  URLCacheManager.swift
+//  BoxOffice
+//
+//  Created by vetto, brody on 23/04/11.
+//
+
+import Foundation
+
+struct URLCacheManager {
+    static let shared = URLCacheManager()
+    private let urlCache = URLCache.shared
+    
+    private init() {}
+    
+    func createCachedResponse(response: URLResponse?, data: Data) throws -> CachedURLResponse {
+        guard let response else {
+            throw NetworkError.invalidResponseError
+        }
+        
+        return CachedURLResponse(response: response,
+                                 data: data,
+                                 userInfo: ["expirationDate": Calendar.current.date(byAdding: .day,
+                                                                                    value: 1,
+                                                                                    to: Date()) ?? Date()],
+                                 storagePolicy: .allowed)
+    }
+    
+    func storeCachedResponse(for cachedResponse: CachedURLResponse, request: URLRequest) {
+        urlCache.storeCachedResponse(cachedResponse, for: request)
+    }
+}

--- a/BoxOffice/Network/URLCacheManager.swift
+++ b/BoxOffice/Network/URLCacheManager.swift
@@ -9,9 +9,11 @@ import Foundation
 
 struct URLCacheManager {
     static let shared = URLCacheManager()
-    private let urlCache = URLCache.shared
+    private var urlCache: URLCache
     
-    private init() {}
+    private init() {
+        urlCache = URLCache(memoryCapacity: 0, diskCapacity: 100 * 1024 * 1024)
+    }
     
     func createCachedResponse(response: URLResponse?, data: Data) throws -> CachedURLResponse {
         guard let response else {

--- a/BoxOffice/Network/URLCacheManager.swift
+++ b/BoxOffice/Network/URLCacheManager.swift
@@ -30,9 +30,6 @@ struct URLCacheManager {
         
         return CachedURLResponse(response: response,
                                  data: data,
-                                 userInfo: ["expirationDate": Calendar.current.date(byAdding: .day,
-                                                                                    value: 1,
-                                                                                    to: Date()) ?? Date()],
                                  storagePolicy: .allowed)
     }
     

--- a/BoxOffice/View/BoxOfficeGridCell.swift
+++ b/BoxOffice/View/BoxOfficeGridCell.swift
@@ -71,7 +71,7 @@ final class BoxOfficeGridCell: UICollectionViewCell {
         self.rankIncrementLabel.textColor = .black
     }
     
-    func configure(boxOfficeItem: BoxOfficeItem) {
+    func configureInformation(_ boxOfficeItem: BoxOfficeItem) {
         configureRankInformation(rank: boxOfficeItem.rank,
                                  rankIncrement: boxOfficeItem.rankIncrement,
                                  rankOldAndNew: boxOfficeItem.rankOldAndNew)

--- a/BoxOffice/ViewController/BoxOfficeViewController.swift
+++ b/BoxOffice/ViewController/BoxOfficeViewController.swift
@@ -313,6 +313,7 @@ extension BoxOfficeViewController: UICollectionViewDelegate {
         let movieDetailViewController = MovieDetailViewController(movieName: selectedTitle,
                                                                   movieCode: selectedCode)
         self.navigationController?.pushViewController(movieDetailViewController, animated: true)
+        collectionView.deselectItem(at: indexPath, animated: true)
     }
 }
 

--- a/BoxOffice/ViewController/BoxOfficeViewController.swift
+++ b/BoxOffice/ViewController/BoxOfficeViewController.swift
@@ -201,7 +201,7 @@ extension BoxOfficeViewController {
         
         let gridRegistration = UICollectionView.CellRegistration<BoxOfficeGridCell, BoxOfficeItem> {
             (cell, indexPath, item) in
-            cell.configure(boxOfficeItem: item)
+            cell.configureInformation(item)
         }
         
         dataSource = UICollectionViewDiffableDataSource<Section, BoxOfficeItem.ID>(collectionView: collectionView) {

--- a/BoxOffice/ViewController/MovieDetailViewController.swift
+++ b/BoxOffice/ViewController/MovieDetailViewController.swift
@@ -44,6 +44,7 @@ final class MovieDetailViewController: UIViewController {
     
     private let posterImageView: UIImageView = {
         let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFit
         imageView.translatesAutoresizingMaskIntoConstraints = false
         
         return imageView
@@ -90,9 +91,9 @@ final class MovieDetailViewController: UIViewController {
             contentView.bottomAnchor.constraint(equalTo: self.scrollView.contentLayoutGuide.bottomAnchor),
             contentView.widthAnchor.constraint(equalTo: self.scrollView.frameLayoutGuide.widthAnchor),
             
-            posterImageView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
-            posterImageView.widthAnchor.constraint(equalTo: self.view.widthAnchor, multiplier: 0.9),
-            posterImageView.heightAnchor.constraint(equalTo: self.view.widthAnchor, multiplier: 1),
+            posterImageView.centerXAnchor.constraint(equalTo: self.scrollView.frameLayoutGuide.centerXAnchor),
+            posterImageView.widthAnchor.constraint(equalTo: self.scrollView.frameLayoutGuide.widthAnchor, multiplier: 0.9),
+            posterImageView.heightAnchor.constraint(equalTo: self.scrollView.frameLayoutGuide.heightAnchor, multiplier: 0.6),
             posterImageView.topAnchor.constraint(equalTo: self.contentView.topAnchor),
             
             activityIndicator.centerXAnchor.constraint(equalTo: self.posterImageView.centerXAnchor),

--- a/BoxOffice/ViewController/MovieDetailViewController.swift
+++ b/BoxOffice/ViewController/MovieDetailViewController.swift
@@ -132,11 +132,18 @@ final class MovieDetailViewController: UIViewController {
                     return
                 }
                 
-                DispatchQueue.global().async {
-                    guard let image = try? Data(contentsOf: imageUrl) else { return }
-                    DispatchQueue.main.async {
-                        self?.posterImageView.image = UIImage(data: image)
-                        self?.activityIndicator.stopAnimating()
+                boxOfficeProvider.fetchImage(url: imageUrl) { result in
+                    switch result {
+                    case .success(let imageData):
+                        DispatchQueue.main.async {
+                            self?.posterImageView.image = UIImage(data: imageData)
+                            self?.activityIndicator.stopAnimating()
+                        }
+                    case .failure:
+                        DispatchQueue.main.async {
+                            let alertController = AlertManager.shared.showFailureAlert()
+                            self?.present(alertController, animated: true)
+                        }
                     }
                 }
             case .failure:

--- a/BoxOffice/ViewController/MovieDetailViewController.swift
+++ b/BoxOffice/ViewController/MovieDetailViewController.swift
@@ -81,9 +81,9 @@ final class MovieDetailViewController: UIViewController {
         
         NSLayoutConstraint.activate([
             scrollView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
-            scrollView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
-            scrollView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
-            scrollView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor),
             
             contentView.leadingAnchor.constraint(equalTo: self.scrollView.contentLayoutGuide.leadingAnchor),
             contentView.trailingAnchor.constraint(equalTo: self.scrollView.contentLayoutGuide.trailingAnchor),

--- a/BoxOffice/ViewController/MovieDetailViewController.swift
+++ b/BoxOffice/ViewController/MovieDetailViewController.swift
@@ -131,10 +131,13 @@ final class MovieDetailViewController: UIViewController {
                       let imageUrl = URL(string: url) else {
                     return
                 }
-                guard let image = try? Data(contentsOf: imageUrl) else { return }
-                DispatchQueue.main.async {
-                    self?.posterImageView.image = UIImage(data: image)
-                    self?.activityIndicator.stopAnimating()
+                
+                DispatchQueue.global().async {
+                    guard let image = try? Data(contentsOf: imageUrl) else { return }
+                    DispatchQueue.main.async {
+                        self?.posterImageView.image = UIImage(data: image)
+                        self?.activityIndicator.stopAnimating()
+                    }
                 }
             case .failure:
                 let alertViewController = AlertManager.shared.showFailureAlert()

--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ json의 담긴 데이터를 가져오기 위해 jsonDecoder를 사용하여 데�
             XCTFail("The loadJsonData was not supposed to throw an Error")
         }
 ```
+<br/>
+<br/>
 
 ### 2️⃣ URL Endpoint관리
 > URL을 생성해주는 객체뿐만 아니라 URLRequest를 만들어내는 객체를 정의했습니다.
@@ -358,6 +360,9 @@ boxOfficeProvider.fetchData(.searchImage(movieName: "메이플스토리"), type:
 }
 ```
 
+<br/>
+<br/>
+
 ### 3️⃣ Cell 재사용 문제
 tableView와 마찬가지로 collectionView에서도 cell을 재사용하여 UI를 그려주게 됩니다. 따라서 스크롤을 움직여서 몇몇의 cell이 안보이게 한 후 다시 그려주는 작업을 수행하게 하면 cell의 속성 값이 그대로 남아 적용되는 것을 확인하였습니다.
 
@@ -377,6 +382,9 @@ rankIncrementLabel.text = nil
 rankIncrementLabel.textColor = .black
 ```
 
+
+<br/>
+<br/>
 
 ### 4️⃣ UICollectionViewListCell, ContentConfiguration의 사용
 요구사항의 뷰를 보고 테이블 뷰로 구현할 지, 컬렉션 뷰로 구현할 지, CollectionListCell을 이용해서 구현할 지 고민했습니다.
@@ -477,7 +485,8 @@ BoxOfficeListCell에서는 데이터를 주입하고, BoxOfficeContentConfigurat
 
 이와 같이 역할을 분리함으로써 상태에 따른 모든 코드를 같은 객체에 정의하는 것을 피했습니다.
 
-<br>
+<br/>
+<br/>
 
 ### 5️⃣ ClipsToBound사용을 통한 이미지 뷰 짤리는 현상 해결
 이미지 뷰를 오토레이아웃해서 `width`의 값을 루트 view의 0.9배율로 설정해주었는데 정해준 width를 넘어가는 일이 발생했었습니다.

--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@
 2. [타임라인](#2-타임라인)
 3. [프로젝트 구조](#3-프로젝트-구조)
 4. [실행화면](#4-실행-화면)
-5. [트러블슈팅](#5-트러블-슈팅)
-6. [참고링크](#6-참고-링크)
+5. [핵심경험](#5-핵심-경험)
+6. [트러블슈팅](#6-트러블-슈팅)
+7. [팀회고](#7-팀-회고)
+8. [참고링크](#8-참고-링크)
 
 <br>
 
@@ -168,13 +170,19 @@ BoxOffic
 | :---: |
 | <img src="https://i.imgur.com/VtOFUY9.gif" width="500" height="250"> |
 
+<br/>
 
 
+## 5. 핵심 경험
+- ✅ Modern CollectionView, Cell 활용
+- ✅ URLCache 활용
+- ✅ 비동기 통신 TestDouble 활용
+- ✅ API, Endpoint 관리
 
 </br>
 
 
-## 5. 트러블 슈팅
+## 6. 트러블 슈팅
 
 ### 1️⃣ parsing한 데이터 유닛테스트
 json의 담긴 데이터를 가져오기 위해 jsonDecoder를 사용하여 데이터를 파싱하였습니다. 정확한 비교를 하기 위해서는 예상한 데이터들과 파싱한 데이터들을 하나하나 비교해야하는데 그렇게 하는 것은 데이터의 양이 너무 많아 테스트 하는 코드가 기존의 코드보다 길어진다는 것과 코드가 길어지면서 휴먼에러가 발생한다는 문제가 발생하였습니다.
@@ -641,6 +649,7 @@ self.queries.sorted(by:<).forEach { queryItem in
 
 <br/>
 
+## 7. 팀 회고
 <details>
     <summary><big>팀 회고</big></big></summary>
 
@@ -658,7 +667,7 @@ self.queries.sorted(by:<).forEach { queryItem in
 
 <br/>
 
-## 6. 참고 링크
+## 8. 참고 링크
 - [Apple Docs - URLSession](https://developer.apple.com/documentation/foundation/urlsession)
 - [Apple Article - Fetching Website Data into Memory](https://developer.apple.com/documentation/foundation/url_loading_system/fetching_website_data_into_memory)
 - [Apple Docs - UICollectionViewListCell](https://developer.apple.com/documentation/uikit/uicollectionviewlistcell)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 박스 오피스 🎥
 
-> 소개: API를 사용하여 데이터들을 표시하는 어플
+> 소개: 영화진흥위원회 API를 사용하여 영화정보들을 알려주는 어플
 
 </br>
 
@@ -48,7 +48,11 @@
 |23.04.04 (화)| CalendarViewController 구현<br>날짜 선택 navigation item button 구현<br> DataChangeable delegate 구현 |
 |23.04.05 (수)| ToolBar 버튼 구현<br>화면 모드변경 클릭 시 actionsheet생성<br>BoxOfficeGridCell 구현<br>|
 |23.04.06 (목)| 화면 모드 변경 기능 구현<br> 메인화면 DynamicType 적용 |
-|23.04.07 (금)| 영화 상세정보 화면 DynamicType 적용|
+|23.04.07 (금)| 영화 상세정보 화면 DynamicType 적용 |
+|23.04.10 (월)| colletionView 안 보이던 오류 수정 |
+|23.04.11 (화)| URLCacheManger 구현 |
+|23.04.13 (목)| URLCache 정책 설정 및 구현 |
+|23.04.14 (금)| 영화 상세정보 화면 오토레이아웃 수정 |
 
 </details>
 <br>
@@ -82,8 +86,9 @@ BoxOffic
 │   │   │   └── SearchedMovieImageDTO.swift
 │   │   ├── DailyBoxOffice.swift
 │   │   ├── MovieDetailInformation.swift
-│   │   └── MovieDetailInformationItem.swift
-│   │   └── Alertmangaer.swift
+│   │   ├── MovieDetailInformationItem.swift
+│   │   ├── Alertmangaer.swift
+│   │   └── LayoutType.swift
 │   ├── Network
 │   │   ├── BoxOfficeAPI.swift
 │   │   ├── BoxOfficeProvider.swift
@@ -92,7 +97,8 @@ BoxOffic
 │   │   ├── HttpMethod.swift
 │   │   ├── Requestable.swift
 │   │   ├── URLSessionDataTaskProtocol.swift
-│   │   └── URLSessionProtocol.swift
+│   │   ├── URLSessionProtocol.swift
+│   │   └── URLCacheManager.swift
 │   ├── Resources
 │   │   ├── Assets.xcassets
 │   │   │   └── box_office_sample.dataset
@@ -148,7 +154,25 @@ BoxOffic
 | :--------: |:---:| :---: |
 | ![](https://i.imgur.com/1wQ5Z8R.gif) | ![](https://i.imgur.com/OiNHjKa.gif) | ![](https://i.imgur.com/bF8khC8.gif) |
 
+
+| 화면 모드 전환 | 아이콘 클릭 | 캐시 후 속도 향상 |
+| :--------: | :--------: | :--------: |
+| ![](https://i.imgur.com/QRCoB3R.gif) | ![](https://i.imgur.com/APhSgfo.gif) | ![](https://i.imgur.com/HHRl8cA.gif) |
+
+
+| 가로화면 1 <br/> 일일 박스 오피스 |
+| :--------: |
+| <img src="https://i.imgur.com/1cC6Jzv.gif" width="500" height="250"> |
+
+| 가로화면 2 <br/> 영화 상세 정보 |
+| :---: |
+| <img src="https://i.imgur.com/VtOFUY9.gif" width="500" height="250"> |
+
+
+
+
 </br>
+
 
 ## 5. 트러블 슈팅
 
@@ -474,19 +498,170 @@ BoxOfficeListCell에서는 데이터를 주입하고, BoxOfficeContentConfigurat
 
 <br>
 
+### 6️⃣ 하나의 DataSource 내에 두 개의 셀을 등록함으로써 두 개의 레이아웃 구성
+토글 버튼을 통해 리스트 형식의 레이아웃을 그리드 형식으로 변환해야 했습니다.
+
+처음에는 리스트 형식의 셀과 그리드 형식의 셀이 다르기 때문에 토글버튼을 통해 레이아웃이 변경될 때 데이터소스에 새로운 셀을 등록시켜야 한다고 생각했습니다.
+```swift
+private func updateLayout() {
+    self.layoutType = self.layoutType == .list ? .grid : .list
+    self.configureDataSource(for: self.layoutType)
+    self.collectionView.setCollectionViewLayout(self.createLayout(for: self.layoutType),
+                                                animated: false)
+    self.dataSource.apply(self.snapshot, animatingDifferences: true)
+}
+
+private func configureDataSource(for layout: LayoutType = .list) {
+    let listCellRegistration = UICollectionView.CellRegistration<BoxOfficeListCell, BoxOfficeItem> {
+        (cell, indexPath, item) in
+        cell.item = item
+    }
+
+    let gridRegistration = UICollectionView.CellRegistration<BoxOfficeGridCell, BoxOfficeItem> {
+        (cell, indexPath, item) in
+        cell.configure(boxOfficeItem: item)
+    }
+
+    dataSource = UICollectionViewDiffableDataSource<Section, BoxOfficeItem.ID>(collectionView: collectionView) {
+        (collectionView: UICollectionView, indexPath: IndexPath, identifier: BoxOfficeItem.ID) -> UICollectionViewCell? in
+
+        let boxOfficeItem = self.boxOfficeItems.filter { $0.id == identifier }.first
+        switch layout {
+        case .list:
+            let cell = collectionView.dequeueConfiguredReusableCell(using: listCellRegistration,
+                                                                    for: indexPath,
+                                                                    item: boxOfficeItem)
+            return cell
+        case .grid:
+            let cell = collectionView.dequeueConfiguredReusableCell(using: gridRegistration,
+                                                                    for: indexPath,
+                                                                    item: boxOfficeItem)
+            return cell
+        }
+    }
+}
+```
+이를 구현하기 위해 레이아웃 타입을 변경한 후에 변경된 레이아웃 타입을 기반으로 셀이 구성되고 이를 데이터소스에서 등록하는 함수를 호출했습니다.
+
+하지만 토글이 되더라도 셀에 사용되는 데이터는 같은데 데이터소스 인스턴스가 새롭게 생성되고 할당되는 것이 비효율적인 비용이라고 생각했습니다. 
+
+이 고민을 하면서 컬렉션 뷰에는 cell을 새롭게 구성할 수 있는 `reloadData`가 있는 것을 알게되었습니다.
+
+이 메서드는 현재 컬렉션 뷰의 보여지는 셀을 제거한 후에 dataSource 객체의 현재 상태에 따라 재생성하는 메서드입니다.
+
+레이아웃타입을 변경한 후 이 메서드를 직접 호출함으로써 현재 데이터소스의 레이아웃 타입 상태변경으로 인해 셀을 새롭게 등록해서 변경해주었습니다. 
+
+이후 컬렉션뷰의 `setCollectionViewLayout`을 사용함으로써 토글버튼에 따라 레이아웃이 변경되도록 만들었습니다.
+```swift
+private func updateLayout() {
+    self.layoutType = self.layoutType == .list ? .grid : .list
+    self.collectionView.reloadData()
+    self.collectionView.setCollectionViewLayout(self.createLayout(for: self.layoutType),
+                                                animated: true)
+}
+```
+
+### 7️⃣ URLCache를 통한 네트워크 데이터 응답 캐시
+네트워크에 여러번 접근하는 비용을 줄이기 위해 어떤 종류의 캐시를 이용해야 현재 상황에 알맞은 지에 대한 고민이 있었습니다.
+
+관련된 캐시방법으로는 `NSCache`와 `URLCache`가 존재했는데요 `NSCache`대신 `URLCache`를 사용한 이유는 다음과 같았습니다.
+
+NSCache는 in-memory에서 데이터를 가져오기 때문에 on-disk를 사용하는 URLCache보다 빠르다는 장점이 있습니다.
+하지만 NSCache는 비휘발성이기에 앱을 종료하고 다시 들어온다면 네트워크와의 연결을 재시도해야합니다. 또한 in-memory는 메모리 청크에 할당하기 때문에 메모리에 많은 데이터들이 올라와있는 상황이라면 성능이 저하될 수 있습니다.
+
+반면에 URLCache는 in-memory와 on-disk방식 둘 다 사용할 수 있고 on-disk의 경우 디스크를 사용하기 때문에 메모리 청크를 할당하지않습니다. 또한 디스크의 크기를 정할 수 있다는 점에서 유연합니다.
+
+그리고 네트워크를 통해 받아온 데이터의 크기는 약 6000바이트로 상당히 크기에 NSCache로 구현한 경우 메모리가 금방 초과되어 제거될 가능성이 높다고 생각했습니다. 따라서 on-disk방식의 URLCache를 사용하는 것으로 결정했습니다.
+
+`URLCache.shared`에 중복해서 접근하기 보다는 `URLCacheManager`라는 싱글톤 객체를 만들어 디스크 용량부터 정책까지 커스텀 된 타입을 정의해서 관리했습니다. 
+이를 통해 가독성과 활용성을 향상시켰습니다.
+
+#### 
+```swift
+struct URLCacheManager {
+    static let shared = URLCacheManager()
+    private var urlCache: URLCache
+    
+    private init() {
+        urlCache = URLCache(memoryCapacity: 0, diskCapacity: 100 * 1024 * 1024)
+    }
+    
+    func cachedResponse(for request: URLRequest) -> CachedURLResponse? {
+        guard let response = urlCache.cachedResponse(for: request) else {
+            return nil
+        }
+        
+        return response
+    }
+    
+    func createCachedResponse(response: URLResponse?, data: Data) throws -> CachedURLResponse {
+        guard let response else {
+            throw NetworkError.invalidResponseError
+        }
+        
+        return CachedURLResponse(response: response,
+                                 data: data,
+                                 storagePolicy: .allowed)
+    }
+    
+    func storeCachedResponse(for cachedResponse: CachedURLResponse, request: URLRequest) {
+        urlCache.storeCachedResponse(cachedResponse, for: request)
+    }
+}
+```
+
+### 8️⃣ Query 순서 보장
+처음 구현할 때 저희는 query의 순서를 고려하지 않고 forEach문을 사용하여 query를 추가하였습니다.
+```swift
+self.queries.forEach { queryItem in
+    let queryItem = URLQueryItem(name: queryItem.key, value: queryItem.value)
+    queriesItem.append(queryItem)
+}
+```
+위에 코드로 인해 쿼리의 순서가 무작위로 더해져 cache를 할때 cache를 저장하는 값이 달라져 같은 데이터임에도 다른 캐시를 저장할때가 있었습니다. 이러한 문제점을 해결하고자 저희는 sorted메서드를 사용하여 순서를 보장하도록 만들어 동일한 캐시를 저장할 수 있게 하였습니다.
+```swift
+self.queries.sorted(by:<).forEach { queryItem in
+    let queryItem = URLQueryItem(name: queryItem.key, value: queryItem.value)
+    queriesItem.append(queryItem)
+}
+```
+
+<br/>
+
+<details>
+    <summary><big>팀 회고</big></big></summary>
+
+### 잘한 점
+- 특정 주제에 대해 계속 파고들면서 얘기를 나눠, 더 깊은 이해를 가졌다.(ex. 캐시정책은 무엇이고 iOS에서는 어떻게 사용되면서 만료된 데이터들은 어떤 시점에 제거해주는 게 효율적일까)
+- 서로의 의견을 존중해주고 적극적으로 코드에 녹여냈다.
+- 서로의 개인적인 시간을 잘 이해해줬다.
+
+
+### 아쉬운 점
+- rebase를 진행하면서 commit이 한 사람에게 몰린 branch가 존재한다.
+- 다이나믹 타입을 적용하면서 해결하지 못한 부분이 존재하고 이 부분에 대해 원인을 정확하게 파악하지 못했다.
+
+</details>
+
+<br/>
+
 ## 6. 참고 링크
 - [Apple Docs - URLSession](https://developer.apple.com/documentation/foundation/urlsession)
 - [Apple Article - Fetching Website Data into Memory](https://developer.apple.com/documentation/foundation/url_loading_system/fetching_website_data_into_memory)
+- [Apple Docs - UICollectionViewListCell](https://developer.apple.com/documentation/uikit/uicollectionviewlistcell)
+- [Apple Docs - contentConfiguration](https://developer.apple.com/documentation/uikit/uitableviewcell/3601057-contentconfiguration)
+- [Apple Docs - reloadData](https://developer.apple.com/documentation/uikit/uicollectionview/1618078-reloaddata)
+- [Apple Docs - ClipsToBound](https://developer.apple.com/documentation/uikit/uiview/1622415-clipstobounds)
+- [Apple Docs - ImageView ContentMode](https://developer.apple.com/documentation/uikit/uiview/contentmode)
+- [Apple Docs - URLCache](https://developer.apple.com/documentation/foundation/urlcache)
+- [Apple Docs - NSCache](https://developer.apple.com/documentation/foundation/nscache)
+- [WWDC - Modern cell configuration](https://developer.apple.com/videos/play/wwdc2020/10027/)
+- [To NSCache or not to NSCache, what is the URLCache](https://medium.com/@master13sust/to-nscache-or-not-to-nscache-what-is-the-urlcache-35a0c3b02598)
 - [Closure](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/closures/)
 - [우아한 형제들 - iOS Networking and Testing](https://techblog.woowahan.com/2704/)
 - [네트워크와 무관한 URLSession Unit Test](https://wody.tistory.com/10)
 - [mock 이용한 URLSession Unit Test](https://sujinnaljin.medium.com/swift-mock-%EC%9D%84-%EC%9D%B4%EC%9A%A9%ED%95%9C-network-unit-test-%ED%95%98%EA%B8%B0-a69570defb41)
 - [info.plist api키 가리기](https://velog.io/@loopbackseal/Swift-Plist%EB%A5%BC-%ED%99%9C%EC%9A%A9%ED%95%B4%EC%84%9C-API-key%EB%AF%BC%EA%B0%90%EC%A0%95%EB%B3%B4-%EA%B0%80%EB%A6%AC%EA%B8%B0)
-- [Apple Docs - UICollectionViewListCell](https://developer.apple.com/documentation/uikit/uicollectionviewlistcell)
-- [Apple Docs - contentConfiguration](https://developer.apple.com/documentation/uikit/uitableviewcell/3601057-contentconfiguration)
-- [WWDC - Modern cell configuration](https://developer.apple.com/videos/play/wwdc2020/10027/)
 - [UICollectionView List with Custom Cell and Custom Configuration](https://swiftsenpai.com/development/uicollectionview-list-custom-cell/)
 - [Moya github](https://github.com/Moya/Moya)
-- [Apple Docs - ClipsToBound](https://developer.apple.com/documentation/uikit/uiview/1622415-clipstobounds)
-- [Apple Docs - ImageView ContentMode](https://developer.apple.com/documentation/uikit/uiview/contentmode)
 ---

--- a/README.md
+++ b/README.md
@@ -560,6 +560,8 @@ private func updateLayout() {
                                                 animated: true)
 }
 ```
+<br/>
+<br/>
 
 ### 7️⃣ URLCache를 통한 네트워크 데이터 응답 캐시
 네트워크에 여러번 접근하는 비용을 줄이기 위해 어떤 종류의 캐시를 이용해야 현재 상황에 알맞은 지에 대한 고민이 있었습니다.
@@ -609,6 +611,8 @@ struct URLCacheManager {
     }
 }
 ```
+<br/>
+<br/>
 
 ### 8️⃣ Query 순서 보장
 처음 구현할 때 저희는 query의 순서를 고려하지 않고 forEach문을 사용하여 query를 추가하였습니다.

--- a/SearchedMovieImageDTOTests/SearchedMovieImageDTOTests.swift
+++ b/SearchedMovieImageDTOTests/SearchedMovieImageDTOTests.swift
@@ -29,7 +29,6 @@ final class SearchedMovieImageDTOTests: XCTestCase {
                                     type: SearchedMovieImageDTO.self) { result in
             switch result {
             case .success(let data):
-                print(data.documents[0])
                 resultImageURL = data.documents[0].imageURL
                 expectation.fulfill()
             case .failure:


### PR DESCRIPTION
@uuu1101
안녕하세요 태태!
박스오피스 II step3 PR입니다.

step3 구현을 완료하여 PR보냅니다.

리뷰 잘 부탁드리겠습니다!

## 고민한 점

### NSCache대신 URLCache를 사용한 이유
NSCache는 in-memory에서 데이터를 가져오기 때문에 on-disk를 사용하는 URLCache보다 빠르다는 장점이 있습니다. 
하지만 NSCache는 비휘발성이기에 앱을 종료하고 다시 들어온다면 네트워크와의 연결을 재시도해야합니다. 또한 in-memory는 메모리 청크에 할당하기 때문에 메모리에 많은 데이터들이 올라와있는 상황이라면 성능이 저하될 수 있습니다. 

반면에 URLCache는 in-memory와 on-disk방식 둘 다 사용할 수 있고 on-disk의 경우 디스크를 사용하기 때문에 메모리 청크를 할당하지않습니다. 또한 디스크의 크기를 정할 수 있다는 점에서 유연합니다. [NSCache, URLCache](https://medium.com/@master13sust/to-nscache-or-not-to-nscache-what-is-the-urlcache-35a0c3b02598)

그리고 네트워크를 통해 받아온 데이터의 크기는 약 6000바이트로 상당히 크기에 NSCache로 구현한 경우 메모리가 금방 초과되어 제거될 가능성이 높다고 생각했습니다. 따라서 on-disk방식의 URLCache를 사용하는 것으로 결정했습니다.


### Query parameter에 따른 캐시
처음 구현할 때 저희는 query의 순서를 고려하지 않고 forEach문을 사용하여 query를 추가하였습니다.

```swift
self.queries.forEach { queryItem in
    let queryItem = URLQueryItem(name: queryItem.key, value: queryItem.value)
    queriesItem.append(queryItem)
}
```
그 결과 쿼리의 순서가 무작위로 더해져 cache를 할때 cache를 저장하는 값이 달라져 같은 데이터임에도 다른 캐시를 저장할때가 있었습니다. 이러한 문제점을 해결하고자 저희는 sorted메서드를 사용하여 순서를 보장하여 query를 추가하여 같은 캐시를 저장할 수 있게 하였습니다.

```swift
self.queries.sorted(by:<).forEach { queryItem in
    let queryItem = URLQueryItem(name: queryItem.key, value: queryItem.value)
    queriesItem.append(queryItem)
}
```

## 조언 받고 싶은 점
저희가 지금은 잔존기한을 설정해주지 않아서 잔존기한에 따른 자동삭제 부분을 구현하지 못했습니다. 만약 잔존기한을 설정한다고 하면 아래의 코드와 같이 1일정도로 잔존기한을 설정할 거 같습니다.
```swift
userInfo: ["expirationDate": Calendar.current.date(byAdding: .day,
                                                   value: 1,
                                                   to: Date()) ?? Date()]
```
userInfo에는 Any타입을 받기 때문에 이를 사용하여 잔존기한을 설정하는 것이 좋다고 생각했습니다. 여기서 궁금한 점은 이 잔존기한을 이용하여 캐시를 삭제해야하는데 어디서 검사하고 어떤 방식으로 삭제해야하는지 모르겠습니다.

1. 캐시된 데이터가 있는지 확인 후 삭제
캐시된 데이터가 있는지 확인 후에 추가적으로 그 함수 안에서 데이터가 만료가 되었다면 그 캐시를 삭제하면 되기 때문에 on-disk메모리 안에서 지워져서 문제가 되지 않지만,
캐시된 데이터가 있는지 확인을 안한다면(사용자가 한 번 클릭했던 날짜를 오랜기간 누르지 않았다면) 만료된 캐시가 삭제되지 않고 오랜기간 남아있을 것 같습니다. 이 경우에는 만료되었지만 on-disk에 오랜기간 남아있는 것이 일반적일까요?

2. 모든 캐시 잔존기한 확인 후 삭제
1번의 문제로 인해서 2번의 방안을 생각해봤습니다. 앱 실행 시 앱에 존재하는 모든 캐시된 데이터들의 잔존기한을 확인한 후 지난 것 데이터들은 지워주는 방법을 생각했습니다. 하지만 이 방법은 앱 실행 시 모든 캐시들의 만료기한을 확인하기 때문에 비용이 클 수도 있겠다고 생각했습니다. 

캐시정책으로 `useProtocolCachePolicy`을 사용하는 경우에는 서버의 정책을 따르게 되는데 현재는 API응답헤더에는 정책을 정의해주지 않고 있어서 클라이언트에서 정책을 설정해줘야했습니다. 따라서 1번방법과 2번방법에 대해서 고민을 했는데요!
현재 상황에서 URLCache를 사용하면서 어떤 방법으로 만료된 캐시를 삭제하는 것이 좋을까요?(아니면 만료된 캐시를 굳이 삭제해줄 필요가 없는걸까요?) 
