### PR TITLE
박스오피스 II 🎬 [STEP3] Goat, 송준

### DIFF
--- a/BoxOffice/Application/AppDelegate.swift
+++ b/BoxOffice/Application/AppDelegate.swift
@@ -30,7 +30,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
-
-
+    
+    func applicationWillTerminate(_ application: UIApplication) {
+        ImageSearchService().removeCache()
+    }
 }
 

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -29,11 +29,16 @@ final class BoxOfficeViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        setURLCache()
         imageSearchService.removeCacheAfter30min()
         fetchDailyBoxOffice()
         setUpView()
         setCalendarViewDelegate()
         
+    }
+    
+    private func setURLCache() {
+        URLCache.shared = .init(memoryCapacity: 300 * 1024 * 1024, diskCapacity: 300 * 1024 * 1024, directory: FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0])
     }
     
     private func fetchDailyBoxOffice() {

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -15,6 +15,7 @@ final class BoxOfficeViewController: UIViewController {
     let boxOfficeService = BoxOfficeService()
     private var provider = Provider()
     private var isCurrentListLayout: Bool = true
+    private let imageSearchService = ImageSearchService()
     let calendarViewController = CalendarViewController()
     var choosenDate: String = "" {
         didSet {
@@ -28,9 +29,11 @@ final class BoxOfficeViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        imageSearchService.removeCacheAfter30min()
         fetchDailyBoxOffice()
         setUpView()
         setCalendarViewDelegate()
+        
     }
     
     private func fetchDailyBoxOffice() {

--- a/BoxOffice/Controller/MovieDetailViewController.swift
+++ b/BoxOffice/Controller/MovieDetailViewController.swift
@@ -24,7 +24,6 @@ class MovieDetailViewController: UIViewController {
         view = movieDetailView
         setActivityIndicator()
         fetchMoiveDetail()
-        
         }
     
     private func setActivityIndicator() {

--- a/BoxOffice/Controller/MovieDetailViewController.swift
+++ b/BoxOffice/Controller/MovieDetailViewController.swift
@@ -24,6 +24,7 @@ class MovieDetailViewController: UIViewController {
         view = movieDetailView
         setActivityIndicator()
         fetchMoiveDetail()
+        
         }
     
     private func setActivityIndicator() {

--- a/BoxOffice/Model/ImageSearchService.swift
+++ b/BoxOffice/Model/ImageSearchService.swift
@@ -12,29 +12,25 @@ class ImageSearchService {
     private var searchedImage: ImageSearch?
     
     func fetchSearchedImage(boxOfficeService: BoxOfficeService, completion: @escaping (Data) -> Void) {
-    
+        
         guard let movieName = boxOfficeService.movieDetail?.movieInformationResult.movieInformation.movieName else { return }
-
+        
         var imageSearchEndpoint = ImageSearchEndpoint()
         imageSearchEndpoint.insertImageQueryValue(imageName: movieName)
         
         provider.loadBoxOfficeAPI(endpoint: imageSearchEndpoint, parser: Parser<ImageSearch>()) {
             parsedData in
-           
+            
             guard let url = URL(string: parsedData.imageDatas[0].imageURL) else { return }
-            self.loadImageURL(url: url) { data in
+            self.loadImageFromURL(url: url) { data in
                 completion(data)
             }
-
         }
     }
     
-    func loadImageURL(url: URL, completion: @escaping (Data) -> Void){ // Renaming 필요
-    
+    func loadImageFromURL(url: URL, completion: @escaping (Data) -> Void){
         var urlRequest = URLRequest(url: url)
-        
         urlRequest.httpMethod = "GET"
-        
         urlRequest.cachePolicy = .returnCacheDataElseLoad
         
         let dataTask = URLSession.shared.dataTask(with: urlRequest) { data, response, error in
@@ -62,8 +58,17 @@ class ImageSearchService {
         }
     }
     
+    func removeCacheAfter30min() {
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1800) {
+            URLCache.shared.removeAllCachedResponses()
+            print("캐시 지워짐")
+        }
+    }
+    
     func removeCache() {
-        print("캐시 지워짐")
-        URLCache.shared.removeAllCachedResponses()
+        DispatchQueue.main.async() {
+            URLCache.shared.removeAllCachedResponses()
+            print("캐시 지워짐")
+        }
     }
 }

--- a/BoxOffice/Model/ImageSearchService.swift
+++ b/BoxOffice/Model/ImageSearchService.swift
@@ -20,11 +20,31 @@ class ImageSearchService {
         
         provider.loadBoxOfficeAPI(endpoint: imageSearchEndpoint, parser: Parser<ImageSearch>()) {
             parsedData in
-            
+           
             guard let url = URL(string: parsedData.imageDatas[0].imageURL) else { return }
-            guard let data = try? Data(contentsOf: url) else { return }
+            self.loadImageURL(url: url) { data in
+                completion(data)
+            }
 
-            completion(data)
         }
+    }
+    
+    func loadImageURL(url: URL, completion: @escaping (Data) -> Void){ // Renaming 필요
+    
+        var urlRequest = URLRequest(url: url)
+        
+        urlRequest.httpMethod = "GET"
+        
+        let dataTask = URLSession.shared.dataTask(with: urlRequest) { data, response, error in
+            guard error == nil else { return }
+            
+            guard let httpURLResponse = response as? HTTPURLResponse, (200...299).contains(httpURLResponse.statusCode) else { return }
+            
+            guard let validData = data else { return }
+            
+            completion(validData)
+        }
+        
+        dataTask.resume()
     }
 }


### PR DESCRIPTION

# 🎬박스오피스 II [STEP3] 
@forestjae
안녕하세요 숲재! 
박스오피스 II [STEP3] PR입니다.
URLcache에 정확히 이해하지못해서인지 구현했음에도 오류가 많네요ㅜ
cache데이터가 정상적으로 담기고 가져와지고있는지, 정책이 잘 적용되었는지 등 검증하는 과정 또한  
cache데이터가 명확히 보이지않아 어려움이 있던 것 같습니다.
그럼 이번 리뷰도 잘 부탁드리겠습니다ㅎ

### 구현한 점
- URLCache 구현

### 고민한 점 + 해결하지못한 점

### :fire: URLCache 잔존기한 설정 - removeAllCachedResponses
* URLCache 잔존기한 설정을 `removeAllCachedResponses()` 매서드를 활용해서 2가지 조건을 통해 구현하고자했습니다.
    * 1. viewDidLoad에 아래 `removeCacheAfter30min()`매서드를 구현해 30분간 캐시데이터가 잔존할 수 있도록하며 이후에 캐시데이터를 삭제시키는 조건입니다.
    * 2. appdelegate - applicationWillTerminate() `removeCache()`매서드를 구현해 앱이 종료되는 시점에 캐시데이터를 삭제시키는 조건입니다.
```swift!
//viewDidLoad
 func removeCacheAfter30min() {
        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1800) {
            URLCache.shared.removeAllCachedResponses()
            print("캐시 지워짐")
    }
}
```

```swift!
//Appdelegate - applicationWillTerminate()
 func removeCache() {
        DispatchQueue.main.async() {
            URLCache.shared.removeAllCachedResponses()
            print("캐시 지워짐")
    }
}
```
* (문제점) 앱이 실행된 이후에 시간을 갖고 캐시데이터를 삭제시키는 매서드는 정상적으로 구현되는 반면에 앱이 종료되는 시점에 캐시데이터를 삭제시키는 매서드는 정상작동되지않았습니다. `applicationWillterminate()`매서드는 정상적으로 동작하는데 내부에 `removeCache`가 작동되지않았고 이를 해결하지 못했습니다.

### :fire: URLCache 정책
* URLCache의 4가지 정책중 `urlRequest.cachePolicy = .returnCacheDataElseLoad` 정책을 선택해서 캐시데이터가 있을때는 네트워킹을 허용하지않고 캐시데이터가 없을때만 네트워킹을 하도록 정책을 선택했습니다.
* 또 `storagePolicy = .allowedInMemoryOnly`로 설정함으로써 메모리에 저장하게끔 설정해 앱이 실행종료되면 메모리캐싱 특성상 캐싱데이터가 날아게끔 설정했는데 이 또한 정상작동되지 않았습니다.