### PR TITLE
박스오피스 II 🎥 [STEP 3] Rhode, 릴라

### DIFF
--- a/BoxOffice/Network/NetworkManager.swift
+++ b/BoxOffice/Network/NetworkManager.swift
@@ -9,7 +9,6 @@ import Foundation
 
 final class NetworkManager {
     static let shared = NetworkManager()
-    
     private let session: URLSession
 
     init(session: URLSession = URLSession.customCacheShared) {


### PR DESCRIPTION

@yim2627
안녕하세요 지성!! `로릴라` 인사 드립니다. 🙇🏻‍♀️🙇🏻‍♂️ 
드디어 STEP3까지 왔습니다!!!!


## 고민했던 부분 🧐


### 1️⃣ Cache vs Core Data

`Cache` 와 `CoreData` 모두 데이터를 저장하고 관리하는데 사용되는 방법 중 하나입니다.

현재 저희 프로젝트에서 관리하고 있는 데이터는 네트워크 요청을 통해 받아오고 있습니다. 이 데이터를 영구적으로 보관할지 임시로 보관할지에 대해 고민을 해봤는데, 

영구적으로 보관할 시 해당 데이터를 언제까지 보관해야한다는 기준도 명확하지 않고, 데이터가 계속해서 누적되는 경우 차지하는 용량또한 한없이 커질것이라 생각을 합니다.

그렇기 때문에 빠른 접근이 가능하지만 일정시간이 지나면 데이터가 휘발되는 Cache를 사용하기로 했습니다.



### 2️⃣ NSCache vs URLCache

캐시란 데이터나 값을 미리 복사해놓는 임시 장소를 말합니다. 캐시의 접근시간에 비해 원래 데이터에 접근하는 시간이 오래걸리는 경우 혹은 이 시간을 세이브하기 위해서 사용합니다. 캐시에 데이터를 미리 복사해놓으면 접근시간 없이 더 빠른 속도로 데이터에 접근할 수 있기 때문입니다.

캐시 방법에는 두 가지 방법이 있습니다. Memory Caching 과 Disk Caching이 그것입니다:

| Memory Caching | Disk Caching | 
| -------- | -------- | 
| ▪️ 어플리케이션의 메모리 영역 일부분을 Caching에 사용하는 것 <br/> ▪️ 단점: 어플리케이션이 종료되어 메모리에서 해제되면 이 영역에 있던 리소스들은 OS에 반환되면서 Memory Caching되어있던 리소스들이 사라짐 | ▪️ 데이터를 파일 형태로 디스크에 저장하는 것 <br/> ▪️ 단점: Disk Caching이 반복적으로 발생하면 어플리케이션이 차지하는 용량이 커짐 <br/> ▪️ 장점: 어플리케이션을 껐다 켜도 데이터가 사라지지 않음 | 

⬜️ NSCache
▪️ in-Memory Caching 방식
▪️ 응용프로그램에 중요치 않고 메모리가 부족하다고 판단되면 자동으로 삭제 됨
▪️ 앱을 끄면 자동으로 삭제 됨

⬜️ URLCache
▪️ 복합 캐싱 방식(in-Memory Caching + on-Disk Caching)
▪️ 시스템의 디스크 공간이 부족해질 때까지 캐시된 데이터를 유지함

  이처럼 NSCache와 URLCache의 두드러지는 차이점은 캐싱 방식에서 나타납니다. URLCache는 NSCache와 달리 복합 캐싱 방식을 지원하기 때문에 Disk Caching이 가능하며, in-Memory Caching이 가지는 한계를 보완할 수 있습니다. 드라이브는 RAM보다 느리지만 상대적으로 많이 저장될 수 있기때문에, 이미지가 있는 데이터를 저장하기에는 URLCache를 선택하는 것이 적절하다고 생각했습니다. 또한, NSCache는 앱을 끄면 자동으로 삭제가 됩니다. 박스오피스가 받아올 데이터들은 그날의 데이터가 나오면 내용이 변하지 않습니다. 그러므로 앱을 껐다 켤때마다 데이터를 받아올 필요가 없다고 생각했습니다. 그래서 앱을 끌 때 캐시가 삭제 되는 NSCache보다는 URLCache로 데이터를 저장하는 것이 적절하다고 판단했습니다.


### 3️⃣ Cache Policy

캐시 정책은 URLRequest의 cachePolicy 속성을 통해 설정할 수 있습니다. URLRequst의 cachePolicy 속성은 다음과 같은 값을 가질 수 있습니다.

| <center>캐시 정책</center> | <center>로컬 캐시</center>| <center>원본 소스</center> |
| -------- | -------- | -------- |
| reloadIgnoringLocalCacheData | 무시 됨 | 항상 네트워크에 접근 |
| returnCacheDataDontLoad | 무조건 사용 | 항상 네트워크에 접근하지 않음 |
| returnCacheDataElseLoad | 우선 시도 | 필요하다면 접근 |
| useProtocolCachePolicy | 프로토콜에 따라 다름 | 프로토콜에 따라 다름 |

    
    
저희의 경우 캐시된 데이터가 있을경우 해당 데이터를 반환하고 데이터가 없다면 그 때 네트워크에 요청을 하는 방식을 띄고 있습니다.
    
    
그래서 저희는 캐시정책을 returnCacheDataElseLoad 을 채택하였고 Cache를 5분 동안만 가질 수 있게 해두었습니다.

    
```swift
    let request = URLRequest(url: url,
                            cachePolicy: .returnCacheDataElseLoad,
                            timeoutInterval: 300)    
    
```

또한 URLSession 의 공유 인스턴스를 만들어 memoryCapacity와 diskCapacity의 크기를 제한 해두어 용량이 무한정으로 커지지 않게 제한을 해두었습니다,

```swift
extension URLSession {
    static var customCacheShared: URLSession = {
        let memoryCapacity = 10 * 1024 * 1024
        let diskCapacity = 50 * 1024 * 1024
        let cache = URLCache(memoryCapacity: memoryCapacity, diskCapacity: diskCapacity)
        
        let config = URLSessionConfiguration.default
        config.urlCache = cache
        
        let session = URLSession(configuration: config)
        
        return session
    }()
}
```