### PR TITLE
박스오피스 [STEP3] Zion, Hemg

### DIFF
--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -583,7 +583,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -610,7 +610,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -699,7 +699,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -726,7 +726,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		5BE0FBAC2A780646002F6E88 /* JSONDecoder +.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BE0FBAB2A780646002F6E88 /* JSONDecoder +.swift */; };
 		5BE0FBAF2A78B601002F6E88 /* BoxOfficeRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BE0FBAE2A78B601002F6E88 /* BoxOfficeRepository.swift */; };
 		6332DA662A6E6C6B000E3B38 /* BoxOfficeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6332DA652A6E6C6B000E3B38 /* BoxOfficeTests.swift */; };
+		6392307B2A7B9D2600963042 /* MainCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6392307A2A7B9D2600963042 /* MainCollectionViewCell.swift */; };
 		63C263992A737B1B00DB2261 /* MovieInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63C263982A737B1B00DB2261 /* MovieInformation.swift */; };
 		63D8ADBB2A77AE5E005E5B13 /* Nation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D8ADBA2A77AE5E005E5B13 /* Nation.swift */; };
 		63D8ADBD2A77AE8D005E5B13 /* Genre.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D8ADBC2A77AE8D005E5B13 /* Genre.swift */; };
@@ -61,6 +62,7 @@
 		5BE0FBAE2A78B601002F6E88 /* BoxOfficeRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxOfficeRepository.swift; sourceTree = "<group>"; };
 		6332DA632A6E6C6B000E3B38 /* BoxOfficeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BoxOfficeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6332DA652A6E6C6B000E3B38 /* BoxOfficeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxOfficeTests.swift; sourceTree = "<group>"; };
+		6392307A2A7B9D2600963042 /* MainCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainCollectionViewCell.swift; sourceTree = "<group>"; };
 		63C263982A737B1B00DB2261 /* MovieInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieInformation.swift; sourceTree = "<group>"; };
 		63D8ADBA2A77AE5E005E5B13 /* Nation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Nation.swift; sourceTree = "<group>"; };
 		63D8ADBC2A77AE8D005E5B13 /* Genre.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Genre.swift; sourceTree = "<group>"; };
@@ -112,6 +114,7 @@
 			isa = PBXGroup;
 			children = (
 				63DF20F92970E1A1005DF7D1 /* LaunchScreen.storyboard */,
+				6392307A2A7B9D2600963042 /* MainCollectionViewCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -370,6 +373,7 @@
 				63D8ADC32A77AEF7005E5B13 /* Staff.swift in Sources */,
 				63D8ADBF2A77AEB5005E5B13 /* Director.swift in Sources */,
 				63DF20F32970E1A0005DF7D1 /* MainViewController.swift in Sources */,
+				6392307B2A7B9D2600963042 /* MainCollectionViewCell.swift in Sources */,
 				63DF20EF2970E1A0005DF7D1 /* AppDelegate.swift in Sources */,
 				5BE0FBA92A77E065002F6E88 /* MovieInformationDTO.swift in Sources */,
 				63D8ADC12A77AEDB005E5B13 /* Actor.swift in Sources */,

--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		5BE0FBAF2A78B601002F6E88 /* BoxOfficeRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BE0FBAE2A78B601002F6E88 /* BoxOfficeRepository.swift */; };
 		6332DA662A6E6C6B000E3B38 /* BoxOfficeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6332DA652A6E6C6B000E3B38 /* BoxOfficeTests.swift */; };
 		6392307B2A7B9D2600963042 /* MainCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6392307A2A7B9D2600963042 /* MainCollectionViewCell.swift */; };
+		63BF05E62A80EEB500D73800 /* MovieInformationDTOTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63BF05E52A80EEB500D73800 /* MovieInformationDTOTests.swift */; };
 		63C263992A737B1B00DB2261 /* MovieInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63C263982A737B1B00DB2261 /* MovieInformation.swift */; };
 		63D8ADBB2A77AE5E005E5B13 /* Nation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D8ADBA2A77AE5E005E5B13 /* Nation.swift */; };
 		63D8ADBD2A77AE8D005E5B13 /* Genre.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D8ADBC2A77AE8D005E5B13 /* Genre.swift */; };
@@ -46,6 +47,13 @@
 			remoteGlobalIDString = 63DF20EA2970E1A0005DF7D1;
 			remoteInfo = BoxOffice;
 		};
+		63BF05E72A80EEB500D73800 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 63DF20E32970E1A0005DF7D1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 63DF20EA2970E1A0005DF7D1;
+			remoteInfo = BoxOffice;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -63,6 +71,8 @@
 		6332DA632A6E6C6B000E3B38 /* BoxOfficeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BoxOfficeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6332DA652A6E6C6B000E3B38 /* BoxOfficeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxOfficeTests.swift; sourceTree = "<group>"; };
 		6392307A2A7B9D2600963042 /* MainCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainCollectionViewCell.swift; sourceTree = "<group>"; };
+		63BF05E32A80EEB500D73800 /* MovieInformationDtoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MovieInformationDtoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		63BF05E52A80EEB500D73800 /* MovieInformationDTOTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieInformationDTOTests.swift; sourceTree = "<group>"; };
 		63C263982A737B1B00DB2261 /* MovieInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieInformation.swift; sourceTree = "<group>"; };
 		63D8ADBA2A77AE5E005E5B13 /* Nation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Nation.swift; sourceTree = "<group>"; };
 		63D8ADBC2A77AE8D005E5B13 /* Genre.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Genre.swift; sourceTree = "<group>"; };
@@ -85,6 +95,13 @@
 
 /* Begin PBXFrameworksBuildPhase section */
 		6332DA602A6E6C6B000E3B38 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		63BF05E02A80EEB500D73800 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -222,11 +239,20 @@
 			path = BoxOfficeTests;
 			sourceTree = "<group>";
 		};
+		63BF05E42A80EEB500D73800 /* MovieInformationDtoTests */ = {
+			isa = PBXGroup;
+			children = (
+				63BF05E52A80EEB500D73800 /* MovieInformationDTOTests.swift */,
+			);
+			path = MovieInformationDtoTests;
+			sourceTree = "<group>";
+		};
 		63DF20E22970E1A0005DF7D1 = {
 			isa = PBXGroup;
 			children = (
 				63DF20ED2970E1A0005DF7D1 /* BoxOffice */,
 				6332DA642A6E6C6B000E3B38 /* BoxOfficeTests */,
+				63BF05E42A80EEB500D73800 /* MovieInformationDtoTests */,
 				63DF20EC2970E1A0005DF7D1 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -236,6 +262,7 @@
 			children = (
 				63DF20EB2970E1A0005DF7D1 /* BoxOffice.app */,
 				6332DA632A6E6C6B000E3B38 /* BoxOfficeTests.xctest */,
+				63BF05E32A80EEB500D73800 /* MovieInformationDtoTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -280,6 +307,24 @@
 			productReference = 6332DA632A6E6C6B000E3B38 /* BoxOfficeTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		63BF05E22A80EEB500D73800 /* MovieInformationDtoTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 63BF05E92A80EEB500D73800 /* Build configuration list for PBXNativeTarget "MovieInformationDtoTests" */;
+			buildPhases = (
+				63BF05DF2A80EEB500D73800 /* Sources */,
+				63BF05E02A80EEB500D73800 /* Frameworks */,
+				63BF05E12A80EEB500D73800 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				63BF05E82A80EEB500D73800 /* PBXTargetDependency */,
+			);
+			name = MovieInformationDtoTests;
+			productName = MovieInformationDtoTests;
+			productReference = 63BF05E32A80EEB500D73800 /* MovieInformationDtoTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		63DF20EA2970E1A0005DF7D1 /* BoxOffice */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 63DF20FF2970E1A1005DF7D1 /* Build configuration list for PBXNativeTarget "BoxOffice" */;
@@ -311,6 +356,10 @@
 						CreatedOnToolsVersion = 14.0;
 						TestTargetID = 63DF20EA2970E1A0005DF7D1;
 					};
+					63BF05E22A80EEB500D73800 = {
+						CreatedOnToolsVersion = 14.0;
+						TestTargetID = 63DF20EA2970E1A0005DF7D1;
+					};
 					63DF20EA2970E1A0005DF7D1 = {
 						CreatedOnToolsVersion = 14.2;
 					};
@@ -331,12 +380,20 @@
 			targets = (
 				63DF20EA2970E1A0005DF7D1 /* BoxOffice */,
 				6332DA622A6E6C6B000E3B38 /* BoxOfficeTests */,
+				63BF05E22A80EEB500D73800 /* MovieInformationDtoTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		6332DA612A6E6C6B000E3B38 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		63BF05E12A80EEB500D73800 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -361,6 +418,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				6332DA662A6E6C6B000E3B38 /* BoxOfficeTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		63BF05DF2A80EEB500D73800 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				63BF05E62A80EEB500D73800 /* MovieInformationDTOTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -403,6 +468,11 @@
 			isa = PBXTargetDependency;
 			target = 63DF20EA2970E1A0005DF7D1 /* BoxOffice */;
 			targetProxy = 6332DA672A6E6C6B000E3B38 /* PBXContainerItemProxy */;
+		};
+		63BF05E82A80EEB500D73800 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 63DF20EA2970E1A0005DF7D1 /* BoxOffice */;
+			targetProxy = 63BF05E72A80EEB500D73800 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -450,6 +520,48 @@
 				MACOSX_DEPLOYMENT_TARGET = 12.3;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = kr.co.hemg2.BoxOfficeTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/BoxOffice.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/BoxOffice";
+			};
+			name = Release;
+		};
+		63BF05EA2A80EEB500D73800 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = kr.co.hemg2.MovieInformationDtoTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/BoxOffice.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/BoxOffice";
+			};
+			name = Debug;
+		};
+		63BF05EB2A80EEB500D73800 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.3;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = kr.co.hemg2.MovieInformationDtoTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
@@ -636,6 +748,15 @@
 			buildConfigurations = (
 				6332DA6A2A6E6C6B000E3B38 /* Debug */,
 				6332DA6B2A6E6C6B000E3B38 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		63BF05E92A80EEB500D73800 /* Build configuration list for PBXNativeTarget "MovieInformationDtoTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				63BF05EA2A80EEB500D73800 /* Debug */,
+				63BF05EB2A80EEB500D73800 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/BoxOffice/App/SceneDelegate.swift
+++ b/BoxOffice/App/SceneDelegate.swift
@@ -17,10 +17,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let boxOfficeRepository: BoxOfficeRepository = BoxOfficeRepositoryImplementation(sessionProvider: sessionProvider)
         var usecase: MainViewControllerUseCase = MainViewControllerUseCaseImplementation(boxOfficeRepository: boxOfficeRepository)
         let mainViewController = MainViewController(usecase)
+        let navigationController = UINavigationController(rootViewController: mainViewController)
         
         usecase.delegate = mainViewController
         window = UIWindow(windowScene: windowScene)
-        window?.rootViewController = mainViewController
+        window?.rootViewController = navigationController
         window?.makeKeyAndVisible()
     }
 

--- a/BoxOffice/Model/DTO/MovieInformationDTO.swift
+++ b/BoxOffice/Model/DTO/MovieInformationDTO.swift
@@ -4,6 +4,7 @@
 //
 //  Created by Hyungmin Lee on 2023/07/31.
 //
+import UIKit
 
 struct MovieInformationDTO: Hashable {
     let rank: String
@@ -12,4 +13,41 @@ struct MovieInformationDTO: Hashable {
     let movieName: String
     let audienceCount: String
     let audienceAccumulate: String
+}
+
+extension MovieInformationDTO {
+    func conventedRankIntenSybolAndText() -> NSMutableAttributedString {
+        if OldAndNew == "NEW" {
+            return addAttributeString(text: "신작", keyword: "신작", color: .red)
+        }
+        
+        if rankInten == "0" {
+            return addAttributeString(text: "-", keyword: "-", color: .black)
+        } else {
+            let isRankUp = Int(rankInten) ?? 0 > 0
+            let symbol = isRankUp ? "▲" : "▼"
+            let symbolColor: UIColor = isRankUp ? .red : .blue
+            let inten = isRankUp == false ? rankInten.replacingOccurrences(of: "-", with: "") : rankInten
+            let text = "\(symbol)\(inten)"
+            
+            return addAttributeString(text: text, keyword: symbol, color: symbolColor)
+        }
+    }
+    
+    func convertDecimalFormattedString(text: String) -> String {
+        let numberFormatter = NumberFormatter()
+        
+        numberFormatter.numberStyle = .decimal
+        let number = numberFormatter.number(from: text) ?? 0
+        let result = numberFormatter.string(from: number) ?? ""
+        
+        return result
+    }
+    
+    private func addAttributeString(text: String, keyword: String, color: UIColor) -> NSMutableAttributedString {
+        let attributeString = NSMutableAttributedString(string: text)
+        
+        attributeString.addAttribute(.foregroundColor, value: color , range: (text as NSString).range(of: keyword))
+        return attributeString
+    }
 }

--- a/BoxOffice/Model/DTO/MovieInformationDTO.swift
+++ b/BoxOffice/Model/DTO/MovieInformationDTO.swift
@@ -5,7 +5,7 @@
 //  Created by Hyungmin Lee on 2023/07/31.
 //
 
-struct MovieInformationDTO {
+struct MovieInformationDTO: Hashable {
     let rank: String
     let rankInten: String
     let OldAndNew: String

--- a/BoxOffice/Model/DTO/MovieInformationDTO.swift
+++ b/BoxOffice/Model/DTO/MovieInformationDTO.swift
@@ -9,7 +9,7 @@ import UIKit
 struct MovieInformationDTO: Hashable {
     let rank: String
     let rankInten: String
-    let OldAndNew: String
+    let oldAndNew: String
     let movieName: String
     let audienceCount: String
     let audienceAccumulate: String
@@ -17,7 +17,7 @@ struct MovieInformationDTO: Hashable {
 
 extension MovieInformationDTO {
     func conventedRankIntenSybolAndText() -> NSMutableAttributedString {
-        if OldAndNew == "NEW" {
+        if oldAndNew == "NEW" {
             return addAttributeString(text: "신작", keyword: "신작", color: .red)
         }
         

--- a/BoxOffice/Protocol/CanShowNetworkRequestFailureAlert.swift
+++ b/BoxOffice/Protocol/CanShowNetworkRequestFailureAlert.swift
@@ -21,6 +21,6 @@ extension CanShowNetworkRequestFailureAlert {
         
         alert.addAction(retryAction)
         alert.addAction(confirmAction)
-        present(alert, animated: true)
+        present(alert, animated: false)
     }
 }

--- a/BoxOffice/UseCase/MainViewControllerUseCase.swift
+++ b/BoxOffice/UseCase/MainViewControllerUseCase.swift
@@ -10,7 +10,6 @@ import Foundation
 protocol MainViewControllerUseCase {
     var delegate: MainViewControllerUseCaseDelegate? { get set }
     func fetchDailyBoxOffice(targetDate: String)
-    func fetchMovieDetailInformation(movieCode: String)
 }
 
 final class MainViewControllerUseCaseImplementation: MainViewControllerUseCase {
@@ -30,17 +29,6 @@ final class MainViewControllerUseCaseImplementation: MainViewControllerUseCase {
                 self.delegate?.completeFetchDailyBoxOfficeInformation(movieInformationDTOList)
             case .failure(let error):
                 self.delegate?.failFetchDailyBoxOfficeInformation(error.errorDescription)
-            }
-        }
-    }
-    
-    func fetchMovieDetailInformation(movieCode: String) {
-        boxOfficeRepository.fetchMovieDetailInformation(movieCode) { result in
-            switch result {
-            case .success(let result):
-                self.delegate?.completeFetchMovieDetailInformation(result)
-            case .failure(let error):
-                self.delegate?.failFetchMovieDetailInformaion(error.errorDescription)
             }
         }
     }

--- a/BoxOffice/UseCase/MainViewControllerUseCase.swift
+++ b/BoxOffice/UseCase/MainViewControllerUseCase.swift
@@ -9,12 +9,21 @@ import Foundation
 
 protocol MainViewControllerUseCase {
     var delegate: MainViewControllerUseCaseDelegate? { get set }
+    var yesterdayDate: String { get }
     func fetchDailyBoxOffice(targetDate: String)
 }
 
 final class MainViewControllerUseCaseImplementation: MainViewControllerUseCase {
     private let boxOfficeRepository: BoxOfficeRepository
     weak var delegate: MainViewControllerUseCaseDelegate?
+    
+    let yesterdayDate: String = {
+        let yesterday = Date() - (24 * 60 * 60)
+        let formatter = DateFormatter()
+        
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: yesterday)
+    }()
     
     init(boxOfficeRepository: BoxOfficeRepository) {
         self.boxOfficeRepository = boxOfficeRepository

--- a/BoxOffice/UseCase/MainViewControllerUseCase.swift
+++ b/BoxOffice/UseCase/MainViewControllerUseCase.swift
@@ -40,7 +40,7 @@ extension MainViewControllerUseCaseImplementation {
         let movieInformationDTOList = dailyBoxOfficeMovieInformationList.map { movieInformation in
             MovieInformationDTO(rank: movieInformation.rank,
                                 rankInten: movieInformation.rankInten,
-                                OldAndNew: movieInformation.rankOldAndNew,
+                                oldAndNew: movieInformation.rankOldAndNew,
                                 movieName: movieInformation.movieName,
                                 audienceCount: movieInformation.audienceCount,
                                 audienceAccumulate: movieInformation.audienceAccumulate)

--- a/BoxOffice/View/MainCollectionViewCell.swift
+++ b/BoxOffice/View/MainCollectionViewCell.swift
@@ -84,6 +84,16 @@ final class MainCollectionViewCell: UICollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
+    func setUpContent(_ movieInformation: MovieInformationDTO) {
+        rankLabel.text = movieInformation.rank
+        rankIntenLabel.attributedText = rankIntenLabelText(movieInformation.OldAndNew, movieInformation.rankInten)
+        movieNameLabel.text = movieInformation.movieName
+        audienceCountLabel.text = movieInformation.audienceCount
+    }
+}
+
+// MARK: - Private
+extension MainCollectionViewCell {
     private func configureUI() {
         [rankLabel, rankIntenLabel].forEach { rankStackView.addArrangedSubview($0) }
         [movieNameLabel, audienceCountLabel].forEach { movieDescriptionStackView.addArrangedSubview($0) }
@@ -103,14 +113,25 @@ final class MainCollectionViewCell: UICollectionViewCell {
     private func addAttributeString(text: String, keyword: String, color: UIColor) -> NSMutableAttributedString {
         let attributeString = NSMutableAttributedString(string: text)
         
-        attributeString.addAttribute(.foregroundColor, value: UIColor.red , range: (text as NSString).range(of: keyword))
+        attributeString.addAttribute(.foregroundColor, value: color , range: (text as NSString).range(of: keyword))
         return attributeString
     }
     
-    func setUpContent(_ movieInformation: MovieInformationDTO) {
-        rankLabel.text = movieInformation.rank
-        rankIntenLabel.text = movieInformation.OldAndNew == "NEW" ? "신작" : movieInformation.rankInten
-        movieNameLabel.text = movieInformation.movieName
-        audienceCountLabel.text = movieInformation.audienceCount
+    private func rankIntenLabelText(_ oldAndNew: String, _ rankInten: String) -> NSMutableAttributedString {
+        if oldAndNew == "NEW" {
+            return addAttributeString(text: "신작", keyword: "신작", color: .red)
+        }
+        
+        if rankInten == "0" {
+            return addAttributeString(text: "-", keyword: "-", color: .black)
+        } else {
+            let isRankUp = Int(rankInten) ?? 0 > 0
+            let symbol = isRankUp ? "▲" : "▼"
+            let symbolColor: UIColor = isRankUp ? .red : .blue
+            let inten = isRankUp == false ? rankInten.replacingOccurrences(of: "-", with: "") : rankInten
+            let text = "\(symbol)\(inten)"
+            
+            return addAttributeString(text: text, keyword: symbol, color: symbolColor)
+        }
     }
 }

--- a/BoxOffice/View/MainCollectionViewCell.swift
+++ b/BoxOffice/View/MainCollectionViewCell.swift
@@ -1,0 +1,81 @@
+//
+//  MainCollectionViewCell.swift
+//  BoxOffice
+//
+//  Created by 1 on 2023/08/03.
+//
+
+import UIKit
+
+final class MainCollectionViewCell: UICollectionViewCell {
+    static let reuseIdentifier = "cell"
+    
+    private let rankLabel: UILabel = {
+        let label = UILabel()
+        
+        label.textColor = .black
+        return label
+    }()
+    
+    private let rankIntenLabel: UILabel = {
+        let label = UILabel()
+        
+        label.textColor = .black
+        return label
+    }()
+    
+    private let movieNameLabel: UILabel = {
+        let label = UILabel()
+        
+        label.textColor = .black
+        return label
+    }()
+    
+    private let audienceCountLabel: UILabel = {
+        let label = UILabel()
+        
+        label.textColor = .black
+        return label
+    }()
+    
+    private let rankStackView: UIStackView = {
+        let stackView = UIStackView()
+        
+        stackView.axis = .vertical
+        stackView.spacing = 3
+        return stackView
+    }()
+    
+    private let movieDescriptionStackView: UIStackView = {
+        let stackView = UIStackView()
+        
+        stackView.axis = .vertical
+        stackView.spacing = 3
+        stackView.alignment = .leading
+        return stackView
+    }()
+    
+    private let movieInformationStackView: UIStackView = {
+        let stackView = UIStackView()
+        
+        stackView.spacing = 25
+        stackView.axis = .horizontal
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+    
+    private func configureUI() {
+        [rankLabel, rankIntenLabel].forEach { rankStackView.addArrangedSubview($0) }
+        [movieNameLabel, audienceCountLabel].forEach { movieDescriptionStackView.addArrangedSubview($0) }
+        [rankStackView, movieDescriptionStackView].forEach { movieInformationStackView.addArrangedSubview($0) }
+    }
+
+    private func setUpConstraints() {
+        NSLayoutConstraint.activate([
+            movieInformationStackView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            movieInformationStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            movieInformationStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 25),
+            movieInformationStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
+        ])
+    }
+}

--- a/BoxOffice/View/MainCollectionViewCell.swift
+++ b/BoxOffice/View/MainCollectionViewCell.swift
@@ -65,7 +65,7 @@ final class MainCollectionViewCell: UICollectionViewListCell {
         stackView.translatesAutoresizingMaskIntoConstraints = false
         return stackView
     }()
-
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         

--- a/BoxOffice/View/MainCollectionViewCell.swift
+++ b/BoxOffice/View/MainCollectionViewCell.swift
@@ -90,4 +90,11 @@ final class MainCollectionViewCell: UICollectionViewCell {
             movieInformationStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
         ])
     }
+    
+    func setUpContent(_ movieInformation: MovieInformationDTO) {
+        rankLabel.text = movieInformation.rank
+        rankIntenLabel.text = movieInformation.rankInten
+        movieNameLabel.text = movieInformation.movieName
+        audienceCountLabel.text = movieInformation.audienceCount
+    }
 }

--- a/BoxOffice/View/MainCollectionViewCell.swift
+++ b/BoxOffice/View/MainCollectionViewCell.swift
@@ -72,7 +72,7 @@ final class MainCollectionViewCell: UICollectionViewCell {
         stackView.translatesAutoresizingMaskIntoConstraints = false
         return stackView
     }()
-    
+        
     override init(frame: CGRect) {
         super.init(frame: frame)
         
@@ -88,7 +88,7 @@ final class MainCollectionViewCell: UICollectionViewCell {
         rankLabel.text = movieInformation.rank
         rankIntenLabel.attributedText = rankIntenLabelText(movieInformation.OldAndNew, movieInformation.rankInten)
         movieNameLabel.text = movieInformation.movieName
-        audienceCountLabel.text = movieInformation.audienceCount
+        audienceCountLabel.text = "오늘 \(decimalFormattedNumber(text: movieInformation.audienceCount)) / 총 \(decimalFormattedNumber(text: movieInformation.audienceAccumulate))"
     }
 }
 
@@ -133,5 +133,14 @@ extension MainCollectionViewCell {
             
             return addAttributeString(text: text, keyword: symbol, color: symbolColor)
         }
+    }
+    
+    private func decimalFormattedNumber(text: String) -> String {
+        let numberFormatter = NumberFormatter()
+        let numbers = Int(text) ?? 0
+        
+        numberFormatter.numberStyle = .decimal
+        let result = numberFormatter.string(from: NSNumber(value: numbers)) ?? ""
+        return result
     }
 }

--- a/BoxOffice/View/MainCollectionViewCell.swift
+++ b/BoxOffice/View/MainCollectionViewCell.swift
@@ -86,9 +86,13 @@ final class MainCollectionViewCell: UICollectionViewCell {
     
     func setUpContent(_ movieInformation: MovieInformationDTO) {
         rankLabel.text = movieInformation.rank
-        rankIntenLabel.attributedText = rankIntenLabelText(movieInformation.OldAndNew, movieInformation.rankInten)
+        rankIntenLabel.attributedText = movieInformation.conventedRankIntenSybolAndText()
         movieNameLabel.text = movieInformation.movieName
-        audienceCountLabel.text = "오늘 \(decimalFormattedNumber(text: movieInformation.audienceCount)) / 총 \(decimalFormattedNumber(text: movieInformation.audienceAccumulate))"
+        
+        let audienceCount = movieInformation.convertDecimalFormattedString(text: movieInformation.audienceCount)
+        let audienceAccumulateCount = movieInformation.convertDecimalFormattedString(text: movieInformation.audienceAccumulate)
+        
+        audienceCountLabel.text = "오늘 \(audienceCount) / 총 \(audienceAccumulateCount)"
     }
 }
 
@@ -108,39 +112,5 @@ extension MainCollectionViewCell {
             movieInformationStackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 30),
             movieInformationStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -20)
         ])
-    }
-    
-    private func addAttributeString(text: String, keyword: String, color: UIColor) -> NSMutableAttributedString {
-        let attributeString = NSMutableAttributedString(string: text)
-        
-        attributeString.addAttribute(.foregroundColor, value: color , range: (text as NSString).range(of: keyword))
-        return attributeString
-    }
-    
-    private func rankIntenLabelText(_ oldAndNew: String, _ rankInten: String) -> NSMutableAttributedString {
-        if oldAndNew == "NEW" {
-            return addAttributeString(text: "신작", keyword: "신작", color: .red)
-        }
-        
-        if rankInten == "0" {
-            return addAttributeString(text: "-", keyword: "-", color: .black)
-        } else {
-            let isRankUp = Int(rankInten) ?? 0 > 0
-            let symbol = isRankUp ? "▲" : "▼"
-            let symbolColor: UIColor = isRankUp ? .red : .blue
-            let inten = isRankUp == false ? rankInten.replacingOccurrences(of: "-", with: "") : rankInten
-            let text = "\(symbol)\(inten)"
-            
-            return addAttributeString(text: text, keyword: symbol, color: symbolColor)
-        }
-    }
-    
-    private func decimalFormattedNumber(text: String) -> String {
-        let numberFormatter = NumberFormatter()
-        let numbers = Int(text) ?? 0
-        
-        numberFormatter.numberStyle = .decimal
-        let result = numberFormatter.string(from: NSNumber(value: numbers)) ?? ""
-        return result
     }
 }

--- a/BoxOffice/View/MainCollectionViewCell.swift
+++ b/BoxOffice/View/MainCollectionViewCell.swift
@@ -14,6 +14,9 @@ final class MainCollectionViewCell: UICollectionViewCell {
         let label = UILabel()
         
         label.textColor = .black
+        label.font = .boldSystemFont(ofSize: 25)
+        label.textAlignment = .center
+        label.setContentHuggingPriority(.init(1), for: .vertical)
         return label
     }()
     
@@ -21,6 +24,8 @@ final class MainCollectionViewCell: UICollectionViewCell {
         let label = UILabel()
         
         label.textColor = .black
+        label.font = .systemFont(ofSize: 15)
+        label.textAlignment = .center
         return label
     }()
     
@@ -28,6 +33,9 @@ final class MainCollectionViewCell: UICollectionViewCell {
         let label = UILabel()
         
         label.textColor = .black
+        label.font = .systemFont(ofSize: 20)
+        label.numberOfLines = 0
+        label.setContentHuggingPriority(.init(1), for: .vertical)
         return label
     }()
     
@@ -35,6 +43,7 @@ final class MainCollectionViewCell: UICollectionViewCell {
         let label = UILabel()
         
         label.textColor = .black
+        label.font = .systemFont(ofSize: 15)
         return label
     }()
     
@@ -58,7 +67,7 @@ final class MainCollectionViewCell: UICollectionViewCell {
     private let movieInformationStackView: UIStackView = {
         let stackView = UIStackView()
         
-        stackView.spacing = 25
+        stackView.spacing = 30
         stackView.axis = .horizontal
         stackView.translatesAutoresizingMaskIntoConstraints = false
         return stackView
@@ -84,16 +93,16 @@ final class MainCollectionViewCell: UICollectionViewCell {
 
     private func setUpConstraints() {
         NSLayoutConstraint.activate([
-            movieInformationStackView.topAnchor.constraint(equalTo: contentView.topAnchor),
-            movieInformationStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
-            movieInformationStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 25),
-            movieInformationStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
+            movieInformationStackView.topAnchor.constraint(equalTo: topAnchor, constant: 5),
+            movieInformationStackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -5),
+            movieInformationStackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 30),
+            movieInformationStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -20)
         ])
     }
     
     func setUpContent(_ movieInformation: MovieInformationDTO) {
         rankLabel.text = movieInformation.rank
-        rankIntenLabel.text = movieInformation.rankInten
+        rankIntenLabel.text = movieInformation.OldAndNew == "NEW" ? "신작" : movieInformation.rankInten
         movieNameLabel.text = movieInformation.movieName
         audienceCountLabel.text = movieInformation.audienceCount
     }

--- a/BoxOffice/View/MainCollectionViewCell.swift
+++ b/BoxOffice/View/MainCollectionViewCell.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class MainCollectionViewCell: UICollectionViewCell {
+final class MainCollectionViewCell: UICollectionViewListCell {
     static let reuseIdentifier = "cell"
     
     private let rankLabel: UILabel = {
@@ -52,6 +52,7 @@ final class MainCollectionViewCell: UICollectionViewCell {
         
         stackView.axis = .vertical
         stackView.spacing = 3
+        stackView.translatesAutoresizingMaskIntoConstraints = false
         return stackView
     }()
     
@@ -61,23 +62,16 @@ final class MainCollectionViewCell: UICollectionViewCell {
         stackView.axis = .vertical
         stackView.spacing = 3
         stackView.alignment = .leading
-        return stackView
-    }()
-    
-    private let movieInformationStackView: UIStackView = {
-        let stackView = UIStackView()
-        
-        stackView.spacing = 30
-        stackView.axis = .horizontal
         stackView.translatesAutoresizingMaskIntoConstraints = false
         return stackView
     }()
-        
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         
         configureUI()
         setUpConstraints()
+        setUpAccessory()
     }
     
     required init?(coder: NSCoder) {
@@ -101,16 +95,31 @@ extension MainCollectionViewCell {
     private func configureUI() {
         [rankLabel, rankIntenLabel].forEach { rankStackView.addArrangedSubview($0) }
         [movieNameLabel, audienceCountLabel].forEach { movieDescriptionStackView.addArrangedSubview($0) }
-        [rankStackView, movieDescriptionStackView].forEach { movieInformationStackView.addArrangedSubview($0) }
-        addSubview(movieInformationStackView)
+        [rankStackView, movieDescriptionStackView].forEach { addSubview($0) }
     }
     
     private func setUpConstraints() {
+        setUpRankStackViewConstraint()
+        setUpMovieDescriptionStackViewConstraint()
+    }
+    
+    private func setUpAccessory() {
+        accessories = [.disclosureIndicator()]
+    }
+    
+    private func setUpRankStackViewConstraint() {
         NSLayoutConstraint.activate([
-            movieInformationStackView.topAnchor.constraint(equalTo: topAnchor, constant: 5),
-            movieInformationStackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -5),
-            movieInformationStackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 30),
-            movieInformationStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -20)
+            rankStackView.centerXAnchor.constraint(equalTo: leadingAnchor, constant: 40),
+            rankStackView.centerYAnchor.constraint(equalTo: centerYAnchor)
+        ])
+    }
+    
+    private func setUpMovieDescriptionStackViewConstraint() {
+        NSLayoutConstraint.activate([
+            movieDescriptionStackView.topAnchor.constraint(equalTo: topAnchor, constant: 10),
+            movieDescriptionStackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -10),
+            movieDescriptionStackView.leadingAnchor.constraint(equalTo: rankStackView.trailingAnchor, constant: 30),
+            movieDescriptionStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -40)
         ])
     }
 }

--- a/BoxOffice/View/MainCollectionViewCell.swift
+++ b/BoxOffice/View/MainCollectionViewCell.swift
@@ -69,9 +69,8 @@ final class MainCollectionViewCell: UICollectionViewListCell {
     override init(frame: CGRect) {
         super.init(frame: frame)
         
-        configureUI()
-        setUpConstraints()
         setUpAccessory()
+        setUpLayout()
     }
     
     required init?(coder: NSCoder) {
@@ -92,29 +91,47 @@ final class MainCollectionViewCell: UICollectionViewListCell {
 
 // MARK: - Private
 extension MainCollectionViewCell {
-    private func configureUI() {
-        [rankLabel, rankIntenLabel].forEach { rankStackView.addArrangedSubview($0) }
-        [movieNameLabel, audienceCountLabel].forEach { movieDescriptionStackView.addArrangedSubview($0) }
-        [rankStackView, movieDescriptionStackView].forEach { addSubview($0) }
-    }
-    
-    private func setUpConstraints() {
-        setUpRankStackViewConstraint()
-        setUpMovieDescriptionStackViewConstraint()
-    }
-    
     private func setUpAccessory() {
         accessories = [.disclosureIndicator()]
     }
     
-    private func setUpRankStackViewConstraint() {
+    private func setUpLayout() {
+        setUpRankLabelLayout()
+        setUpRankIntenLabelLayout()
+        setUpMovieNameLabelLayout()
+        setUpAudienceCountLabelLayout()
+        setUpRankStackViewLayout()
+        setUpMovieDescriptionStackViewLayout()
+    }
+    
+    private func setUpRankLabelLayout() {
+        rankStackView.addArrangedSubview(rankLabel)
+    }
+    
+    private func setUpRankIntenLabelLayout() {
+        rankStackView.addArrangedSubview(rankIntenLabel)
+    }
+    
+    private func setUpMovieNameLabelLayout() {
+        movieDescriptionStackView.addArrangedSubview(movieNameLabel)
+    }
+    
+    private func setUpAudienceCountLabelLayout() {
+        movieDescriptionStackView.addArrangedSubview(audienceCountLabel)
+    }
+    
+    private func setUpRankStackViewLayout() {
+        addSubview(rankStackView)
+        
         NSLayoutConstraint.activate([
             rankStackView.centerXAnchor.constraint(equalTo: leadingAnchor, constant: 40),
             rankStackView.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
     }
     
-    private func setUpMovieDescriptionStackViewConstraint() {
+    private func setUpMovieDescriptionStackViewLayout() {
+        addSubview(movieDescriptionStackView)
+        
         NSLayoutConstraint.activate([
             movieDescriptionStackView.topAnchor.constraint(equalTo: topAnchor, constant: 10),
             movieDescriptionStackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -10),

--- a/BoxOffice/View/MainCollectionViewCell.swift
+++ b/BoxOffice/View/MainCollectionViewCell.swift
@@ -64,10 +64,22 @@ final class MainCollectionViewCell: UICollectionViewCell {
         return stackView
     }()
     
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        configureUI()
+        setUpConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     private func configureUI() {
         [rankLabel, rankIntenLabel].forEach { rankStackView.addArrangedSubview($0) }
         [movieNameLabel, audienceCountLabel].forEach { movieDescriptionStackView.addArrangedSubview($0) }
         [rankStackView, movieDescriptionStackView].forEach { movieInformationStackView.addArrangedSubview($0) }
+        addSubview(movieInformationStackView)
     }
 
     private func setUpConstraints() {

--- a/BoxOffice/View/MainCollectionViewCell.swift
+++ b/BoxOffice/View/MainCollectionViewCell.swift
@@ -90,7 +90,7 @@ final class MainCollectionViewCell: UICollectionViewCell {
         [rankStackView, movieDescriptionStackView].forEach { movieInformationStackView.addArrangedSubview($0) }
         addSubview(movieInformationStackView)
     }
-
+    
     private func setUpConstraints() {
         NSLayoutConstraint.activate([
             movieInformationStackView.topAnchor.constraint(equalTo: topAnchor, constant: 5),
@@ -98,6 +98,13 @@ final class MainCollectionViewCell: UICollectionViewCell {
             movieInformationStackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 30),
             movieInformationStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -20)
         ])
+    }
+    
+    private func addAttributeString(text: String, keyword: String, color: UIColor) -> NSMutableAttributedString {
+        let attributeString = NSMutableAttributedString(string: text)
+        
+        attributeString.addAttribute(.foregroundColor, value: UIColor.red , range: (text as NSString).range(of: keyword))
+        return attributeString
     }
     
     func setUpContent(_ movieInformation: MovieInformationDTO) {

--- a/BoxOffice/ViewController/MainViewController.swift
+++ b/BoxOffice/ViewController/MainViewController.swift
@@ -47,10 +47,8 @@ final class MainViewController: UIViewController, CanShowNetworkRequestFailureAl
     private lazy var collectionView: UICollectionView = {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: compositionalLayout)
         
-        collectionView.dataSource = diffableDataSource
         collectionView.refreshControl = refreshControl
         collectionView.translatesAutoresizingMaskIntoConstraints = false
-        collectionView.register(MainCollectionViewCell.self, forCellWithReuseIdentifier: MainCollectionViewCell.reuseIdentifier)
         return collectionView
     }()
     
@@ -101,13 +99,13 @@ final class MainViewController: UIViewController, CanShowNetworkRequestFailureAl
     }
     
     private func setUpDiffableDataSource() {
-        diffableDataSource = UICollectionViewDiffableDataSource<Section, MovieInformationDTO>(collectionView: collectionView, cellProvider: { collectionView, indexPath, movieInformation in
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MainCollectionViewCell.reuseIdentifier, for: indexPath) as? MainCollectionViewCell else {
-                return UICollectionViewCell()
-            }
+        let cellResgistration = UICollectionView.CellRegistration<MainCollectionViewCell, MovieInformationDTO> { cell, indexPath, movieInformation in
             
             cell.setUpContent(movieInformation)
-            return cell
+        }
+        
+        diffableDataSource = UICollectionViewDiffableDataSource<Section, MovieInformationDTO>(collectionView: collectionView, cellProvider: { collectionView, indexPath, movieInformation in
+            return collectionView.dequeueConfiguredReusableCell(using: cellResgistration, for: indexPath, item: movieInformation)
         })
     }
 }

--- a/BoxOffice/ViewController/MainViewController.swift
+++ b/BoxOffice/ViewController/MainViewController.swift
@@ -27,7 +27,7 @@ final class MainViewController: UIViewController, CanShowNetworkRequestFailureAl
         return formatter.string(from: yesterday)
     }()
     
-    private lazy var acitivityIndicatorView: UIActivityIndicatorView = {
+    private lazy var activityIndicatorView: UIActivityIndicatorView = {
         let activityIndicatorView = UIActivityIndicatorView()
         
         activityIndicatorView.center = view.center
@@ -43,7 +43,7 @@ final class MainViewController: UIViewController, CanShowNetworkRequestFailureAl
         return refreshControl
     }()
     
-    private let compositinalLayout: UICollectionViewCompositionalLayout = {
+    private let compositionalLayout: UICollectionViewCompositionalLayout = {
         var listConfiguration = UICollectionLayoutListConfiguration(appearance: .plain)
         
         listConfiguration.separatorConfiguration.bottomSeparatorInsets = .init(top: 0, leading: 0, bottom: 0, trailing: 0)
@@ -53,7 +53,7 @@ final class MainViewController: UIViewController, CanShowNetworkRequestFailureAl
     }()
     
     private lazy var collectionView: UICollectionView = {
-        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: compositinalLayout)
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: compositionalLayout)
         
         collectionView.dataSource = diffableDataSource
         collectionView.refreshControl = refreshControl
@@ -96,7 +96,7 @@ final class MainViewController: UIViewController, CanShowNetworkRequestFailureAl
     }
     
     private func configureUI() {
-        [collectionView, acitivityIndicatorView].forEach { view.addSubview($0) }
+        [collectionView, activityIndicatorView].forEach { view.addSubview($0) }
     }
     
     private func setUpConstraints() {
@@ -130,7 +130,7 @@ extension MainViewController: MainViewControllerUseCaseDelegate {
         DispatchQueue.main.async {
             self.diffableDataSource?.apply(snapShot)
             self.refreshControl.endRefreshing()
-            self.acitivityIndicatorView.stopAnimating()
+            self.activityIndicatorView.stopAnimating()
         }
     }
     

--- a/BoxOffice/ViewController/MainViewController.swift
+++ b/BoxOffice/ViewController/MainViewController.swift
@@ -30,8 +30,8 @@ final class MainViewController: UIViewController, CanShowNetworkRequestFailureAl
     
     private lazy var refreshControl: UIRefreshControl = {
         let refreshControl = UIRefreshControl()
-        let refreshAction = UIAction { _ in
-            self.setUpViewControllerContents()
+        let refreshAction = UIAction { [weak self] _ in
+            self?.setUpViewControllerContents()
         }
         
         refreshControl.addAction(refreshAction, for: .valueChanged)

--- a/BoxOffice/ViewController/MainViewController.swift
+++ b/BoxOffice/ViewController/MainViewController.swift
@@ -19,6 +19,14 @@ protocol MainViewControllerUseCaseDelegate: AnyObject {
 final class MainViewController: UIViewController, CanShowNetworkRequestFailureAlert {
     private let usecase: MainViewControllerUseCase
     
+    private let yesterdayDate: String = {
+        let yesterday = Date() - (24 * 60 * 60)
+        let formatter = DateFormatter()
+        
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: yesterday)
+    }()
+    
     private let compositinalLayout: UICollectionViewCompositionalLayout = {
         var listConfiguration = UICollectionLayoutListConfiguration(appearance: .plain)
         
@@ -59,8 +67,9 @@ final class MainViewController: UIViewController, CanShowNetworkRequestFailureAl
     
     private func setUpViewController() {
         view.backgroundColor = .systemBackground
+        navigationItem.title = yesterdayDate
         collectionView.dataSource = diffableDataSource
-        usecase.fetchDailyBoxOffice(targetDate: "20230315")
+        usecase.fetchDailyBoxOffice(targetDate: yesterdayDate.replacingOccurrences(of: "-", with: ""))
     }
     
     private func configureUI() {

--- a/BoxOffice/ViewController/MainViewController.swift
+++ b/BoxOffice/ViewController/MainViewController.swift
@@ -80,6 +80,7 @@ final class MainViewController: UIViewController, CanShowNetworkRequestFailureAl
                 return UICollectionViewCell()
             }
             
+            cell.setUpContent(movieInformation)
             return cell
         })
         

--- a/BoxOffice/ViewController/MainViewController.swift
+++ b/BoxOffice/ViewController/MainViewController.swift
@@ -7,6 +7,10 @@
 
 import UIKit
 
+enum Section {
+    case main
+}
+
 protocol MainViewControllerUseCaseDelegate: AnyObject {
     func completeFetchDailyBoxOfficeInformation(_ movieInformationDTOList: [MovieInformationDTO])
     func failFetchDailyBoxOfficeInformation(_ errorDescription: String?)
@@ -14,6 +18,22 @@ protocol MainViewControllerUseCaseDelegate: AnyObject {
 
 final class MainViewController: UIViewController, CanShowNetworkRequestFailureAlert {
     private let usecase: MainViewControllerUseCase
+    
+    private let compositinalLayout: UICollectionViewCompositionalLayout = {
+        var listConfiguration = UICollectionLayoutListConfiguration(appearance: .plain)
+        listConfiguration.separatorConfiguration.bottomSeparatorInsets = .init(top: 0, leading: 0, bottom: 0, trailing: 0)
+        
+        let compositionalLayout = UICollectionViewCompositionalLayout.list(using: listConfiguration)
+        return compositionalLayout
+    }()
+    
+    private lazy var collectionView: UICollectionView = {
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: compositinalLayout)
+        collectionView.translatesAutoresizingMaskIntoConstraints = false
+        return collectionView
+    }()
+    
+    private var diffableDataSource: UICollectionViewDiffableDataSource<Section, MovieInformationDTO>?
     
     init(_ usecase: MainViewControllerUseCase) {
         self.usecase = usecase
@@ -30,20 +50,29 @@ final class MainViewController: UIViewController, CanShowNetworkRequestFailureAl
         
         configureUI()
         setUpConstraints()
-        setUpBackgroundColor()
+        setUpViewController()
+        setUpDiffableDataSource()
     }
     
-    private func setUpBackgroundColor() {
+    private func setUpViewController() {
         view.backgroundColor = .systemBackground
+        collectionView.dataSource = diffableDataSource
     }
     
     private func configureUI() {
+        view.addSubview(collectionView)
     }
     
     private func setUpConstraints() {
         NSLayoutConstraint.activate([
-            
+            collectionView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            collectionView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            collectionView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            collectionView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
         ])
+    }
+    
+    private func setUpDiffableDataSource() {
     }
 }
 

--- a/BoxOffice/ViewController/MainViewController.swift
+++ b/BoxOffice/ViewController/MainViewController.swift
@@ -30,6 +30,7 @@ final class MainViewController: UIViewController, CanShowNetworkRequestFailureAl
     private lazy var collectionView: UICollectionView = {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: compositinalLayout)
         collectionView.translatesAutoresizingMaskIntoConstraints = false
+        collectionView.register(MainCollectionViewCell.self, forCellWithReuseIdentifier: MainCollectionViewCell.reuseIdentifier)
         return collectionView
     }()
     

--- a/BoxOffice/ViewController/MainViewController.swift
+++ b/BoxOffice/ViewController/MainViewController.swift
@@ -7,16 +7,16 @@
 
 import UIKit
 
-enum Section {
-    case main
-}
-
 protocol MainViewControllerUseCaseDelegate: AnyObject {
     func completeFetchDailyBoxOfficeInformation(_ movieInformationDTOList: [MovieInformationDTO])
     func failFetchDailyBoxOfficeInformation(_ errorDescription: String?)
 }
 
 final class MainViewController: UIViewController, CanShowNetworkRequestFailureAlert {
+    enum Section {
+        case main
+    }
+
     private let usecase: MainViewControllerUseCase
     
     private lazy var activityIndicatorView: UIActivityIndicatorView = {

--- a/BoxOffice/ViewController/MainViewController.swift
+++ b/BoxOffice/ViewController/MainViewController.swift
@@ -19,14 +19,6 @@ protocol MainViewControllerUseCaseDelegate: AnyObject {
 final class MainViewController: UIViewController, CanShowNetworkRequestFailureAlert {
     private let usecase: MainViewControllerUseCase
     
-    private let yesterdayDate: String = {
-        let yesterday = Date() - (24 * 60 * 60)
-        let formatter = DateFormatter()
-        
-        formatter.dateFormat = "yyyy-MM-dd"
-        return formatter.string(from: yesterday)
-    }()
-    
     private lazy var activityIndicatorView: UIActivityIndicatorView = {
         let activityIndicatorView = UIActivityIndicatorView()
         
@@ -86,11 +78,11 @@ final class MainViewController: UIViewController, CanShowNetworkRequestFailureAl
     
     private func setUpViewController() {
         view.backgroundColor = .systemBackground
-        navigationItem.title = yesterdayDate
+        navigationItem.title = usecase.yesterdayDate
     }
     
     @objc private func setUpViewControllerContents() {
-        let targetDate = yesterdayDate.replacingOccurrences(of: "-", with: "")
+        let targetDate = usecase.yesterdayDate.replacingOccurrences(of: "-", with: "")
         
         usecase.fetchDailyBoxOffice(targetDate: targetDate)
     }

--- a/BoxOffice/ViewController/MainViewController.swift
+++ b/BoxOffice/ViewController/MainViewController.swift
@@ -58,6 +58,7 @@ final class MainViewController: UIViewController, CanShowNetworkRequestFailureAl
     private func setUpViewController() {
         view.backgroundColor = .systemBackground
         collectionView.dataSource = diffableDataSource
+        usecase.fetchDailyBoxOffice(targetDate: "20230105")
     }
     
     private func configureUI() {
@@ -74,13 +75,29 @@ final class MainViewController: UIViewController, CanShowNetworkRequestFailureAl
     }
     
     private func setUpDiffableDataSource() {
+        diffableDataSource = UICollectionViewDiffableDataSource<Section, MovieInformationDTO>(collectionView: collectionView, cellProvider: { collectionView, indexPath, movieInformation in
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MainCollectionViewCell.reuseIdentifier, for: indexPath) as? MainCollectionViewCell else {
+                return UICollectionViewCell()
+            }
+            
+            return cell
+        })
+        
+        guard var snapShot = diffableDataSource?.snapshot() else { return }
+        snapShot.appendSections([.main])
+        diffableDataSource?.apply(snapShot)
     }
 }
 
 // MARK: - MainViewControllerUseCaseDelegate
 extension MainViewController: MainViewControllerUseCaseDelegate {
     func completeFetchDailyBoxOfficeInformation(_ movieInformationDTOList: [MovieInformationDTO]) {
-        print(movieInformationDTOList)
+        guard var snapShot = diffableDataSource?.snapshot() else { return }
+        
+        snapShot.appendItems(movieInformationDTOList)
+        DispatchQueue.main.async {
+            self.diffableDataSource?.apply(snapShot)
+        }
     }
     
     func failFetchDailyBoxOfficeInformation(_ errorDescription: String?) {

--- a/BoxOffice/ViewController/MainViewController.swift
+++ b/BoxOffice/ViewController/MainViewController.swift
@@ -123,7 +123,7 @@ extension MainViewController: MainViewControllerUseCaseDelegate {
             self.diffableDataSource?.apply(snapShot)
             self.refreshControl.endRefreshing()
             
-            if self.activityIndicatorView.isAnimating { self.activityIndicatorView.stopAnimating() }
+            self.activityIndicatorView.stopAnimating()
         }
     }
     
@@ -132,7 +132,7 @@ extension MainViewController: MainViewControllerUseCaseDelegate {
             self.refreshControl.endRefreshing()
             self.showNetworkFailAlert(message: errorDescription, retryFunction: self.setUpViewControllerContents)
             
-            if self.activityIndicatorView.isAnimating { self.activityIndicatorView.stopAnimating() }
+            self.activityIndicatorView.stopAnimating()
         }
     }
 }

--- a/BoxOffice/ViewController/MainViewController.swift
+++ b/BoxOffice/ViewController/MainViewController.swift
@@ -113,6 +113,14 @@ final class MainViewController: UIViewController, CanShowNetworkRequestFailureAl
             return cell
         })
     }
+    
+    private func stopRefreshing() {
+        self.refreshControl.endRefreshing()
+        
+        if self.activityIndicatorView.isAnimating {
+            self.activityIndicatorView.stopAnimating()
+        }
+    }
 }
 
 // MARK: - MainViewControllerUseCaseDelegate
@@ -125,16 +133,14 @@ extension MainViewController: MainViewControllerUseCaseDelegate {
         diffableDataSource?.apply(snapShot)
         
         DispatchQueue.main.async {
-            self.refreshControl.endRefreshing()
-            self.activityIndicatorView.stopAnimating()
+            self.stopRefreshing()
         }
     }
     
     func failFetchDailyBoxOfficeInformation(_ errorDescription: String?) {
         DispatchQueue.main.async {
-            self.refreshControl.endRefreshing()
+            self.stopRefreshing()
             self.showNetworkFailAlert(message: errorDescription, retryFunction: self.setUpViewControllerContents)
-            self.activityIndicatorView.stopAnimating()
         }
     }
 }

--- a/BoxOffice/ViewController/MainViewController.swift
+++ b/BoxOffice/ViewController/MainViewController.swift
@@ -122,10 +122,10 @@ extension MainViewController: MainViewControllerUseCaseDelegate {
         
         snapShot.appendSections([.main])
         snapShot.appendItems(movieInformationDTOList)
+        diffableDataSource?.apply(snapShot)
+        
         DispatchQueue.main.async {
-            self.diffableDataSource?.apply(snapShot)
             self.refreshControl.endRefreshing()
-            
             self.activityIndicatorView.stopAnimating()
         }
     }
@@ -134,7 +134,6 @@ extension MainViewController: MainViewControllerUseCaseDelegate {
         DispatchQueue.main.async {
             self.refreshControl.endRefreshing()
             self.showNetworkFailAlert(message: errorDescription, retryFunction: self.setUpViewControllerContents)
-            
             self.activityIndicatorView.stopAnimating()
         }
     }

--- a/BoxOffice/ViewController/MainViewController.swift
+++ b/BoxOffice/ViewController/MainViewController.swift
@@ -130,7 +130,8 @@ extension MainViewController: MainViewControllerUseCaseDelegate {
         DispatchQueue.main.async {
             self.diffableDataSource?.apply(snapShot)
             self.refreshControl.endRefreshing()
-            self.activityIndicatorView.stopAnimating()
+            
+            if self.activityIndicatorView.isAnimating { self.activityIndicatorView.stopAnimating() }
         }
     }
     
@@ -138,6 +139,8 @@ extension MainViewController: MainViewControllerUseCaseDelegate {
         DispatchQueue.main.async {
             self.refreshControl.endRefreshing()
             self.showNetworkFailAlert(message: errorDescription, retryFunction: self.setUpViewControllerContents)
+            
+            if self.activityIndicatorView.isAnimating { self.activityIndicatorView.stopAnimating() }
         }
     }
 }

--- a/BoxOffice/ViewController/MainViewController.swift
+++ b/BoxOffice/ViewController/MainViewController.swift
@@ -21,6 +21,7 @@ final class MainViewController: UIViewController, CanShowNetworkRequestFailureAl
     
     private let compositinalLayout: UICollectionViewCompositionalLayout = {
         var listConfiguration = UICollectionLayoutListConfiguration(appearance: .plain)
+        
         listConfiguration.separatorConfiguration.bottomSeparatorInsets = .init(top: 0, leading: 0, bottom: 0, trailing: 0)
         
         let compositionalLayout = UICollectionViewCompositionalLayout.list(using: listConfiguration)
@@ -29,6 +30,7 @@ final class MainViewController: UIViewController, CanShowNetworkRequestFailureAl
     
     private lazy var collectionView: UICollectionView = {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: compositinalLayout)
+        
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         collectionView.register(MainCollectionViewCell.self, forCellWithReuseIdentifier: MainCollectionViewCell.reuseIdentifier)
         return collectionView
@@ -58,7 +60,7 @@ final class MainViewController: UIViewController, CanShowNetworkRequestFailureAl
     private func setUpViewController() {
         view.backgroundColor = .systemBackground
         collectionView.dataSource = diffableDataSource
-        usecase.fetchDailyBoxOffice(targetDate: "20230105")
+        usecase.fetchDailyBoxOffice(targetDate: "20230315")
     }
     
     private func configureUI() {

--- a/BoxOffice/ViewController/MainViewController.swift
+++ b/BoxOffice/ViewController/MainViewController.swift
@@ -9,53 +9,11 @@ import UIKit
 
 protocol MainViewControllerUseCaseDelegate: AnyObject {
     func completeFetchDailyBoxOfficeInformation(_ movieInformationDTOList: [MovieInformationDTO])
-    func completeFetchMovieDetailInformation(_ movieDetailResult: MovieDetailResult)
     func failFetchDailyBoxOfficeInformation(_ errorDescription: String?)
-    func failFetchMovieDetailInformaion(_ errorDescription: String?)
 }
 
 final class MainViewController: UIViewController, CanShowNetworkRequestFailureAlert {
     private let usecase: MainViewControllerUseCase
-    
-    private lazy var requestMovieDetailInformationButton: UIButton = {
-        let button = UIButton()
-        
-        button.setTitle("영화 개별 상세 조회", for: .normal)
-        button.setTitleColor(.black, for: .normal)
-        button.backgroundColor = .yellow
-        button.addTarget(self, action: #selector(didTappedRequestMovieDetailInformationButton), for: .touchUpInside)
-        return button
-    }()
-    
-    private lazy var requestMovieDailyInformationButton: UIButton = {
-        let button = UIButton()
-        
-        button.setTitle("오늘의 일일 박스오피스 조회", for: .normal)
-        button.setTitleColor(.black, for: .normal)
-        button.backgroundColor = .orange
-        button.addTarget(self, action: #selector(didTappedRequestMovieDailyInformationButton), for: .touchUpInside)
-        return button
-    }()
-    
-    private lazy var networkRequestFailureButton: UIButton = {
-        let button = UIButton()
-        
-        button.setTitle("네트워크 요청 실패 버튼", for: .normal)
-        button.setTitleColor(.black, for: .normal)
-        button.backgroundColor = .red
-        button.addTarget(self, action: #selector(didTappedNetworkRequestFailureButton), for: .touchUpInside)
-        return button
-    }()
-    
-    private let stackView: UIStackView = {
-        let stackView = UIStackView()
-        
-        stackView.axis = .vertical
-        stackView.distribution = .fillEqually
-        stackView.spacing = 5
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        return stackView
-    }()
     
     init(_ usecase: MainViewControllerUseCase) {
         self.usecase = usecase
@@ -80,14 +38,11 @@ final class MainViewController: UIViewController, CanShowNetworkRequestFailureAl
     }
     
     private func configureUI() {
-        [requestMovieDetailInformationButton, requestMovieDailyInformationButton, networkRequestFailureButton].forEach { stackView.addArrangedSubview($0) }
-        view.addSubview(stackView)
     }
     
     private func setUpConstraints() {
         NSLayoutConstraint.activate([
-            stackView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            stackView.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+            
         ])
     }
 }
@@ -98,43 +53,9 @@ extension MainViewController: MainViewControllerUseCaseDelegate {
         print(movieInformationDTOList)
     }
     
-    func completeFetchMovieDetailInformation(_ movieDetailResult: MovieDetailResult) {
-        print(movieDetailResult)
-    }
-    
     func failFetchDailyBoxOfficeInformation(_ errorDescription: String?) {
         DispatchQueue.main.async {
-            self.showNetworkFailAlert(message: errorDescription, retryFunction: self.fetchDailyBoxOfficeForTest)
+//            self.showNetworkFailAlert(message: errorDescription, retryFunction: self.fetchDailyBoxOfficeForTest)
         }
-    }
-    
-    func failFetchMovieDetailInformaion(_ errorDescription: String?) {
-        print("\(errorDescription ?? "")")
-    }
-}
-
-// MARK: - Button Action
-extension MainViewController {
-    @objc private func didTappedRequestMovieDetailInformationButton() {
-        let movieCode = "20228543"
-        
-        usecase.fetchMovieDetailInformation(movieCode: movieCode)
-    }
-    
-    @objc private func didTappedRequestMovieDailyInformationButton() {
-        let tagerDate = "20230723"
-        
-        usecase.fetchDailyBoxOffice(targetDate: tagerDate)
-    }
-}
-
-// MARK: - Test Button Action
-extension MainViewController {
-    private func fetchDailyBoxOfficeForTest() {
-        usecase.fetchDailyBoxOffice(targetDate: "")
-    }
-    
-    @objc private func didTappedNetworkRequestFailureButton() {
-        fetchDailyBoxOfficeForTest()
     }
 }

--- a/BoxOffice/ViewController/MainViewController.swift
+++ b/BoxOffice/ViewController/MainViewController.swift
@@ -55,6 +55,7 @@ final class MainViewController: UIViewController, CanShowNetworkRequestFailureAl
     private lazy var collectionView: UICollectionView = {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: compositinalLayout)
         
+        collectionView.dataSource = diffableDataSource
         collectionView.refreshControl = refreshControl
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         collectionView.register(MainCollectionViewCell.self, forCellWithReuseIdentifier: MainCollectionViewCell.reuseIdentifier)
@@ -86,7 +87,6 @@ final class MainViewController: UIViewController, CanShowNetworkRequestFailureAl
     private func setUpViewController() {
         view.backgroundColor = .systemBackground
         navigationItem.title = yesterdayDate
-        collectionView.dataSource = diffableDataSource
     }
     
     @objc private func setUpViewControllerContents() {

--- a/BoxOffice/ViewController/MainViewController.swift
+++ b/BoxOffice/ViewController/MainViewController.swift
@@ -16,7 +16,7 @@ final class MainViewController: UIViewController, CanShowNetworkRequestFailureAl
     enum Section {
         case main
     }
-
+    
     private let usecase: MainViewControllerUseCase
     
     private lazy var activityIndicatorView: UIActivityIndicatorView = {
@@ -30,8 +30,11 @@ final class MainViewController: UIViewController, CanShowNetworkRequestFailureAl
     
     private lazy var refreshControl: UIRefreshControl = {
         let refreshControl = UIRefreshControl()
+        let refreshAction = UIAction { _ in
+            self.setUpViewControllerContents()
+        }
         
-        refreshControl.addTarget(self, action: #selector(setUpViewControllerContents), for: .valueChanged)
+        refreshControl.addAction(refreshAction, for: .valueChanged)
         return refreshControl
     }()
     
@@ -81,7 +84,7 @@ final class MainViewController: UIViewController, CanShowNetworkRequestFailureAl
         navigationItem.title = usecase.yesterdayDate
     }
     
-    @objc private func setUpViewControllerContents() {
+    private func setUpViewControllerContents() {
         let targetDate = usecase.yesterdayDate.replacingOccurrences(of: "-", with: "")
         
         usecase.fetchDailyBoxOffice(targetDate: targetDate)

--- a/BoxOffice/ViewController/MainViewController.swift
+++ b/BoxOffice/ViewController/MainViewController.swift
@@ -137,7 +137,7 @@ extension MainViewController: MainViewControllerUseCaseDelegate {
     func failFetchDailyBoxOfficeInformation(_ errorDescription: String?) {
         DispatchQueue.main.async {
             self.refreshControl.endRefreshing()
-//            self.showNetworkFailAlert(message: errorDescription, retryFunction: self.fetchDailyBoxOfficeForTest)
+            self.showNetworkFailAlert(message: errorDescription, retryFunction: self.setUpViewControllerContents)
         }
     }
 }

--- a/MovieInformationDtoTests/MovieInformationDTOTests.swift
+++ b/MovieInformationDtoTests/MovieInformationDTOTests.swift
@@ -1,0 +1,40 @@
+//
+//  MovieInformationDtoTests.swift
+//  MovieInformationDtoTests
+//
+//  Created by Zion, Hemg on 2023/08/07.
+//
+
+import XCTest
+@testable import BoxOffice
+
+final class MovieInformationDTOTests: XCTestCase {
+    private var sut: MovieInformationDTO!
+
+    override func setUpWithError() throws {
+        sut = MovieInformationDTO(rank: "1",
+                                  rankInten: "1",
+                                  oldAndNew: "NEW",
+                                  movieName: "밀수",
+                                  audienceCount: "450000",
+                                  audienceAccumulate: "6000000")
+    }
+    
+    override func tearDownWithError() throws {
+        sut = nil
+    }
+    
+    func test_DecimalCount가_converted함수에적용이되는지_확인() {
+        //given
+        let audienceCountExpectation = "450,000"
+        let audienceAccumulateExpectation = "6,000,000"
+        
+        //when
+        let audienceCountResult = sut.convertDecimalFormattedString(text: sut.audienceCount)
+        let audienceAccumulateResult = sut.convertDecimalFormattedString(text: sut.audienceAccumulate)
+        
+        //then
+        XCTAssertEqual(audienceCountExpectation, audienceCountResult)
+        XCTAssertEqual(audienceAccumulateExpectation, audienceAccumulateResult)
+    }
+}

--- a/MovieInformationDtoTests/MovieInformationDTOTests.swift
+++ b/MovieInformationDtoTests/MovieInformationDTOTests.swift
@@ -37,4 +37,77 @@ final class MovieInformationDTOTests: XCTestCase {
         XCTAssertEqual(audienceCountExpectation, audienceCountResult)
         XCTAssertEqual(audienceAccumulateExpectation, audienceAccumulateResult)
     }
+    
+    func test_OldAndNew가_New로되있을시_신작으로표시되는지_확인() {
+        //given
+        let expectiontation = addAttributeString(text: "신작", keyword: "신작", color: .red)
+        
+        //when
+        let result = sut.conventedRankIntenSybolAndText()
+        
+        //then
+        XCTAssertEqual(expectiontation, result)
+    }
+    
+    func test_OldAndNew가_OLD로되있을시_상승rank로_표시되는지_확인() {
+        //given
+        sut = MovieInformationDTO(rank: "1",
+                                  rankInten: "1",
+                                  oldAndNew: "OLD",
+                                  movieName: "밀수",
+                                  audienceCount: "450000",
+                                  audienceAccumulate: "6000000")
+        
+        let expectiontation = addAttributeString(text: "▲\(sut.rankInten)", keyword: "▲", color: .red)
+        
+        //when
+        let result = sut.conventedRankIntenSybolAndText()
+        
+        //then
+        XCTAssertEqual(expectiontation, result)
+    }
+    
+    func test_OldAndNew가_OLD로되있을시_하락rank로_표시되는지_확인() {
+        //given
+        sut = MovieInformationDTO(rank: "10",
+                                  rankInten: "-3",
+                                  oldAndNew: "OLD",
+                                  movieName: "밀수",
+                                  audienceCount: "450000",
+                                  audienceAccumulate: "6000000")
+        
+        let decreaseRank = sut.rankInten.replacingOccurrences(of: "-", with: "")
+        let expectiontation = addAttributeString(text: "▼\(decreaseRank)", keyword: "▼", color: .blue)
+        
+        //when
+        let result = sut.conventedRankIntenSybolAndText()
+        
+        //then
+        XCTAssertEqual(expectiontation, result)
+    }
+    
+    func test_OldAndNew가_OLD로되있을시_동일Rank로_표시되는지_확인() {
+        //given
+        sut = MovieInformationDTO(rank: "10",
+                                  rankInten: "0",
+                                  oldAndNew: "OLD",
+                                  movieName: "밀수",
+                                  audienceCount: "450000",
+                                  audienceAccumulate: "6000000")
+        
+        let expectiontation = addAttributeString(text: "-", keyword: "-", color: .black)
+        
+        //when
+        let result = sut.conventedRankIntenSybolAndText()
+        
+        //then
+        XCTAssertEqual(expectiontation, result)
+    }
+    
+    private func addAttributeString(text: String, keyword: String, color: UIColor) -> NSMutableAttributedString {
+        let attributeString = NSMutableAttributedString(string: text)
+        
+        attributeString.addAttribute(.foregroundColor, value: color , range: (text as NSString).range(of: keyword))
+        return attributeString
+    }
 }


### PR DESCRIPTION
안녕하세요 올라프(@1Consumption)!
박스오피스 STEP3 구현을 진행했습니다.
상세한 리뷰 항상 감사드립니다.
이번에도 잘 부탁드립니다.

## 고민했던 점
### global function에서의 순환참조
global function에서의 타입에 대한 참조는 reference Count를 증가시키지 않습니다.

> Global functions are closures that have a name and don’t capture any values.

왜냐하면 `global function`에서는 어떠한 값도 `capture`하지 않기 때문입니다.
`global capture`에서 값을 캡쳐하지 않아도 되는 이유는 클로저에서 값을 캡처하는 이유는 상수와 변수를 정의한 원래 범위가 더이상 존재하지 않더라도 클로저 내에서 해당 상수와 변수의 값을 참조하고 수정하기 위해서 캡처가 필요하지만, 전역에서 정의된 클로저의 경우 상수와 변수가 정의된 범위가 존재하지 않을 수 없습니다 따라서 `capture`가 필요하지 않습니다.

일반적으로 순환참조가 발생하는 경우는 해당 클로저를 특정 타입에서 참조하고 있고 그 클로저에서 타입을 캡쳐해서 참조하기 때문에 순환참조가 발생합니다. 캡쳐하는 순간 `Strong Reference`로 참조하기 때문입니다. 하지만 `global function`는 어떠한 값도 `capture`하지 않는 클로저 이므로 `reference count` 또한 증가시키지 않기 때문에 `[weak self]` 키워드를 붙이지 않아도 순환참조가 발생하지 않습니다.



<참고 자료>
[Closure docs](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/closures/)
[StackOverFlow](https://stackoverflow.com/questions/49239990/why-swift-global-functions-as-a-special-case-of-closures-capture-global-variable)

### 날짜 표시
```swift
private let dateFormatter: DateFormatter = {
        let formatter = DateFormatter()
        formatter.locale = Locale(identifier: "ko_kr")
        formatter.dateFormat = "yyyy-MM-dd"
        return formatter
    }()
    
    private var dateString: String {
        let dataString = dateFormatter.string(from: Date())
        let removeString = dataString.components(separatedBy: ["-"]).joined()
        let change = String((Int(removeString) ?? 0) - 1)
        return change
    }
```  
-  위와 같은 코드로 진행하여 Formatter를 생성후 변환을 하여 `NavigationBar`의 날짜와 `어제`의 박스오피스 순위를 가져오게 진행 하게끔했습니다. 이렇게하면 2개의 프로퍼티 생성을 진행하게 되어 좋지않을꺼라는 생각을 하게 되었으며 다른 방법을 생각 하게 되었습니다.
```swift
 private let yesterdayDate: String = {
        let yesterday = Date() - (24 * 60 * 60)
        let formatter = DateFormatter()
        
        formatter.dateFormat = "yyyy-MM-dd"
        return formatter.string(from: yesterday)
    }()

    lldb po Date() 
    2023-08-04 07:01:02 +0000
  - timeIntervalSinceReferenceDate : 712825262.9015
```    
- `Date()`에는 timeIntervalSinceReferenceDate값을 알게되었고  이값으로 날짜 조정이 가능한점을 알게 되어 간단하게 1개의 프로퍼티 생성으로 날짜 표현을 진행했습니다.
    
## 조언을 얻고 싶은 부분
### DiffableDataSource 사용시 메모리 누수
| deleteAllItems를 하고 새로 추가하는 경우 | SnapShot을 새롭게 만들어 apply 하는 경우 |
| :-: | :-: |
| <img src="https://cdn.discordapp.com/attachments/1136463230886215751/1136926200422465616/deleteDiffable.gif" width="500"/> | <img src="https://cdn.discordapp.com/attachments/1136463230886215751/1136926200820932619/newDataDiffable.gif" width="500"/> |

- `DailyBoxOffice`의 정보를 가져와서 `diffableDataSource`의 `snapShot`을 생성할 때 `NSDiffableDataSource`에서 `SnapShot`을 생성하는 2가지 방법중 `snapShot`을 새로 만들어서 `diffableDataSource`에 `apply`해주는 방법을 적용했습니다. 기존의 스냅샷을 삭제 및 추가 변경하는 것이 아닌 새롭게 데이터를 받아 `reload` 해줘야했기 때문입니다. 따라서 새롭게 `sanpShot`을 만들어 `section`과 `item`을 추가 하고 `apply`할 때 마다 메모리가 누수되지 않는지 고민하게 되었고 디버깅 툴을 사용해 확인해본 결과 `reload`를 할 때마다 사용하고 있는 메모리가 점점 상승해서 해제되지 않는 현상을 발견하게 되었습니다. 이러한 현상은 기존의 `snapShot`을 받아온뒤 `deleteAllItems`을 하고 다시 `item`을 추가해주는 방식을 사용해도 동일한 현상이 발생하고 있었습니다.

    위와 같은 메모리 누수 현상을 해결할 수 있는 방법을 알고 싶습니다. 

<참고 자료>
[NSDiffableSnaptShot docs](https://developer.apple.com/documentation/uikit/nsdiffabledatasourcesnapshot)

### Animation도중 Animation이 끼어드는 경우
<img src="https://hackmd.io/_uploads/ry2oBI5oh.gif" width="500"/> 

targetDate를 임의로 빈문자열("")로 부여하여 의도적으로 오류를 발생시켜 팝업을 노출시킨 상황에서 RrefreshControl을 사용하여 CollectionView를 Refresh하게 되는 경우 종종 endRefreshing이 호출되었음에도 위의 예시화면처럼 endRefreshing동작을 하지 않는 다는 것을 발견했습니다.

저는 해당 이슈의 원인을 여러가지 애니메이션 메서드가 동시에 호출되어서 endRefreshing 애니메이션 메서드가 호출되어 실행되는 도중에 다른 애니메이션 메서드가 끼어들어서 endRefreshing 동작을 제대로 수행하지 못했다고 생각합니다. 따라서 도중에 여러가지 애니메이션 메서드가 호출되는 것을 방지하기위해 이에따른 예외처리를 구현했습니다. (96199c0f2bfe3ea6ca6eabb38d3ddcbf0a45d3b0)

하지만 이와 같은 커밋의 수정은 근본적인 해결책이 될 수 없다고 생각합니다. 또한 앞으로 코드를 작성하면서 반드시 겪을 상황이라고 생각합니다.

위와 같은 이슈의 근본적인 원인과 이를 해결할 수 있는 방법에 대해 조언을 구하고 싶습니다.

----
