### PR TITLE
박스오피스 [STEP 3] Dasan, Whales

### DIFF
--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -480,7 +480,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -508,7 +508,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		3C35A80D2A6F9937008BB5C2 /* DecodingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C35A80C2A6F9937008BB5C2 /* DecodingManager.swift */; };
 		3C35A80F2A6F9A17008BB5C2 /* DataError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C35A80E2A6F9A17008BB5C2 /* DataError.swift */; };
+		3CB38E9A2A7FEB6C0070E63C /* TargetDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CB38E992A7FEB6C0070E63C /* TargetDate.swift */; };
 		3CF5610B2A73D30F0048D14D /* URLConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF5610A2A73D30F0048D14D /* URLConfigurable.swift */; };
 		3CF5610D2A73D3540048D14D /* KobisOpenAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF5610C2A73D3540048D14D /* KobisOpenAPI.swift */; };
 		3CF5610F2A73E7830048D14D /* URL+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF5610E2A73E7830048D14D /* URL+.swift */; };
@@ -41,6 +42,7 @@
 /* Begin PBXFileReference section */
 		3C35A80C2A6F9937008BB5C2 /* DecodingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodingManager.swift; sourceTree = "<group>"; };
 		3C35A80E2A6F9A17008BB5C2 /* DataError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataError.swift; sourceTree = "<group>"; };
+		3CB38E992A7FEB6C0070E63C /* TargetDate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetDate.swift; sourceTree = "<group>"; };
 		3CF5610A2A73D30F0048D14D /* URLConfigurable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLConfigurable.swift; sourceTree = "<group>"; };
 		3CF5610C2A73D3540048D14D /* KobisOpenAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KobisOpenAPI.swift; sourceTree = "<group>"; };
 		3CF5610E2A73E7830048D14D /* URL+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+.swift"; sourceTree = "<group>"; };
@@ -185,6 +187,7 @@
 				3C35A80C2A6F9937008BB5C2 /* DecodingManager.swift */,
 				AC11E7E42A729FE3008A84B0 /* NetworkManager.swift */,
 				3CF5610E2A73E7830048D14D /* URL+.swift */,
+				3CB38E992A7FEB6C0070E63C /* TargetDate.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -312,6 +315,7 @@
 				AC02E17C2A6F703D00C6A91B /* BoxOffice.swift in Sources */,
 				3C35A80F2A6F9A17008BB5C2 /* DataError.swift in Sources */,
 				3CF5610F2A73E7830048D14D /* URL+.swift in Sources */,
+				3CB38E9A2A7FEB6C0070E63C /* TargetDate.swift in Sources */,
 				3CF561352A77C9480048D14D /* NetworkError.swift in Sources */,
 				3CF5610B2A73D30F0048D14D /* URLConfigurable.swift in Sources */,
 				3C35A80D2A6F9937008BB5C2 /* DecodingManager.swift in Sources */,

--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		AC11E7E52A729FE3008A84B0 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC11E7E42A729FE3008A84B0 /* NetworkManager.swift */; };
 		AC9BDB3E2A78D083000FA75F /* KobisAPIKey.plist in Resources */ = {isa = PBXBuildFile; fileRef = AC9BDB3D2A78D083000FA75F /* KobisAPIKey.plist */; };
 		ACDC76492A7D4DAA00D324E5 /* BoxOfficeCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACDC76482A7D4DAA00D324E5 /* BoxOfficeCell.swift */; };
+		ACF5C62E2A811956005CB910 /* BoxOfficeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACF5C62D2A811956005CB910 /* BoxOfficeManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -66,6 +67,7 @@
 		AC2C7AF12A6FC21C000CD35F /* BoxOffice.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = BoxOffice.xctestplan; sourceTree = "<group>"; };
 		AC9BDB3D2A78D083000FA75F /* KobisAPIKey.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = KobisAPIKey.plist; sourceTree = "<group>"; };
 		ACDC76482A7D4DAA00D324E5 /* BoxOfficeCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxOfficeCell.swift; sourceTree = "<group>"; };
+		ACF5C62D2A811956005CB910 /* BoxOfficeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxOfficeManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -94,6 +96,7 @@
 				3CF5610A2A73D30F0048D14D /* URLConfigurable.swift */,
 				3CF5610C2A73D3540048D14D /* KobisOpenAPI.swift */,
 				3CF561372A78D79F0048D14D /* Bundle+.swift */,
+				ACF5C62D2A811956005CB910 /* BoxOfficeManager.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -318,6 +321,7 @@
 				AC02E17C2A6F703D00C6A91B /* BoxOffice.swift in Sources */,
 				3C35A80F2A6F9A17008BB5C2 /* DataError.swift in Sources */,
 				3CF5610F2A73E7830048D14D /* URL+.swift in Sources */,
+				ACF5C62E2A811956005CB910 /* BoxOfficeManager.swift in Sources */,
 				3CB38E9A2A7FEB6C0070E63C /* TargetDate.swift in Sources */,
 				3CF561352A77C9480048D14D /* NetworkError.swift in Sources */,
 				3CB38E9C2A7FF7690070E63C /* CountFormatter.swift in Sources */,

--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		AC11E7DF2A729341008A84B0 /* Movie.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC11E7DE2A729341008A84B0 /* Movie.swift */; };
 		AC11E7E52A729FE3008A84B0 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC11E7E42A729FE3008A84B0 /* NetworkManager.swift */; };
 		AC9BDB3E2A78D083000FA75F /* KobisAPIKey.plist in Resources */ = {isa = PBXBuildFile; fileRef = AC9BDB3D2A78D083000FA75F /* KobisAPIKey.plist */; };
+		ACDC76492A7D4DAA00D324E5 /* BoxOfficeCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACDC76482A7D4DAA00D324E5 /* BoxOfficeCell.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -60,6 +61,7 @@
 		AC11E7E42A729FE3008A84B0 /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
 		AC2C7AF12A6FC21C000CD35F /* BoxOffice.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = BoxOffice.xctestplan; sourceTree = "<group>"; };
 		AC9BDB3D2A78D083000FA75F /* KobisAPIKey.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = KobisAPIKey.plist; sourceTree = "<group>"; };
+		ACDC76482A7D4DAA00D324E5 /* BoxOfficeCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxOfficeCell.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -97,6 +99,7 @@
 			children = (
 				63DF20F42970E1A0005DF7D1 /* Main.storyboard */,
 				63DF20F92970E1A1005DF7D1 /* LaunchScreen.storyboard */,
+				ACDC76482A7D4DAA00D324E5 /* BoxOfficeCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -303,6 +306,7 @@
 				AC11E7DF2A729341008A84B0 /* Movie.swift in Sources */,
 				63DF20EF2970E1A0005DF7D1 /* AppDelegate.swift in Sources */,
 				63DF20F12970E1A0005DF7D1 /* SceneDelegate.swift in Sources */,
+				ACDC76492A7D4DAA00D324E5 /* BoxOfficeCell.swift in Sources */,
 				3CF561382A78D79F0048D14D /* Bundle+.swift in Sources */,
 				AC11E7E52A729FE3008A84B0 /* NetworkManager.swift in Sources */,
 				AC02E17C2A6F703D00C6A91B /* BoxOffice.swift in Sources */,

--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		3C35A80D2A6F9937008BB5C2 /* DecodingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C35A80C2A6F9937008BB5C2 /* DecodingManager.swift */; };
 		3C35A80F2A6F9A17008BB5C2 /* DataError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C35A80E2A6F9A17008BB5C2 /* DataError.swift */; };
 		3CB38E9A2A7FEB6C0070E63C /* TargetDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CB38E992A7FEB6C0070E63C /* TargetDate.swift */; };
+		3CB38E9C2A7FF7690070E63C /* CountFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CB38E9B2A7FF7690070E63C /* CountFormatter.swift */; };
 		3CF5610B2A73D30F0048D14D /* URLConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF5610A2A73D30F0048D14D /* URLConfigurable.swift */; };
 		3CF5610D2A73D3540048D14D /* KobisOpenAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF5610C2A73D3540048D14D /* KobisOpenAPI.swift */; };
 		3CF5610F2A73E7830048D14D /* URL+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF5610E2A73E7830048D14D /* URL+.swift */; };
@@ -43,6 +44,7 @@
 		3C35A80C2A6F9937008BB5C2 /* DecodingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodingManager.swift; sourceTree = "<group>"; };
 		3C35A80E2A6F9A17008BB5C2 /* DataError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataError.swift; sourceTree = "<group>"; };
 		3CB38E992A7FEB6C0070E63C /* TargetDate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetDate.swift; sourceTree = "<group>"; };
+		3CB38E9B2A7FF7690070E63C /* CountFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountFormatter.swift; sourceTree = "<group>"; };
 		3CF5610A2A73D30F0048D14D /* URLConfigurable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLConfigurable.swift; sourceTree = "<group>"; };
 		3CF5610C2A73D3540048D14D /* KobisOpenAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KobisOpenAPI.swift; sourceTree = "<group>"; };
 		3CF5610E2A73E7830048D14D /* URL+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+.swift"; sourceTree = "<group>"; };
@@ -188,6 +190,7 @@
 				AC11E7E42A729FE3008A84B0 /* NetworkManager.swift */,
 				3CF5610E2A73E7830048D14D /* URL+.swift */,
 				3CB38E992A7FEB6C0070E63C /* TargetDate.swift */,
+				3CB38E9B2A7FF7690070E63C /* CountFormatter.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -317,6 +320,7 @@
 				3CF5610F2A73E7830048D14D /* URL+.swift in Sources */,
 				3CB38E9A2A7FEB6C0070E63C /* TargetDate.swift in Sources */,
 				3CF561352A77C9480048D14D /* NetworkError.swift in Sources */,
+				3CB38E9C2A7FF7690070E63C /* CountFormatter.swift in Sources */,
 				3CF5610B2A73D30F0048D14D /* URLConfigurable.swift in Sources */,
 				3C35A80D2A6F9937008BB5C2 /* DecodingManager.swift in Sources */,
 			);

--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		3C35A80F2A6F9A17008BB5C2 /* DataError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C35A80E2A6F9A17008BB5C2 /* DataError.swift */; };
 		3CB38E9A2A7FEB6C0070E63C /* TargetDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CB38E992A7FEB6C0070E63C /* TargetDate.swift */; };
 		3CB38E9C2A7FF7690070E63C /* CountFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CB38E9B2A7FF7690070E63C /* CountFormatter.swift */; };
+		3CB38E9F2A8141CA0070E63C /* ConstraintsNamespace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CB38E9E2A8141CA0070E63C /* ConstraintsNamespace.swift */; };
 		3CF5610B2A73D30F0048D14D /* URLConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF5610A2A73D30F0048D14D /* URLConfigurable.swift */; };
 		3CF5610D2A73D3540048D14D /* KobisOpenAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF5610C2A73D3540048D14D /* KobisOpenAPI.swift */; };
 		3CF5610F2A73E7830048D14D /* URL+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF5610E2A73E7830048D14D /* URL+.swift */; };
@@ -46,6 +47,7 @@
 		3C35A80E2A6F9A17008BB5C2 /* DataError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataError.swift; sourceTree = "<group>"; };
 		3CB38E992A7FEB6C0070E63C /* TargetDate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetDate.swift; sourceTree = "<group>"; };
 		3CB38E9B2A7FF7690070E63C /* CountFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountFormatter.swift; sourceTree = "<group>"; };
+		3CB38E9E2A8141CA0070E63C /* ConstraintsNamespace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstraintsNamespace.swift; sourceTree = "<group>"; };
 		3CF5610A2A73D30F0048D14D /* URLConfigurable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLConfigurable.swift; sourceTree = "<group>"; };
 		3CF5610C2A73D3540048D14D /* KobisOpenAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KobisOpenAPI.swift; sourceTree = "<group>"; };
 		3CF5610E2A73E7830048D14D /* URL+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+.swift"; sourceTree = "<group>"; };
@@ -128,6 +130,14 @@
 			path = Application;
 			sourceTree = "<group>";
 		};
+		3CB38E9D2A8141A30070E63C /* Namespace */ = {
+			isa = PBXGroup;
+			children = (
+				3CB38E9E2A8141CA0070E63C /* ConstraintsNamespace.swift */,
+			);
+			path = Namespace;
+			sourceTree = "<group>";
+		};
 		3CF561332A77C91C0048D14D /* Error */ = {
 			isa = PBXGroup;
 			children = (
@@ -163,6 +173,7 @@
 				3C35A8082A6F68A9008BB5C2 /* Model */,
 				3C35A8092A6F68B1008BB5C2 /* View */,
 				3C35A80A2A6F68BB008BB5C2 /* Controller */,
+				3CB38E9D2A8141A30070E63C /* Namespace */,
 				3CF561332A77C91C0048D14D /* Error */,
 				AC9BDB3C2A78CD14000FA75F /* Resource */,
 			);
@@ -326,6 +337,7 @@
 				3CF561352A77C9480048D14D /* NetworkError.swift in Sources */,
 				3CB38E9C2A7FF7690070E63C /* CountFormatter.swift in Sources */,
 				3CF5610B2A73D30F0048D14D /* URLConfigurable.swift in Sources */,
+				3CB38E9F2A8141CA0070E63C /* ConstraintsNamespace.swift in Sources */,
 				3C35A80D2A6F9937008BB5C2 /* DecodingManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -113,7 +113,7 @@ extension BoxOfficeViewController {
                 return NSMutableAttributedString(string: "-")
             }
         } else {
-            let text = " 신작 "
+            let text = "신작"
             let attributedString = NSMutableAttributedString(string: text)
             attributedString.addAttribute(.foregroundColor, value: UIColor.systemRed, range: (text as NSString).range(of: "신작"))
             return attributedString

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -8,8 +8,15 @@
 import UIKit
 import OSLog
 
-class BoxOfficeViewController: UIViewController {
+private enum Section: Hashable {
+    case main
+}
 
+class BoxOfficeViewController: UIViewController {
+    private var dataSource: UICollectionViewDiffableDataSource<Section, BoxOfficeData>! = nil
+    private var collectionView: UICollectionView! = nil
+    private var items: [BoxOfficeData] = [BoxOfficeData]()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -133,7 +133,9 @@ extension BoxOfficeViewController {
     }
     
     private func stopActivityIndicator() {
-        activityIndicatorView.stopAnimating()
+        DispatchQueue.main.async {
+            self.activityIndicatorView.stopAnimating()
+        }
     }
     
     private func configureRefreshControl() {

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -20,6 +20,7 @@ class BoxOfficeViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        navigationItem.title = "20220102"
         configureHierarchy()
         configureDataSource()
         

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -15,18 +15,19 @@ private enum Section: Hashable {
 class BoxOfficeViewController: UIViewController {
     private var dataSource: UICollectionViewDiffableDataSource<Section, BoxOfficeData>! = nil
     private var collectionView: UICollectionView! = nil
-    private var items: [BoxOfficeData] = [BoxOfficeData]()
+    private var items = [BoxOfficeData]()
+    private let yesterday = TargetDate(dayFromNow: -1)
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        navigationItem.title = "20220102"
+        navigationItem.title = yesterday.formatByHypen()
         configureHierarchy()
         configureDataSource()
         
         let networkManager = NetworkManager()
         
-        networkManager.fetchData(url: KobisOpenAPI.boxOffice(targetDate: "20220102").url) { result in
+        networkManager.fetchData(url: KobisOpenAPI.boxOffice(targetDate: yesterday.formatNoSeparator()).url) { result in
             switch result {
             case .success(let data):
                 do {

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -22,14 +22,14 @@ class BoxOfficeViewController: UIViewController {
                     let decodedData = try DecodingManager.decodeJSON(type: BoxOffice.self, data: data)
                     print(decodedData)
                 } catch DataError.notFoundAsset {
-                    print(DataError.notFoundAsset.localizedDescription)
+                    os_log("%{public}@", type: .default, DataError.notFoundAsset.localizedDescription)
                 } catch DataError.failedDecoding {
-                    print(DataError.failedDecoding.localizedDescription)
+                    os_log("%{public}@", type: .default, DataError.failedDecoding.localizedDescription)
                 } catch {
                     os_log("알 수 없는 오류입니다.", type: .default)
                 }
             case .failure(let error):
-                print(error.localizedDescription)
+                os_log("%{public}@", type: .default, error.localizedDescription)
             }
         }
         
@@ -40,14 +40,14 @@ class BoxOfficeViewController: UIViewController {
                     let decodedData = try DecodingManager.decodeJSON(type: Movie.self, data: data)
                     print(decodedData)
                 } catch DataError.notFoundAsset {
-                    print(DataError.notFoundAsset.localizedDescription)
+                    os_log("%{public}@", type: .default, DataError.notFoundAsset.localizedDescription)
                 } catch DataError.failedDecoding {
-                    print(DataError.failedDecoding.localizedDescription)
+                    os_log("%{public}@", type: .default, DataError.failedDecoding.localizedDescription)
                 } catch {
                     os_log("알 수 없는 오류입니다.", type: .default)
                 }
             case .failure(let error):
-                print(error.localizedDescription)
+                os_log("%{public}@", type: .default, error.localizedDescription)
             }
         }
     }

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -16,7 +16,7 @@ class BoxOfficeViewController: UIViewController {
     private var dataSource: UICollectionViewDiffableDataSource<Section, BoxOfficeData>! = nil
     private var collectionView: UICollectionView! = nil
     private var items = [BoxOfficeData]()
-    private let yesterday = TargetDate(dayFromNow: -1)
+    private let yesterday = TargetDate(dayFromNow: -579)
     private let activityIndicatorView = UIActivityIndicatorView()
     
     override func viewDidLoad() {
@@ -76,7 +76,8 @@ extension BoxOfficeViewController {
     
     private func configureDataSource() {
         let cellRegistration = UICollectionView.CellRegistration<BoxOfficeCell, BoxOfficeData> { (cell, indexPath, item) in
-            cell.configureCell(with: item)
+            let rankIntensityText = self.configureRankIntensity(with: item)
+            cell.configureCell(with: item, rankIntensityText)
         }
         
         dataSource = UICollectionViewDiffableDataSource<Section, BoxOfficeData>(collectionView: collectionView) {
@@ -88,6 +89,35 @@ extension BoxOfficeViewController {
         snapshot.appendSections([.main])
         snapshot.appendItems(items)
         dataSource.apply(snapshot, animatingDifferences: false)
+    }
+    
+    private func configureRankIntensity(with boxOfficeData: BoxOfficeData) -> NSMutableAttributedString {
+        let rankOldOrNew = boxOfficeData.rankOldOrNew
+        guard let rankIntensity = Int(boxOfficeData.rankIntensity) else { return NSMutableAttributedString(string: "")}
+        
+        if rankOldOrNew == "OLD" {
+            var text: String
+            var attributedString: NSMutableAttributedString
+
+            if rankIntensity < 0 {
+                text = "▼\(-rankIntensity)"
+                attributedString = NSMutableAttributedString(string: text)
+                attributedString.addAttribute(.foregroundColor, value: UIColor.systemBlue, range: (text as NSString).range(of: "▼"))
+                return attributedString
+            } else if rankIntensity > 0 {
+                text = "▲\(rankIntensity)"
+                attributedString = NSMutableAttributedString(string: text)
+                attributedString.addAttribute(.foregroundColor, value: UIColor.systemRed, range: (text as NSString).range(of: "▲"))
+                return attributedString
+            } else {
+                return NSMutableAttributedString(string: "-")
+            }
+        } else {
+            let text = " 신작 "
+            let attributedString = NSMutableAttributedString(string: text)
+            attributedString.addAttribute(.foregroundColor, value: UIColor.systemRed, range: (text as NSString).range(of: "신작"))
+            return attributedString
+        }
     }
 }
 

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -53,6 +53,7 @@ extension BoxOfficeViewController {
     
     private func createLayout() -> UICollectionViewLayout {
         let configuration = UICollectionLayoutListConfiguration(appearance: .plain)
+        
         return UICollectionViewCompositionalLayout.list(using: configuration)
     }
     
@@ -85,21 +86,26 @@ extension BoxOfficeViewController {
     }
     
     private func configureRankIntensity(with boxOfficeData: BoxOfficeData) -> NSMutableAttributedString {
-        let rankOldOrNew = boxOfficeData.rankOldOrNew
-        guard let rankIntensity = Int(boxOfficeData.rankIntensity) else { return NSMutableAttributedString(string: "")}
         var text: String
         var attributedString: NSMutableAttributedString
+        let rankOldOrNew = boxOfficeData.rankOldOrNew
+        
+        guard let rankIntensity = Int(boxOfficeData.rankIntensity) else {
+            return NSMutableAttributedString(string: "")
+        }
         
         if rankOldOrNew == "OLD" {
             if rankIntensity < 0 {
                 text = "▼\(-rankIntensity)"
                 attributedString = NSMutableAttributedString(string: text)
                 attributedString.addAttribute(.foregroundColor, value: UIColor.systemBlue, range: (text as NSString).range(of: "▼"))
+                
                 return attributedString
             } else if rankIntensity > 0 {
                 text = "▲\(rankIntensity)"
                 attributedString = NSMutableAttributedString(string: text)
                 attributedString.addAttribute(.foregroundColor, value: UIColor.systemRed, range: (text as NSString).range(of: "▲"))
+                
                 return attributedString
             } else {
                 return NSMutableAttributedString(string: "-")
@@ -108,6 +114,7 @@ extension BoxOfficeViewController {
             text = "신작"
             attributedString = NSMutableAttributedString(string: text)
             attributedString.addAttribute(.foregroundColor, value: UIColor.systemRed, range: (text as NSString).range(of: "신작"))
+            
             return attributedString
         }
     }

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -26,7 +26,7 @@ final class BoxOfficeViewController: UIViewController {
         configureHierarchy()
         configureDataSource()
         configureActivityIndicatorView()
-        configureNavigationItem(title: yesterday.formatByHyphen())
+        configureNavigationItem(title: yesterday.formattedWithHyphen())
     }
 }
 
@@ -141,7 +141,7 @@ extension BoxOfficeViewController {
     @objc func handleRefreshControl() {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
             self.loadData()
-            self.configureNavigationItem(title: self.yesterday.formatByHyphen())
+            self.configureNavigationItem(title: self.yesterday.formattedWithHyphen())
             self.collectionView.refreshControl?.endRefreshing()
         }
     }

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -60,6 +60,7 @@ extension BoxOfficeViewController {
     private func configureHierarchy() {
         collectionView = UICollectionView(frame: view.bounds, collectionViewLayout: createLayout())
         collectionView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        
         view.addSubview(collectionView)
         configureRefreshControl()
     }

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -20,6 +20,9 @@ class BoxOfficeViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        configureHierarchy()
+        configureDataSource()
+        
         let networkManager = NetworkManager()
         
         networkManager.fetchData(url: KobisOpenAPI.boxOffice(targetDate: "20220102").url) { result in
@@ -28,6 +31,18 @@ class BoxOfficeViewController: UIViewController {
                 do {
                     let decodedData = try DecodingManager.decodeJSON(type: BoxOffice.self, data: data)
                     print(decodedData)
+                    
+                    let boxOfficeItems = decodedData.boxOfficeResult.dailyBoxOfficeList
+                    
+                    boxOfficeItems.forEach { item in
+                        self.items.append(item)
+                    }
+                    
+                    var snapshot = NSDiffableDataSourceSnapshot<Section, BoxOfficeData>()
+                    snapshot.appendSections([.main])
+                    snapshot.appendItems(self.items)
+                    self.dataSource.apply(snapshot, animatingDifferences: true)
+                    
                 } catch DataError.notFoundAsset {
                     os_log("%{public}@", type: .default, DataError.notFoundAsset.localizedDescription)
                 } catch DataError.failedDecoding {

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -67,7 +67,7 @@ extension BoxOfficeViewController {
     private func configureDataSource() {
         let cellRegistration = UICollectionView.CellRegistration<BoxOfficeCell, BoxOfficeData> { (cell, indexPath, item) in
             let rankIntensityText = self.configureRankIntensity(with: item)
-            cell.configureCell(with: item, rankIntensityText)
+            cell.updateLabel(with: item, rankIntensityText)
         }
         
         dataSource = UICollectionViewDiffableDataSource<Section, BoxOfficeData>(collectionView: collectionView) {

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -132,8 +132,8 @@ extension BoxOfficeViewController {
     }
     
     @objc func handleRefreshControl() {
-        DispatchQueue.main.async {
-            self.collectionView.reloadData()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
+            self.loadData()
             self.collectionView.refreshControl?.endRefreshing()
         }
     }

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -134,6 +134,7 @@ extension BoxOfficeViewController {
     @objc func handleRefreshControl() {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
             self.loadData()
+            self.configureNavigationItem(title: self.yesterday.formatByHyphen())
             self.collectionView.refreshControl?.endRefreshing()
         }
     }

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -129,7 +129,14 @@ extension BoxOfficeViewController {
         
         activityIndicatorView.center = view.center
         activityIndicatorView.style = .large
-        activityIndicatorView.startAnimating()
+        
+        startActivityIndicator()
+    }
+    
+    private func startActivityIndicator() {
+        DispatchQueue.main.async {
+            self.activityIndicatorView.startAnimating()
+        }
     }
     
     private func stopActivityIndicator() {

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -71,6 +71,7 @@ extension BoxOfficeViewController {
         collectionView = UICollectionView(frame: view.bounds, collectionViewLayout: createLayout())
         collectionView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         view.addSubview(collectionView)
+        configureRefreshControl()
     }
     
     private func configureDataSource() {
@@ -101,5 +102,17 @@ extension BoxOfficeViewController {
     
     private func stopActivityIndicator() {
         activityIndicatorView.stopAnimating()
+    }
+    
+    private func configureRefreshControl() {
+        collectionView.refreshControl = UIRefreshControl()
+        collectionView.refreshControl?.addTarget(self, action: #selector(handleRefreshControl), for: .valueChanged)
+    }
+    
+    @objc func handleRefreshControl() {
+        DispatchQueue.main.async {
+            self.collectionView.reloadData()
+            self.collectionView.refreshControl?.endRefreshing()
+        }
     }
 }

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -12,56 +12,45 @@ private enum Section: Hashable {
     case main
 }
 
-class BoxOfficeViewController: UIViewController {
+final class BoxOfficeViewController: UIViewController {
     private var dataSource: UICollectionViewDiffableDataSource<Section, BoxOfficeData>! = nil
     private var collectionView: UICollectionView! = nil
-    private var items = [BoxOfficeData]()
-    private let yesterday = TargetDate(dayFromNow: -579)
     private let activityIndicatorView = UIActivityIndicatorView()
-    
+    private let yesterday = TargetDate(dayFromNow: -1)
+    private var items = [BoxOfficeData]()
+
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        navigationItem.title = yesterday.formatByHyphen()
+        loadData()
         configureHierarchy()
         configureDataSource()
         configureActivityIndicatorView()
+        configureNavigationItem(title: yesterday.formatByHyphen())
+    }
+}
+
+extension BoxOfficeViewController {
+    private func configureNavigationItem(title: String) {
+        navigationItem.title = title
+    }
+    
+    private func loadData() {
+        let boxOfficeManager = BoxOfficeManager(targetDate: yesterday)
         
-        let networkManager = NetworkManager()
-        
-        networkManager.fetchData(url: KobisOpenAPI.boxOffice(targetDate: yesterday.formatNoSeparator()).url) { result in
+        boxOfficeManager.fetchBoxOfficeData { result in
             switch result {
-            case .success(let data):
-                do {
-                    let decodedData = try DecodingManager.decodeJSON(type: BoxOffice.self, data: data)
-                    print(decodedData)
-                    
-                    let boxOfficeItems = decodedData.boxOfficeResult.dailyBoxOfficeList
-                    
-                    boxOfficeItems.forEach { item in
-                        self.items.append(item)
-                    }
-                    
-                    var snapshot = NSDiffableDataSourceSnapshot<Section, BoxOfficeData>()
-                    snapshot.appendSections([.main])
-                    snapshot.appendItems(self.items)
-                    self.dataSource.apply(snapshot, animatingDifferences: true)
-                    self.stopActivityIndicator()
-                } catch DataError.notFoundAsset {
-                    os_log("%{public}@", type: .default, DataError.notFoundAsset.localizedDescription)
-                } catch DataError.failedDecoding {
-                    os_log("%{public}@", type: .default, DataError.failedDecoding.localizedDescription)
-                } catch {
-                    os_log("알 수 없는 오류입니다.", type: .default)
-                }
+            case .success(let items):
+                guard let items = items else { return }
+                self.items = items
+                self.applySnapshot()
+                self.stopActivityIndicator()
             case .failure(let error):
                 os_log("%{public}@", type: .default, error.localizedDescription)
             }
         }
     }
-}
-
-extension BoxOfficeViewController {
+    
     private func createLayout() -> UICollectionViewLayout {
         let configuration = UICollectionLayoutListConfiguration(appearance: .plain)
         return UICollectionViewCompositionalLayout.list(using: configuration)
@@ -85,20 +74,23 @@ extension BoxOfficeViewController {
             return collectionView.dequeueConfiguredReusableCell(using: cellRegistration, for: indexPath, item: identifier)
         }
         
+        applySnapshot()
+    }
+    
+    private func applySnapshot() {
         var snapshot = NSDiffableDataSourceSnapshot<Section, BoxOfficeData>()
         snapshot.appendSections([.main])
         snapshot.appendItems(items)
-        dataSource.apply(snapshot, animatingDifferences: false)
+        dataSource.apply(snapshot, animatingDifferences: true)
     }
     
     private func configureRankIntensity(with boxOfficeData: BoxOfficeData) -> NSMutableAttributedString {
         let rankOldOrNew = boxOfficeData.rankOldOrNew
         guard let rankIntensity = Int(boxOfficeData.rankIntensity) else { return NSMutableAttributedString(string: "")}
+        var text: String
+        var attributedString: NSMutableAttributedString
         
         if rankOldOrNew == "OLD" {
-            var text: String
-            var attributedString: NSMutableAttributedString
-
             if rankIntensity < 0 {
                 text = "▼\(-rankIntensity)"
                 attributedString = NSMutableAttributedString(string: text)
@@ -113,8 +105,8 @@ extension BoxOfficeViewController {
                 return NSMutableAttributedString(string: "-")
             }
         } else {
-            let text = "신작"
-            let attributedString = NSMutableAttributedString(string: text)
+            text = "신작"
+            attributedString = NSMutableAttributedString(string: text)
             attributedString.addAttribute(.foregroundColor, value: UIColor.systemRed, range: (text as NSString).range(of: "신작"))
             return attributedString
         }

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -59,3 +59,10 @@ class BoxOfficeViewController: UIViewController {
         }
     }
 }
+
+extension BoxOfficeViewController {
+    private func createLayout() -> UICollectionViewLayout {
+        let configuration = UICollectionLayoutListConfiguration(appearance: .plain)
+        return UICollectionViewCompositionalLayout.list(using: configuration)
+    }
+}

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -82,7 +82,10 @@ extension BoxOfficeViewController {
         var snapshot = NSDiffableDataSourceSnapshot<Section, BoxOfficeData>()
         snapshot.appendSections([.main])
         snapshot.appendItems(items)
-        dataSource.apply(snapshot, animatingDifferences: true)
+        
+        DispatchQueue.main.async {
+            self.dataSource.apply(snapshot, animatingDifferences: true)
+        }
     }
     
     private func configureRankIntensity(with boxOfficeData: BoxOfficeData) -> NSMutableAttributedString {

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -17,13 +17,15 @@ class BoxOfficeViewController: UIViewController {
     private var collectionView: UICollectionView! = nil
     private var items = [BoxOfficeData]()
     private let yesterday = TargetDate(dayFromNow: -1)
+    private let activityIndicatorView = UIActivityIndicatorView()
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        navigationItem.title = yesterday.formatByHypen()
+        navigationItem.title = yesterday.formatByHyphen()
         configureHierarchy()
         configureDataSource()
+        configureActivityIndicatorView()
         
         let networkManager = NetworkManager()
         
@@ -44,7 +46,7 @@ class BoxOfficeViewController: UIViewController {
                     snapshot.appendSections([.main])
                     snapshot.appendItems(self.items)
                     self.dataSource.apply(snapshot, animatingDifferences: true)
-                    
+                    self.stopActivityIndicator()
                 } catch DataError.notFoundAsset {
                     os_log("%{public}@", type: .default, DataError.notFoundAsset.localizedDescription)
                 } catch DataError.failedDecoding {
@@ -85,5 +87,19 @@ extension BoxOfficeViewController {
         snapshot.appendSections([.main])
         snapshot.appendItems(items)
         dataSource.apply(snapshot, animatingDifferences: false)
+    }
+}
+
+extension BoxOfficeViewController {
+    private func configureActivityIndicatorView() {
+        view.addSubview(activityIndicatorView)
+        
+        activityIndicatorView.center = view.center
+        activityIndicatorView.style = .large
+        activityIndicatorView.startAnimating()
+    }
+    
+    private func stopActivityIndicator() {
+        activityIndicatorView.stopAnimating()
     }
 }

--- a/BoxOffice/Error/DataError.swift
+++ b/BoxOffice/Error/DataError.swift
@@ -12,7 +12,7 @@ enum DataError: LocalizedError {
     case failedDecoding
     
     var errorDescription: String {
-        switch self{
+        switch self {
         case .notFoundAsset:
             return "해당 DataAsset을 찾을 수 없습니다."
         case .failedDecoding:

--- a/BoxOffice/Error/DataError.swift
+++ b/BoxOffice/Error/DataError.swift
@@ -11,7 +11,7 @@ enum DataError: LocalizedError {
     case notFoundAsset
     case failedDecoding
     
-    var errorDescription: String {
+    var errorDescription: String? {
         switch self {
         case .notFoundAsset:
             return "해당 DataAsset을 찾을 수 없습니다."

--- a/BoxOffice/Model/BoxOffice.swift
+++ b/BoxOffice/Model/BoxOffice.swift
@@ -21,7 +21,7 @@ struct DailyBoxOfficeResult: Decodable {
     }
 }
 
-struct BoxOfficeData: Decodable {
+struct BoxOfficeData: Decodable, Hashable {
     let number: String
     let rank: String
     let rankIntensity: String

--- a/BoxOffice/Model/BoxOfficeManager.swift
+++ b/BoxOffice/Model/BoxOfficeManager.swift
@@ -15,7 +15,7 @@ final class BoxOfficeManager {
     func fetchBoxOfficeData(completionHandler: @escaping (Result<[BoxOfficeData]?, Error>) -> Void) {
         let networkManager = NetworkManager()
         
-        networkManager.fetchData(url: KobisOpenAPI.boxOffice(targetDate: targetDate.formatNoSeparator()).url) { (data, error) in
+        networkManager.fetchData(url: KobisOpenAPI.boxOffice(targetDate: targetDate.formattedWithoutSeparator()).url) { (data, error) in
             do {
                 if let error = error {
                     completionHandler(.failure(error))

--- a/BoxOffice/Model/BoxOfficeManager.swift
+++ b/BoxOffice/Model/BoxOfficeManager.swift
@@ -17,13 +17,17 @@ final class BoxOfficeManager {
         
         networkManager.fetchData(url: KobisOpenAPI.boxOffice(targetDate: targetDate.formatNoSeparator()).url) { (data, error) in
             do {
+                if let error = error {
+                    completionHandler(.failure(error))
+                    
+                    return
+                }
+                
                 if let data = data {
                     let decodedData = try DecodingManager.decodeJSON(type: BoxOffice.self, data: data)
                     print(decodedData)
                     let boxOfficeItems = decodedData.boxOfficeResult.dailyBoxOfficeList
                     completionHandler(.success(boxOfficeItems))
-                } else if let error = error {
-                    completionHandler(.failure(error))
                 }
             } catch {
                 completionHandler(.failure(error))

--- a/BoxOffice/Model/BoxOfficeManager.swift
+++ b/BoxOffice/Model/BoxOfficeManager.swift
@@ -1,0 +1,33 @@
+//
+//  BoxOfficeManager.swift
+//  BoxOffice
+//
+//  Created by Dasan & Whales on 2023/08/07.
+//
+
+final class BoxOfficeManager {
+    private let targetDate: TargetDate
+    
+    init(targetDate: TargetDate) {
+        self.targetDate = targetDate
+    }
+    
+    func fetchBoxOfficeData(completionHandler: @escaping (Result<[BoxOfficeData]?, Error>) -> Void) {
+        let networkManager = NetworkManager()
+        
+        networkManager.fetchData(url: KobisOpenAPI.boxOffice(targetDate: targetDate.formatNoSeparator()).url) { (data, error) in
+            do {
+                if let data = data {
+                    let decodedData = try DecodingManager.decodeJSON(type: BoxOffice.self, data: data)
+                    print(decodedData)
+                    let boxOfficeItems = decodedData.boxOfficeResult.dailyBoxOfficeList
+                    completionHandler(.success(boxOfficeItems))
+                } else if let error = error {
+                    completionHandler(.failure(error))
+                }
+            } catch {
+                completionHandler(.failure(error))
+            }
+        }
+    }
+}

--- a/BoxOffice/Model/BoxOfficeManager.swift
+++ b/BoxOffice/Model/BoxOfficeManager.swift
@@ -25,7 +25,6 @@ final class BoxOfficeManager {
                 
                 if let data = data {
                     let decodedData = try DecodingManager.decodeJSON(type: BoxOffice.self, data: data)
-                    print(decodedData)
                     let boxOfficeItems = decodedData.boxOfficeResult.dailyBoxOfficeList
                     completionHandler(.success(boxOfficeItems))
                 }

--- a/BoxOffice/Model/Bundle+.swift
+++ b/BoxOffice/Model/Bundle+.swift
@@ -16,6 +16,7 @@ extension Bundle {
         guard let key = resource["KOBIS_API_KEY"] as? String else {
             fatalError("KOBIS_API_KEY error")
         }
+        
         return key
     }
 }

--- a/BoxOffice/Namespace/ConstraintsNamespace.swift
+++ b/BoxOffice/Namespace/ConstraintsNamespace.swift
@@ -1,0 +1,17 @@
+//
+//  ConstraintsNamespace.swift
+//  BoxOffice
+//
+//  Created by Dasan & Whales on 2023/08/08.
+//
+
+import Foundation
+
+enum ConstraintsNamespace {
+    static let rankStackViewFromCellWidth: CGFloat = 0.23
+    static let stackViewFromCellTrailing: CGFloat = 0.12
+    static let stackViewFromCellTop: CGFloat = 14
+    static let stackViewFromCellBottom: CGFloat = -14
+    static let titleViewFromCellTop: CGFloat = 5
+    static let titleViewFromCellBottom: CGFloat = -5  
+}

--- a/BoxOffice/Namespace/ConstraintsNamespace.swift
+++ b/BoxOffice/Namespace/ConstraintsNamespace.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 enum ConstraintsNamespace {
-    static let rankStackViewFromCellWidth: CGFloat = 0.23
-    static let stackViewFromCellTrailing: CGFloat = 0.12
-    static let stackViewFromCellTop: CGFloat = 14
-    static let stackViewFromCellBottom: CGFloat = -14
-    static let titleViewFromCellTop: CGFloat = 5
-    static let titleViewFromCellBottom: CGFloat = -5  
+    static let rankStackViewFromContentViewWidth: CGFloat = 0.23
+    static let stackViewFromContentViewTrailing: CGFloat = -10
+    static let stackViewFromContentViewTop: CGFloat = 14
+    static let stackViewFromContentViewBottom: CGFloat = -14
+    static let titleViewFromContentViewTop: CGFloat = 5
+    static let titleViewFromContentViewBottom: CGFloat = -5  
 }

--- a/BoxOffice/Utility/CountFormatter.swift
+++ b/BoxOffice/Utility/CountFormatter.swift
@@ -11,6 +11,7 @@ struct CountFormatter {
     static var decimal: NumberFormatter = {
         let numberFormatter = NumberFormatter()
         numberFormatter.numberStyle = .decimal
+        
         return numberFormatter
     }()
 }

--- a/BoxOffice/Utility/CountFormatter.swift
+++ b/BoxOffice/Utility/CountFormatter.swift
@@ -1,0 +1,16 @@
+//
+//  CountFormatter.swift
+//  BoxOffice
+//
+//  Created by Dasan & Whales on 2023/08/07.
+//
+
+import Foundation
+
+struct CountFormatter {
+    static var decimal: NumberFormatter = {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .decimal
+        return numberFormatter
+    }()
+}

--- a/BoxOffice/Utility/NetworkManager.swift
+++ b/BoxOffice/Utility/NetworkManager.swift
@@ -8,33 +8,33 @@
 import Foundation
 
 struct NetworkManager {
-    func fetchData(url: URL?, completionHandler: @escaping (Result<Data, NetworkError>) -> Void) {
+    func fetchData(url: URL?, completionHandler: @escaping ((Data?, NetworkError?)) -> Void) {
         guard let url = url else {
             return
         }
         
         let task = URLSession.shared.dataTask(with: url) { data, response, error in
             if error != nil {
-                completionHandler(.failure(.requestFailed))
+                completionHandler((nil, NetworkError.requestFailed))
 
                 return
             }
             
             guard let httpResponse = response as? HTTPURLResponse,
                   (200...299).contains(httpResponse.statusCode) else {
-                completionHandler(.failure(.invalidResponse))
+                completionHandler((nil, NetworkError.invalidResponse))
                 
                 return
             }
             
             DispatchQueue.main.async {
                 guard let data = data else {
-                    completionHandler(.failure(.noData))
+                    completionHandler((nil, NetworkError.noData))
                     
                     return
                 }
                 
-                completionHandler(.success(data))
+                completionHandler((data, nil))
             }
         }
         

--- a/BoxOffice/Utility/NetworkManager.swift
+++ b/BoxOffice/Utility/NetworkManager.swift
@@ -9,9 +9,7 @@ import Foundation
 
 struct NetworkManager {
     func fetchData(url: URL?, completionHandler: @escaping ((Data?, NetworkError?)) -> Void) {
-        guard let url = url else {
-            return
-        }
+        guard let url = url else { return }
         
         let task = URLSession.shared.dataTask(with: url) { data, response, error in
             if error != nil {

--- a/BoxOffice/Utility/NetworkManager.swift
+++ b/BoxOffice/Utility/NetworkManager.swift
@@ -27,13 +27,15 @@ struct NetworkManager {
                 return
             }
             
-            guard let data = data else {
-                completionHandler(.failure(.noData))
+            DispatchQueue.main.async {
+                guard let data = data else {
+                    completionHandler(.failure(.noData))
+                    
+                    return
+                }
                 
-                return
+                completionHandler(.success(data))
             }
-            
-            completionHandler(.success(data))
         }
         
         task.resume()

--- a/BoxOffice/Utility/NetworkManager.swift
+++ b/BoxOffice/Utility/NetworkManager.swift
@@ -25,15 +25,13 @@ struct NetworkManager {
                 return
             }
             
-            DispatchQueue.main.async {
-                guard let data = data else {
-                    completionHandler((nil, NetworkError.noData))
-                    
-                    return
-                }
+            guard let data = data else {
+                completionHandler((nil, NetworkError.noData))
                 
-                completionHandler((data, nil))
+                return
             }
+            
+            completionHandler((data, nil))
         }
         
         task.resume()

--- a/BoxOffice/Utility/TargetDate.swift
+++ b/BoxOffice/Utility/TargetDate.swift
@@ -1,0 +1,32 @@
+//
+//  TargetDate.swift
+//  BoxOffice
+//
+//  Created by Dasan & Whales on 2023/08/06.
+//
+
+import Foundation
+
+struct TargetDate {
+    private let dayFromNow: Int
+    private let dayToSecond: TimeInterval
+    private let oneDayToSecond: Double = 86400
+    private let dateFormatter = DateFormatter()
+    
+    init(dayFromNow: Int) {
+        self.dayFromNow = dayFromNow
+        self.dayToSecond = TimeInterval(dayFromNow) * oneDayToSecond
+    }
+    
+    func formatByHypen() -> String {
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        
+        return dateFormatter.string(from:Date(timeIntervalSinceNow: dayToSecond))
+    }
+    
+    func formatNoSeparator() -> String {
+        dateFormatter.dateFormat = "yyyyMMdd"
+        
+        return dateFormatter.string(from: Date(timeIntervalSinceNow: dayToSecond))
+    }
+}

--- a/BoxOffice/Utility/TargetDate.swift
+++ b/BoxOffice/Utility/TargetDate.swift
@@ -18,13 +18,13 @@ struct TargetDate {
         self.dayToSecond = TimeInterval(dayFromNow) * oneDayToSecond
     }
     
-    func formatByHyphen() -> String {
+    func formattedWithHyphen() -> String {
         dateFormatter.dateFormat = "yyyy-MM-dd"
         
         return dateFormatter.string(from:Date(timeIntervalSinceNow: dayToSecond))
     }
     
-    func formatNoSeparator() -> String {
+    func formattedWithoutSeparator() -> String {
         dateFormatter.dateFormat = "yyyyMMdd"
         
         return dateFormatter.string(from: Date(timeIntervalSinceNow: dayToSecond))

--- a/BoxOffice/Utility/TargetDate.swift
+++ b/BoxOffice/Utility/TargetDate.swift
@@ -18,7 +18,7 @@ struct TargetDate {
         self.dayToSecond = TimeInterval(dayFromNow) * oneDayToSecond
     }
     
-    func formatByHypen() -> String {
+    func formatByHyphen() -> String {
         dateFormatter.dateFormat = "yyyy-MM-dd"
         
         return dateFormatter.string(from:Date(timeIntervalSinceNow: dayToSecond))

--- a/BoxOffice/View/Base.lproj/Main.storyboard
+++ b/BoxOffice/View/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="t7X-qZ-p4c">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
@@ -19,10 +19,29 @@
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
+                    <navigationItem key="navigationItem" id="eNz-26-NHa"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="126" y="-27"/>
+            <point key="canvasLocation" x="1052.6717557251909" y="-27.464788732394368"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="Drr-XU-xjU">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="t7X-qZ-p4c" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="qiM-g7-1Tw">
+                        <rect key="frame" x="0.0" y="59" width="393" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="BYZ-38-t0r" kind="relationship" relationship="rootViewController" id="1mZ-QG-R7x"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="81v-6p-kj8" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="125.95419847328243" y="-27.464788732394368"/>
         </scene>
     </scenes>
     <resources>

--- a/BoxOffice/View/BoxOfficeCell.swift
+++ b/BoxOffice/View/BoxOfficeCell.swift
@@ -64,6 +64,7 @@ final class BoxOfficeCell: UICollectionViewListCell {
         
         self.addSubview(stackView)
         self.accessories = [.disclosureIndicator()]
+        setUpStackViewConstraints()
     }
 }
 

--- a/BoxOffice/View/BoxOfficeCell.swift
+++ b/BoxOffice/View/BoxOfficeCell.swift
@@ -10,6 +10,15 @@ import UIKit
 final class BoxOfficeCell: UICollectionViewListCell {
     static let Identifier = "boxOfficeCell"
     
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureCell()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     override func prepareForReuse() {
         super.prepareForReuse()
         rankIntensityLabel.textColor = .black
@@ -78,22 +87,7 @@ final class BoxOfficeCell: UICollectionViewListCell {
         return stackView
     }()
     
-    private func configureLabel(with boxOfficeData: BoxOfficeData, _ rankIntensityText: NSMutableAttributedString) {
-        rankLabel.text = boxOfficeData.rank
-        rankIntensityLabel.text = boxOfficeData.rankIntensity
-        movieNameLabel.text = boxOfficeData.movieName
-        
-        guard let audienceCount = CountFormatter.decimal.string(for: Int(boxOfficeData.audienceCount)),
-              let audienceAccumulate = CountFormatter.decimal.string(for: Int(boxOfficeData.audienceAccumulate))
-        else { return }
-        
-        audienceLabel.text = "오늘 \(audienceCount) / 총 \(audienceAccumulate)"
-        rankIntensityLabel.attributedText = rankIntensityText
-    }
-        
-    func configureCell(with boxOfficeData: BoxOfficeData, _ rankIntensityText: NSMutableAttributedString) {
-        configureLabel(with: boxOfficeData, rankIntensityText)
-        
+    private func configureCell() {
         rankStackView.addArrangedSubview(rankLabel)
         rankStackView.addArrangedSubview(rankIntensityLabel)
         titleStackView.addArrangedSubview(movieNameLabel)
@@ -104,6 +98,19 @@ final class BoxOfficeCell: UICollectionViewListCell {
         self.addSubview(stackView)
         self.accessories = [.disclosureIndicator()]
         setUpStackViewConstraints()
+    }
+    
+    func updateLabel(with boxOfficeData: BoxOfficeData, _ rankIntensityText: NSMutableAttributedString) {
+        rankLabel.text = boxOfficeData.rank
+        rankIntensityLabel.text = boxOfficeData.rankIntensity
+        movieNameLabel.text = boxOfficeData.movieName
+        
+        guard let audienceCount = CountFormatter.decimal.string(for: Int(boxOfficeData.audienceCount)),
+              let audienceAccumulate = CountFormatter.decimal.string(for: Int(boxOfficeData.audienceAccumulate))
+        else { return }
+        
+        audienceLabel.text = "오늘 \(audienceCount) / 총 \(audienceAccumulate)"
+        rankIntensityLabel.attributedText = rankIntensityText
     }
 }
 

--- a/BoxOffice/View/BoxOfficeCell.swift
+++ b/BoxOffice/View/BoxOfficeCell.swift
@@ -85,9 +85,7 @@ final class BoxOfficeCell: UICollectionViewListCell {
         
         guard let audienceCount = CountFormatter.decimal.string(for: Int(boxOfficeData.audienceCount)),
               let audienceAccumulate = CountFormatter.decimal.string(for: Int(boxOfficeData.audienceAccumulate))
-        else {
-            return
-        }
+        else { return }
         
         audienceLabel.text = "오늘 \(audienceCount) / 총 \(audienceAccumulate)"
         rankIntensityLabel.attributedText = rankIntensityText

--- a/BoxOffice/View/BoxOfficeCell.swift
+++ b/BoxOffice/View/BoxOfficeCell.swift
@@ -74,6 +74,9 @@ final class BoxOfficeCell: UICollectionViewListCell {
         rankStackView.axis = .vertical
         titleStackView.axis = .vertical
         stackView.axis = .horizontal
+        stackView.alignment = .center
+        
+        titleStackView.distribution = .fillProportionally
         
         self.addSubview(stackView)
         self.accessories = [.disclosureIndicator()]
@@ -84,12 +87,15 @@ final class BoxOfficeCell: UICollectionViewListCell {
 extension BoxOfficeCell {
     private func setUpStackViewConstraints() {
         stackView.translatesAutoresizingMaskIntoConstraints = false
+        
         NSLayoutConstraint.activate([
-            rankStackView.widthAnchor.constraint(equalTo: self.widthAnchor, multiplier: 0.25),
+            rankStackView.widthAnchor.constraint(equalTo: self.widthAnchor, multiplier: 0.23),
             stackView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-            stackView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
-            stackView.topAnchor.constraint(equalTo: self.topAnchor, constant: 15),
-            stackView.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -15)
+            stackView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -(self.frame.width * 0.12)),
+            stackView.topAnchor.constraint(equalTo: self.topAnchor, constant: 14),
+            stackView.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -14),
+            titleStackView.topAnchor.constraint(equalTo: stackView.topAnchor, constant: 5),
+            titleStackView.bottomAnchor.constraint(equalTo: stackView.bottomAnchor, constant: -5)
         ])
     }
 }

--- a/BoxOffice/View/BoxOfficeCell.swift
+++ b/BoxOffice/View/BoxOfficeCell.swift
@@ -1,0 +1,81 @@
+//
+//  BoxOfficeCell.swift
+//  BoxOffice
+//
+//  Created by Dasan & Whales on 2023/08/05.
+//
+
+import UIKit
+
+final class BoxOfficeCell: UICollectionViewListCell {
+    static let Identifier = "boxOfficeCell"
+    private var stackView = UIStackView()
+    private var rankStackView = UIStackView()
+    private var titleStackView = UIStackView()
+    
+    private let rankLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.preferredFont(forTextStyle: .largeTitle)
+        label.textAlignment = .center
+        return label
+    }()
+    
+    private let rankIntensityLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.preferredFont(forTextStyle: .body)
+        label.textAlignment = .center
+        return label
+    }()
+    
+    private let movieNameLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.preferredFont(forTextStyle: .title2)
+        label.textAlignment = .left
+        return label
+    }()
+    
+    private let audienceLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.preferredFont(forTextStyle: .body)
+        label.textAlignment = .left
+        return label
+    }()
+    
+    private func configureLabel(with boxOfficeData: BoxOfficeData) {
+        rankLabel.text = boxOfficeData.rank
+        rankIntensityLabel.text = boxOfficeData.rankIntensity
+        movieNameLabel.text = boxOfficeData.movieName
+        audienceLabel.text = "오늘 \(boxOfficeData.audienceCount) / 총 \(boxOfficeData.audienceAccumulate)"
+    }
+        
+    func configureCell(with boxOfficeData: BoxOfficeData) {
+        configureLabel(with: boxOfficeData)
+        
+        rankStackView.addArrangedSubview(rankLabel)
+        rankStackView.addArrangedSubview(rankIntensityLabel)
+        titleStackView.addArrangedSubview(movieNameLabel)
+        titleStackView.addArrangedSubview(audienceLabel)
+        stackView.addArrangedSubview(rankStackView)
+        stackView.addArrangedSubview(titleStackView)
+        
+        rankStackView.axis = .vertical
+        titleStackView.axis = .vertical
+        stackView.axis = .horizontal
+        
+        self.addSubview(stackView)
+        self.accessories = [.disclosureIndicator()]
+    }
+}
+
+extension BoxOfficeCell {
+    private func setUpStackViewConstraints() {
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            rankStackView.widthAnchor.constraint(equalTo: self.widthAnchor, multiplier: 0.25),
+            stackView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            stackView.topAnchor.constraint(equalTo: self.topAnchor, constant: 15),
+            stackView.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -15)
+        ])
+    }
+}

--- a/BoxOffice/View/BoxOfficeCell.swift
+++ b/BoxOffice/View/BoxOfficeCell.swift
@@ -95,7 +95,7 @@ final class BoxOfficeCell: UICollectionViewListCell {
         stackView.addArrangedSubview(rankStackView)
         stackView.addArrangedSubview(titleStackView)
         
-        self.addSubview(stackView)
+        contentView.addSubview(stackView)
         self.accessories = [.disclosureIndicator()]
         setUpStackViewConstraints()
     }
@@ -120,31 +120,31 @@ extension BoxOfficeCell {
         
         NSLayoutConstraint.activate([
             rankStackView.widthAnchor.constraint(
-                equalTo: self.widthAnchor,
-                multiplier: ConstraintsNamespace.rankStackViewFromCellWidth
+                equalTo: contentView.widthAnchor,
+                multiplier: ConstraintsNamespace.rankStackViewFromContentViewWidth
             ),
             stackView.leadingAnchor.constraint(
-                equalTo: self.leadingAnchor
+                equalTo: contentView.leadingAnchor
             ),
             stackView.trailingAnchor.constraint(
-                equalTo: self.trailingAnchor,
-                constant: -(self.frame.width * ConstraintsNamespace.stackViewFromCellTrailing)
+                equalTo: contentView.trailingAnchor,
+                constant: ConstraintsNamespace.stackViewFromContentViewTrailing
             ),
             stackView.topAnchor.constraint(
-                equalTo: self.topAnchor,
-                constant: ConstraintsNamespace.stackViewFromCellTop
+                equalTo: contentView.topAnchor,
+                constant: ConstraintsNamespace.stackViewFromContentViewTop
             ),
             stackView.bottomAnchor.constraint(
-                equalTo: self.bottomAnchor,
-                constant: ConstraintsNamespace.stackViewFromCellBottom
+                equalTo: contentView.bottomAnchor,
+                constant: ConstraintsNamespace.stackViewFromContentViewBottom
             ),
             titleStackView.topAnchor.constraint(
                 equalTo: stackView.topAnchor,
-                constant: ConstraintsNamespace.titleViewFromCellTop
+                constant: ConstraintsNamespace.titleViewFromContentViewTop
             ),
             titleStackView.bottomAnchor.constraint(
                 equalTo: stackView.bottomAnchor,
-                constant: ConstraintsNamespace.titleViewFromCellBottom
+                constant: ConstraintsNamespace.titleViewFromContentViewBottom
             )
         ])
     }

--- a/BoxOffice/View/BoxOfficeCell.swift
+++ b/BoxOffice/View/BoxOfficeCell.swift
@@ -45,7 +45,14 @@ final class BoxOfficeCell: UICollectionViewListCell {
         rankLabel.text = boxOfficeData.rank
         rankIntensityLabel.text = boxOfficeData.rankIntensity
         movieNameLabel.text = boxOfficeData.movieName
-        audienceLabel.text = "오늘 \(boxOfficeData.audienceCount) / 총 \(boxOfficeData.audienceAccumulate)"
+        
+        guard let audienceCount = CountFormatter.decimal.string(for: Int(boxOfficeData.audienceCount)),
+              let audienceAccumulate = CountFormatter.decimal.string(for: Int(boxOfficeData.audienceAccumulate))
+        else {
+            return
+        }
+        
+        audienceLabel.text = "오늘 \(audienceCount) / 총 \(audienceAccumulate)"
     }
         
     func configureCell(with boxOfficeData: BoxOfficeData) {

--- a/BoxOffice/View/BoxOfficeCell.swift
+++ b/BoxOffice/View/BoxOfficeCell.swift
@@ -13,6 +13,11 @@ final class BoxOfficeCell: UICollectionViewListCell {
     private var rankStackView = UIStackView()
     private var titleStackView = UIStackView()
     
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        rankIntensityLabel.textColor = .black
+    }
+    
     private let rankLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.preferredFont(forTextStyle: .largeTitle)

--- a/BoxOffice/View/BoxOfficeCell.swift
+++ b/BoxOffice/View/BoxOfficeCell.swift
@@ -22,6 +22,9 @@ final class BoxOfficeCell: UICollectionViewListCell {
         let label = UILabel()
         label.font = UIFont.preferredFont(forTextStyle: .largeTitle)
         label.textAlignment = .center
+        label.adjustsFontForContentSizeCategory = true
+        label.numberOfLines = 1
+        
         return label
     }()
     
@@ -29,6 +32,9 @@ final class BoxOfficeCell: UICollectionViewListCell {
         let label = UILabel()
         label.font = UIFont.preferredFont(forTextStyle: .body)
         label.textAlignment = .center
+        label.adjustsFontForContentSizeCategory = true
+        label.numberOfLines = 1
+        
         return label
     }()
     
@@ -36,6 +42,9 @@ final class BoxOfficeCell: UICollectionViewListCell {
         let label = UILabel()
         label.font = UIFont.preferredFont(forTextStyle: .title2)
         label.textAlignment = .left
+        label.adjustsFontForContentSizeCategory = true
+        label.numberOfLines = 1
+        
         return label
     }()
     
@@ -43,6 +52,9 @@ final class BoxOfficeCell: UICollectionViewListCell {
         let label = UILabel()
         label.font = UIFont.preferredFont(forTextStyle: .body)
         label.textAlignment = .left
+        label.adjustsFontForContentSizeCategory = true
+        label.numberOfLines = 1
+        
         return label
     }()
     

--- a/BoxOffice/View/BoxOfficeCell.swift
+++ b/BoxOffice/View/BoxOfficeCell.swift
@@ -41,7 +41,7 @@ final class BoxOfficeCell: UICollectionViewListCell {
         return label
     }()
     
-    private func configureLabel(with boxOfficeData: BoxOfficeData) {
+    private func configureLabel(with boxOfficeData: BoxOfficeData, _ rankIntensityText: NSMutableAttributedString) {
         rankLabel.text = boxOfficeData.rank
         rankIntensityLabel.text = boxOfficeData.rankIntensity
         movieNameLabel.text = boxOfficeData.movieName
@@ -53,10 +53,11 @@ final class BoxOfficeCell: UICollectionViewListCell {
         }
         
         audienceLabel.text = "오늘 \(audienceCount) / 총 \(audienceAccumulate)"
+        rankIntensityLabel.attributedText = rankIntensityText
     }
         
-    func configureCell(with boxOfficeData: BoxOfficeData) {
-        configureLabel(with: boxOfficeData)
+    func configureCell(with boxOfficeData: BoxOfficeData, _ rankIntensityText: NSMutableAttributedString) {
+        configureLabel(with: boxOfficeData, rankIntensityText)
         
         rankStackView.addArrangedSubview(rankLabel)
         rankStackView.addArrangedSubview(rankIntensityLabel)

--- a/BoxOffice/View/BoxOfficeCell.swift
+++ b/BoxOffice/View/BoxOfficeCell.swift
@@ -101,13 +101,33 @@ extension BoxOfficeCell {
         stackView.translatesAutoresizingMaskIntoConstraints = false
         
         NSLayoutConstraint.activate([
-            rankStackView.widthAnchor.constraint(equalTo: self.widthAnchor, multiplier: 0.23),
-            stackView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-            stackView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -(self.frame.width * 0.12)),
-            stackView.topAnchor.constraint(equalTo: self.topAnchor, constant: 14),
-            stackView.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -14),
-            titleStackView.topAnchor.constraint(equalTo: stackView.topAnchor, constant: 5),
-            titleStackView.bottomAnchor.constraint(equalTo: stackView.bottomAnchor, constant: -5)
+            rankStackView.widthAnchor.constraint(
+                equalTo: self.widthAnchor,
+                multiplier: ConstraintsNamespace.rankStackViewFromCellWidth
+            ),
+            stackView.leadingAnchor.constraint(
+                equalTo: self.leadingAnchor
+            ),
+            stackView.trailingAnchor.constraint(
+                equalTo: self.trailingAnchor,
+                constant: -(self.frame.width * ConstraintsNamespace.stackViewFromCellTrailing)
+            ),
+            stackView.topAnchor.constraint(
+                equalTo: self.topAnchor,
+                constant: ConstraintsNamespace.stackViewFromCellTop
+            ),
+            stackView.bottomAnchor.constraint(
+                equalTo: self.bottomAnchor,
+                constant: ConstraintsNamespace.stackViewFromCellBottom
+            ),
+            titleStackView.topAnchor.constraint(
+                equalTo: stackView.topAnchor,
+                constant: ConstraintsNamespace.titleViewFromCellTop
+            ),
+            titleStackView.bottomAnchor.constraint(
+                equalTo: stackView.bottomAnchor,
+                constant: ConstraintsNamespace.titleViewFromCellBottom
+            )
         ])
     }
 }

--- a/BoxOffice/View/BoxOfficeCell.swift
+++ b/BoxOffice/View/BoxOfficeCell.swift
@@ -9,9 +9,6 @@ import UIKit
 
 final class BoxOfficeCell: UICollectionViewListCell {
     static let Identifier = "boxOfficeCell"
-    private var stackView = UIStackView()
-    private var rankStackView = UIStackView()
-    private var titleStackView = UIStackView()
     
     override func prepareForReuse() {
         super.prepareForReuse()
@@ -58,6 +55,29 @@ final class BoxOfficeCell: UICollectionViewListCell {
         return label
     }()
     
+    private var stackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.alignment = .center
+        
+        return stackView
+    }()
+    
+    private var rankStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        
+        return stackView
+    }()
+    
+    private var titleStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.distribution = .fillProportionally
+        
+        return stackView
+    }()
+    
     private func configureLabel(with boxOfficeData: BoxOfficeData, _ rankIntensityText: NSMutableAttributedString) {
         rankLabel.text = boxOfficeData.rank
         rankIntensityLabel.text = boxOfficeData.rankIntensity
@@ -82,13 +102,6 @@ final class BoxOfficeCell: UICollectionViewListCell {
         titleStackView.addArrangedSubview(audienceLabel)
         stackView.addArrangedSubview(rankStackView)
         stackView.addArrangedSubview(titleStackView)
-        
-        rankStackView.axis = .vertical
-        titleStackView.axis = .vertical
-        stackView.axis = .horizontal
-        stackView.alignment = .center
-        
-        titleStackView.distribution = .fillProportionally
         
         self.addSubview(stackView)
         self.accessories = [.disclosureIndicator()]

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@
 
 | 앱 시작시 로딩 | 12시 새로고침(날짜변경) |
 | :--------: | :--------: |
-| <img src = "https://hackmd.io/_uploads/HyffIP73h.gif" height = "500"> | <img src = "https://hackmd.io/_uploads/B1TbrPXh3.gif" height = "500"> |
+| <img src = "https://hackmd.io/_uploads/HyffIP73h.gif" width = "250"> | <img src = "https://hackmd.io/_uploads/B1TbrPXh3.gif" width = "250"> |
 
 </br>
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,428 @@
-## 박스오피스 프로젝트 저장소
+# 🎬 박스오피스 _ 웰다비🍿🥤
 
-이 저장소를 자신의 저장소로 fork하여 프로젝트를 진행합니다!
+## 📖 목차
+🍀 [소개](#소개) </br>
+👨‍💻 [팀원](#팀원) </br>
+⏱️ [타임라인](#타임라인) </br>
+👀 [시각화된 프로젝트 구조](#시각화된_프로젝트_구조) </br>
+💻 [실행 화면](#실행_화면) </br>
+⛑️ [핵심 경험](#핵심_경험) </br>
+🧨 [트러블 슈팅](#트러블_슈팅) </br>
+📚 [참고 링크](#참고_링크) </br>
+
+</br>
+
+## 🍀 소개<a id="소개"></a>
+`Whales`과 `Dasan`이 만든 박스오피스입니다.
+영화진흥위원회의 Open API를 이용하여 일별 박스오피스 정보와 영화 상세 정보를 가져옵니다.
+
+</br>
+
+## 👨‍💻 팀원<a id="팀원"></a>
+| 🐬Whales🐬 | 🌳Dasan🌳 |
+| :--------: | :--------: |
+| <Img src = "https://github.com/WhalesJin/FireSaturdayStudyClassC/assets/124643545/e4e33a5d-f56c-4a3d-80b5-484ab3c62f27" width="200"> | <Img src = "https://user-images.githubusercontent.com/106504779/253477235-ca103b42-8938-447f-9381-29d0bcf55cac.jpeg" width="200"> |
+|[Github Profile](https://github.com/WhalesJin) |[Github Profile](https://github.com/DasanKim) |
+
+</br>
+
+## ⏱️ 타임라인<a id="타임라인"></a>
+|날짜|내용|
+|:--:|--|
+|2023.07.24(월)| - [영화진흥위원회의 일별 박스오피스 API 문서](https://www.kobis.or.kr/kobisopenapi/homepg/apiservice/searchServiceInfo.do?serviceId=searchDailyBoxOffice)의 데이터 형식을 고려한 모델 타입 설계 |
+|2023.07.25(화)| - `BoxOffic`, `BoxOfficeData`, `DailyBoxOfficeResult` 타입 생성 <br> - `DecodingManager`, `DataError` 타입 생성 및 구현 <br> - `DecodingManager`에 대한 Unit Test 진행 <br> - 파일 그룹화|
+|2023.07.26(수)| - **Test Plan Reference** 오류 수정 <br> - [URLSession](https://developer.apple.com/documentation/foundation/urlsession) 공부 |
+|2023.07.27(목)| - `Movie`, `MovieInformationResult`, `MovieInformation` 타입 생성 <br> - 각각의 관련 타입들 `BoxOffice`, `Movie` 파일로 **병합** <br> - `NetworkManager` 타입 생성 및 구현|
+|2023.07.28(금)| - `Movie` 타입 오류 수정 <br> - `fetchData`매서드에 `completionHandler` 추가 <br> - README 작성|
+|2023.07.31(월)| - 네트워크 관련 에러 `Result` 타입으로 수정 <br> -`Utility`, `Error` 그룹 생성 및 그룹화 <br> - 피드백 반영| 
+|2023.08.01(화)| - plist를 활용하여 github에서 API key값이 보이지 않도록 수정 <br> - `Resource` 그룹 생성 및 그룹화|
+|2023.08.02(수)| - `os log` 메서드 활용 및 전체적인 리펙토링 |
+|2023.08.03(목)| - [Modern cell configuration](https://developer.apple.com/videos/play/wwdc2020/10027/), [Lists in UICollectionView](https://developer.apple.com/videos/play/wwdc2020/10026) 공부 <br> - 첫번째 페이지 UI 설계 |
+|2023.08.04(금)| - README 작성 <br> - 개발 타겟 버전 `iOS 14` 이상으로 수정 <br> - `Modern Collection View`를 활용한 UI 구현|
+|2023.08.07(월)| - `TargetDate` 타입 생성 <br> - `UIActivityIndicatorView`, `RefreshControl`를 활용한 로딩 화면 구현 <br> - `BoxOfficeManager` 타입 생성|
+|2023.08.08(화)| - `Dynamic Type` 적용 <br> - `ConstraintsNamespace` 추가 및 적용 <br> - 전체적인 리펙토링 |
+|2023.08.09(수)| - `Kakao REST API` 타입 설계 |
+|2023.08.10(목)| - 영화 상세 페이지 UI 설계 |
+|2023.08.11(금)| - 피드백 반영 및 수정 <br> - README 작성 |
+
+</br>
+
+## 👀 시각화된 프로젝트 구조<a id="시각화된_프로젝트_구조"></a>
+
+### ℹ️ File Tree
+    ┌── BoxOffice
+    │   ├── BoxOffice
+    │   │   ├── Application
+    │   │   │   ├── AppDelegate
+    │   │   │   └── SceneDelegate
+    │   │   ├── Utility
+    │   │   │   ├── DecodingManager
+    │   │   │   ├── NetworkManager
+    │   │   │   ├── URL+
+    │   │   │   ├── TargetDate
+    │   │   │   └── CountFormatter
+    │   │   ├── Model
+    │   │   │   ├── BoxOffice
+    │   │   │   ├── Movie
+    │   │   │   ├── URLConfigurable
+    │   │   │   ├── KobisOpenAPI
+    │   │   │   ├── Bundle+
+    │   │   │   └── BoxOfficeManager
+    │   │   ├── View
+    │   │   │   ├── Main
+    │   │   │   ├── LaunchScreen
+    │   │   │   └── BoxOfficeCell
+    │   │   ├── Controller
+    │   │   │   └── BoxOfficeViewController
+    │   │   ├── Namespace
+    │   │   │   └── ConstraintsNamespace
+    │   │   ├── Error
+    │   │   │   ├── DataError
+    │   │   │   └── NetworkError
+    │   │   ├── Resource
+    │   │   │   ├── Assets
+    │   │   │   ├── Info
+    │   │   │   └── KobisAPIKey
+    │   └── BoxOfficeTests
+    │       └── DecodingManagerTests
+    │           └── DecodingManagerTests
+    └── README
+</br>
+
+### 📐 Diagram
+
+- Model<br>
+    <img width = "450" src = "https://hackmd.io/_uploads/SkjAuGcon.png"> <br>
+
+- View & Controller<br>
+    <img width = "700" src = "https://hackmd.io/_uploads/SJ02gv7nn.png"> <br>
+
+- <details> 
+      <summary> View & Utility </summary>
+  <img width = "250" src = "https://hackmd.io/_uploads/BygtbwQh3.png">
+  </details>
+
+- <details> 
+      <summary> Controller & Utility </summary>
+  <img width = "700" src = "https://hackmd.io/_uploads/H1dEWwXhn.png">
+  </details>
+
+- <details> 
+      <summary> Model - DTO </summary>
+  <img width = "550" src = "https://hackmd.io/_uploads/SkPRdzqo2.png">
+  </details>
+
+- <details> 
+      <summary> Error & Utility </summary>
+  <img width = "450" src = "https://hackmd.io/_uploads/HJy0uG9j2.png">
+  </details>
+
+</br>
+
+## 💻 실행 화면<a id="실행_화면"></a>
+
+
+| 앱 시작시 로딩 | 12시 새로고침(날짜변경) |
+| :--------: | :--------: |
+| <img src = "https://hackmd.io/_uploads/HyffIP73h.gif" height = "500"> | <img src = "https://hackmd.io/_uploads/B1TbrPXh3.gif" height = "500"> |
+
+</br>
+
+
+## ⛑️ 핵심 경험<a id="핵심_경험"></a>
+
+### Unit Test의 XCTAssertThrowsError
+- `DecodingManager` 타입의 decodeJSON`메서드`를 테스트하여, **decoding 및 parsing**이 잘 이루어지고 있는지를 확인하고 싶었습니다.
+- Tests 내에서 `XCTAssertThrowsError`, `XCTAssertNoThrow` 메서드를 사용하여 상황에 맞게 오류를 잘 던지고 있는지 확인하였습니다.
+ 
+<details>
+    <summary> 코드 </summary>
+    
+```swift
+//DecodingManagerTests.swfit
+
+func test_일치하는_dataAsset이없을때_notFoundAsset에러를_던진다() {
+    //given
+    let fileName = "없는파일이름"
+
+    //when, then
+    XCTAssertThrowsError(try sut.decodeJSON(fileName: fileName) as BoxOffice) { error in
+        XCTAssertEqual(error as! DataError, DataError.notFoundAsset)
+    }
+}
+    
+func test_일치하는_dataAsset가있을때_notFoundAsset에러를_던지지않는다() {
+    //given
+    let fileName = "box_office_sample"
+
+    //when, then
+    XCTAssertNoThrow(try sut.decodeJSON(fileName: fileName) as BoxOffice)
+}
+```
+</details>
+
+### Modern Collection Veiw 활용
+- Modern Collection View를 활용하여 `list Layout`을 쉽게 구현할 수 있었습니다.
+- 또한 `NSDiffableDataSourceSnapshot` 및 `UICollectionViewDiffableDataSource`를 활용하여 collection View 내의 Data를 업데이트하였습니다.
+
+<details>
+    <summary> 코드 </summary>
+    
+```swift
+// BoxOfficeViewController.swfit
+
+extension BoxOfficeViewController {
+    private func createLayout() -> UICollectionViewLayout {
+        let configuration = UICollectionLayoutListConfiguration(appearance: .plain)
+
+        return UICollectionViewCompositionalLayout.list(using: configuration)
+    }
+
+    (...)
+
+    private func configureDataSource() {
+        (...)
+        dataSource = UICollectionViewDiffableDataSource <Section, BoxOfficeData>(collectionView: collectionView) {
+            (collectionView: UICollectionView, indexPath: IndexPath, identifier: BoxOfficeData) -> UICollectionViewListCell? in
+            return collectionView.dequeueConfiguredReusableCell(using: cellRegistration, for: indexPath, item: identifier)
+        }
+
+        applySnapshot()
+    }
+
+    private func applySnapshot() {
+        var snapshot = NSDiffableDataSourceSnapshot<Section, BoxOfficeData >()
+        snapshot.appendSections([.main])
+        snapshot.appendItems(items)
+        dataSource.apply(snapshot, animatingDifferences: true)
+    }
+    (...)
+}
+```
+</details>
+
+<br>
+
+## 🧨 트러블 슈팅<a id="트러블_슈팅"></a>
+
+### 1️⃣ Test Plan Reference 오류
+`DecodingManager` 타입에 대한 Unit Test을 진행하였습니다. 후에 추후 추가될 Test들을 생각하여 `BoxOfficeTests`라는 상위 폴더를 생성하고, `DecodingManagerTests` 폴더 및 `BoxOffice.xctestplan` 파일을 `BoxOfficeTests` 폴더에 넣어주었습니다.
+
+    └── BoxOfficeTests
+        ├── BoxOffice.xctestplan
+        └── DecodingManagerTests
+            └── DecodingManagerTests.swift
+
+🚨 **문제점** <br>
+
+- 폴더 및 파일들을 `BoxOfficeTests`로 이동한 후부터, 아래와 같은 메시지창이 뜨며 Unit Test가 실행되지 않았습니다.
+   - error 메시지
+   <img src="https://github-production-user-asset-6210df.s3.amazonaws.com/124643545/256756273-ba5fd051-9faa-44dd-a94d-c553a6f1f220.png" width="400">
+
+   - missing된 DecodingManagerTests
+   <img src="https://github-production-user-asset-6210df.s3.amazonaws.com/124643545/256756316-e934d064-053f-41d3-9ce4-8de7fd238d7b.png" width="400">
+
+- 위와 같은 문제가 생긴 이유는 `Test Plan`의 위치를 옮길 때 `BoxOffice` 타겟에 대한 `Test Plan reference` 경로가 변경되었기 때문이었습니다.
+
+   <img src = "https://github-production-user-asset-6210df.s3.amazonaws.com/124643545/256756329-6f5c135a-60e7-4b0a-82c8-fed4ee89c675.png" width = "700">
+
+💡 **해결방법** <br>
+- 이 문제를 해결할 수 있는 방법에는 2가지가 있었습니다:
+    1. Test Plan의 `configurations` 설정
+        - Test Plan > configurations > Target for Variable Expansion
+        - Target for Variable Expansion 값을 none으로 바꾸었다가 다시 App으로 변경
+    2. 기존 Test Plan 삭제 후 `새롭게 추가`
+        - Product > Scheme > Edit scheme > Test
+        - Test Plans에 있는 기존 BoxOffice Test Plan을 삭제하고, 다시 add
+    
+        <img src = "https://hackmd.io/_uploads/SkvTsgRqh.png" width = "500">
+
+- 저희는 첫번째 방법으로는 해결이 되지 않아, 두번째 방법으로 해결하였습니다.
+
+<br>
+
+### 2️⃣ API Key 숨기기 
+🚨 **문제점** <br>
+- 처음엔 `API key` 값을 아래와 같이 `KobisOpenAPI` 내 key 프로퍼티에 넣어주었습니다.
+- `private` 접근제어를 통하여 코드적으로는 외부에서 프로퍼티에 접근하지 못하도록해주었지만, git에 올렸을 때 key값이 **그대로 노출되는 문제**가 발생되었습니다.
+
+```swift
+// KobisOpenAPI.swift
+enum KobisOpenAPI {
+    case boxOffice(String)
+    case movie(String)
+}
+
+extension KobisOpenAPI: API {
+    (...)
+    private var key: String {
+        return "fb92260b76d9959bbf3ab69c991d8985"
+    }
+    (...)
+}
+```
+
+💡 **해결방법** <br>
+- API Key를 아래와 같은 방법으로 숨겼습니다.
+
+    1. 새로운 `plist`를 만들어 KOBIS_API_KEY라는 이름의 `Key`와 KOBIS API KEY VALUE의 `Value`를 생성후, push 해주었습니다.
+    2. 후에 **더이상 새로운 `plist`파일을 추적하지 못하도록** `.gitignore` 파일 내에 새로운 plist path를 추가해준 뒤 push 해주었습니다.
+    3. 더 이상 추적하지 못하도록 한 뒤, `KOBIS API KEY VALUE`로 적혀있던 Value에 `실제 API Key`를 넣어주었습니다.
+    ![](https://hackmd.io/_uploads/S1qX7Xqjh.png)
+<br>
+
+### 3️⃣ 역할 분리
+🚨 **문제점** <br>
+- 프로젝트를 진행하면서 아래와 같이 `ViewController`가 비대해졌고, 이는 `ViewController`가 많은 책임을 가지게 하였습니다.(또한 본래의 책임과는 동떨어진 기능들도 가지고 있었습니다.)
+
+    <details>
+        <summary> 코드 </summary>
+    
+    ```swift
+    // BoxOfficeViewController.swift
+    class BoxOfficeViewController: UIViewController {
+        (...)
+
+        override func viewDidLoad(){
+            let networkManager = NetworkManager()
+
+            networkManager.fetchData(url: KobisOpenAPI.boxOffice(targetDate: targetDate.formatNoSeparator()).url) { result in
+                switch result {
+                case .success(let data):
+                    do {
+                        let decodedData = try DecodingManager.decodeJSON(type: BoxOffice.self, data: data)
+                        print(decodedData)
+
+                        let boxOfficeItems = decodedData.boxOfficeResult.dailyBoxOfficeList
+
+                        boxOfficeItems.forEach { item in
+                            self.items.append(item)
+                        }
+
+                        (...)
+                        self.dataSource.apply(snapshot, animatingDifferences: true)
+                        self.stopActivityIndicator()
+                    } catch DataError.notFoundAsset {
+                        os_log("%{public}@", type: .default, DataError.notFoundAsset.localizedDescription)
+                    } catch DataError.failedDecoding {
+                        os_log("%{public}@", type: .default, DataError.failedDecoding.localizedDescription)
+                    } catch {
+                        os_log("알 수 없는 오류입니다.", type: .default)
+                    }
+                case .failure(let error):
+                    os_log("%{public}@", type: .default, error.localizedDescription)
+                }
+            }
+        }
+        (...)
+    }
+    ```
+    </details>
+    
+</br>
+
+💡 **해결방법** <br>
+
+- `ViewController`가 본래의 책임만을 다할 수 있도록 `BoxOfficeManager`라는 타입을 만들었습니다.
+    > 본래 `ViewController`의 주요 책임
+    > - 일반적으로 기초 데이터의 변경에 대한 응답으로 `뷰의 콘텐츠를 업데이트`
+    > - 뷰에 대한 `사용자 상호 작용에 응답`
+    > - 뷰 `크기 조정` 및 전체 인터페이스의 `레이아웃 관리`
+    > - 앱에서 다른 객체(다른 뷰 컨트롤러 포함)와 조정
+
+- 더불어 각 Manager들이 하나의 책임만 갖도록 하였습니다.
+  - **NetworkManager**: `API`를 통해 요청한 `Data`를 가져옵니다.
+  - **DecodingManager**: `Data`를 `Swift`에서 사용할 수 있는 특정 데이터 타입으로 `Decodeing`합니다.
+  - **BoxOfficeManager**: BoxOffice 관련 데이터 타입으로 디코딩된 `Data`를 `Result` 타입으로 반환합니다.
+  - **ViewController**: `API`와의 통신 및 `Decoding` 과정을 몰라도 되며, `BoxOfficeManager`를 통해 받은 `Data`를 가지고 `View`에 전달하는 역할에 집중할 수 있도록 하였습니다.
+
+   <details>
+        <summary> 코드 </summary>
+
+    ```swift
+    // BoxOfficeManager.swift
+    final class BoxOfficeManager {
+        (...)
+        func fetchBoxOfficeData(completionHandler: @escaping (Result[BoxOfficeData]?, Error) -> Void) {
+            let networkManager = NetworkManager()
+
+            networkManager.fetchData(url: KobisOpenAPI.boxOffice(targetDate: targetDate.formatNoSeparator()).url) { (data, error) in
+                do {
+                    if let error = error {
+                        completionHandler(.failure(error))
+
+                        return
+                    }
+
+                    if let data = data {
+                        let decodedData = try DecodingManager.decodeJSON(type: BoxOffice.self, data: data)
+                        let boxOfficeItems = decodedData.boxOfficeResult.dailyBoxOfficeList
+                        completionHandler(.success(boxOfficeItems))
+                    }
+                } catch {
+                    completionHandler(.failure(error))
+                }
+            }
+        }
+    }
+    ```
+    ``` swift
+    // BoxOfficeViewController.swift
+    extension BoxOfficeViewController {
+        private func loadData() {
+            let boxOfficeManager = BoxOfficeManager(targetDate: yesterday)
+
+            boxOfficeManager.fetchBoxOfficeData { result in
+                switch result {
+                case .success(let items):
+                    guard let items = items else { return }
+                    self.items = items
+                    self.applySnapshot()
+                    self.stopActivityIndicator()
+                case .failure(let error):
+                    os_log("%{public}@", type: .default, error.localizedDescription)
+                }
+            }
+        }
+    ```
+   </details>
+
+<br>
+
+### 4️⃣ 셀 재사용으로 인한 문제
+🚨 **문제점** <br>
+- 새로고침 시 `rankIntensityLabel`의 `text` 색상이 바뀌는 문제가 있었습니다.<br>
+
+  <img src = "https://github.com/WhalesJin/FireSaturdayStudyClassC/assets/124643545/04a41bb7-cde0-4203-a56c-6e5219280fed" height = "500">
+
+</br>
+
+💡 **해결방법** <br>
+- 셀이 **재사용**이 되면서 발생하는 문제임을 알고, `prepareForReuse` 매서드에서 `rankIntensityLabel`의 `text` 색상을 초기화해주었습니다.
+
+    ```swift
+    // BoxOfficeCell.swift
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        rankIntensityLabel.textColor = .black
+    }
+    ```
+<br>
+
+## 📚 참고 링크<a id="참고_링크"></a>
+
+- [🍎Apple Docs: URLSession](https://developer.apple.com/documentation/foundation/urlsession)
+- [🍎Apple Docs: Fetching Website Data into Memory](https://developer.apple.com/documentation/foundation/url_loading_system/fetching_website_data_into_memory)
+- [🍎Apple Docs: Swift Closures - Capturing Values](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/closures/)
+- [🍎Apple Docs: UICollectionView](https://developer.apple.com/documentation/uikit/uicollectionview)
+- [🍎Apple Docs: XCTAssertThrowsError](https://developer.apple.com/documentation/xctest/1500795-xctassertthrowserror)
+- [🍏WWDC: Modern cell configuration](https://developer.apple.com/videos/play/wwdc2020/10027/)
+- [🍎Apple Docs: Implementing Modern Collection Views](https://developer.apple.com/documentation/uikit/views_and_controls/collection_views/implementing_modern_collection_views)
+- [🍎Apple Docs: CollectionView Layout](https://developer.apple.com/documentation/uikit/views_and_controls/collection_views/layouts)
+- [🍎Apple Docs: prepareforreuse](https://developer.apple.com/documentation/uikit/uicollectionreusableview/1620141-prepareforreuse)
+- <Img src = "https://github.com/WhalesJin/ios-bank-manager/assets/124643545/d1df2d8a-6667-438d-9643-aab8a83a4754" width="20"/> [Alamofire](https://github.com/Alamofire/Alamofire/blob/master/Source/Alamofire.swift)
+- <Img src = "https://github.com/WhalesJin/ios-bank-manager/assets/124643545/d1df2d8a-6667-438d-9643-aab8a83a4754" width="20"/> [Moya](https://github.com/Moya/Moya/tree/master/Sources/Moya)
+- <Img src = "https://github.com/mint3382/ios-calculator-app/assets/124643545/56986ab4-dc23-4e29-bdda-f00ec1db809b" width="20"/> [야곰닷넷: Test Double](https://yagom.net/courses/unit-test-작성하기/lessons/테스트를-위한-객체-만들기/topic/테스트를-위한-객체를-이용해서-테스트-작성하기/)
+- <Img src = "https://hackmd.io/_uploads/ByTEsGUv3.png" width="20"/> [blog: URL 처리 방법](https://ios-development.tistory.com/1014)
+
+<br>


### PR DESCRIPTION
안녕하세요, 븨븨(@YebinKim)!! 💃🏻
웰다비의 Dasan🌳, Whales🐬 인사드립니다 🙆🏻‍♀️
Step3 PR이 너무 늦어졌네요ㅠㅠ
늦어진만큼 꼼꼼히 챙겨가고 싶었는데, 보시기에 잘 되었을지 모르겠습니다 🥺

이번 스텝에서는 다양한 고민을 많이 해보았습니다.
`@available(iOS 14.0, *)` 키워드를 계속 붙여주는 대신 `Minimum Deployments`를 수정하는
비교적 간단한 고민부터,
메서드나 타입 기능분리나 텍스트에 `Dynamic Type`을 적용하는 부분까지!
정말 여러가지 고민들도 많이 해보고 해결도 해보는 유익한 Step3였습니다!!

보시고 부족한 부분을 알려주신다면 또 열심히 공부해보겠습니다 💪🏻🔥
이번 리뷰도 잘 부탁드립니다 🙇🏻‍♀️


## 🤹🏻 고민했던 점

### 🔹 역할 분리
🚨 **문제점** <br>
- 프로젝트를 진행하면서 아래와 같이 `ViewController`가 비대해졌고, 이는 `ViewController`가 많은 책임을 가지게 하였습니다.(또한 본래의 책임과는 동떨어진 기능들도 가지고 있었습니다.)

    <details>
        <summary> 코드 </summary>
    
    ```swift
    // BoxOfficeViewController.swift
    class BoxOfficeViewController: UIViewController {
        (...)

        override func viewDidLoad(){
            let networkManager = NetworkManager()

            networkManager.fetchData(url: KobisOpenAPI.boxOffice(targetDate: targetDate.formatNoSeparator()).url) { result in
                switch result {
                case .success(let data):
                    do {
                        let decodedData = try DecodingManager.decodeJSON(type: BoxOffice.self, data: data)
                        print(decodedData)

                        let boxOfficeItems = decodedData.boxOfficeResult.dailyBoxOfficeList

                        boxOfficeItems.forEach { item in
                            self.items.append(item)
                        }

                        (...)
                        self.dataSource.apply(snapshot, animatingDifferences: true)
                        self.stopActivityIndicator()
                    } catch DataError.notFoundAsset {
                        os_log("%{public}@", type: .default, DataError.notFoundAsset.localizedDescription)
                    } catch DataError.failedDecoding {
                        os_log("%{public}@", type: .default, DataError.failedDecoding.localizedDescription)
                    } catch {
                        os_log("알 수 없는 오류입니다.", type: .default)
                    }
                case .failure(let error):
                    os_log("%{public}@", type: .default, error.localizedDescription)
                }
            }
        }
        (...)
    }
    ```
    </details>
    
</br>

💡 **해결방법** <br>

- `ViewController`가 본래의 책임만을 다할 수 있도록 `BoxOfficeManager`라는 타입을 만들었습니다.
    > 본래 `ViewController`의 주요 책임
    > - 일반적으로 기초 데이터의 변경에 대한 응답으로 `뷰의 콘텐츠를 업데이트`
    > - 뷰에 대한 `사용자 상호 작용에 응답`
    > - 뷰 `크기 조정` 및 전체 인터페이스의 `레이아웃 관리`
    > - 앱에서 다른 객체(다른 뷰 컨트롤러 포함)와 조정

- `BoxOfficeManager`에서는 `API`를 통해 얻어온 `Data`를 `Swift`에서 사용할 수 있도록 `Data`를 디코딩하고, 그 결과를 `Result` 타입으로 반환합니다.
- `ViewController`에서는 `API`와의 통신을 몰라도 되며, `BoxOfficeManager`를 통해 받은 `Data`를 가지고 `View`에 전달하는 역할에 집중할 수 있도록 하였습니다.
    
    <details>
        <summary> 코드 </summary>
    
    ```swift
    // BoxOfficeManager.swift
    final class BoxOfficeManager {
        (...)
        func fetchBoxOfficeData(completionHandler: @escaping (Result[BoxOfficeData]?, Error) -> Void) {
            let networkManager = NetworkManager()

            networkManager.fetchData(url: KobisOpenAPI.boxOffice(targetDate: targetDate.formatNoSeparator()).url) { (data, error) in
                do {
                    if let error = error {
                        completionHandler(.failure(error))

                        return
                    }

                    if let data = data {
                        let decodedData = try DecodingManager.decodeJSON(type: BoxOffice.self, data: data)
                        let boxOfficeItems = decodedData.boxOfficeResult.dailyBoxOfficeList
                        completionHandler(.success(boxOfficeItems))
                    }
                } catch {
                    completionHandler(.failure(error))
                }
            }
        }
    }
    
    // BoxOfficeViewController.swift
    extension BoxOfficeViewController {
        private func loadData() {
            let boxOfficeManager = BoxOfficeManager(targetDate: yesterday)

            boxOfficeManager.fetchBoxOfficeData { result in
                switch result {
                case .success(let items):
                    guard let items = items else { return }
                    self.items = items
                    self.applySnapshot()
                    self.stopActivityIndicator()
                case .failure(let error):
                    os_log("%{public}@", type: .default, error.localizedDescription)
                }
            }
        }
    }
    ```
    </details>

### 🔹 Namespace
🚨 **문제점** <br>
- 셀의 구성 요소들의 크기와 간격을 조정하면서 제약사항 중 `constant`나 `multiplier`를 넣어주는 부분들을 구현하였는데 숫자를 직접 넣게 되면 나중에 유지/보수 시에 일일히 찾으러 가야해서 좋지 않다고 생각했습니다.
    <details>
        <summary> 코드 </summary>

    ```swift
    NSLayoutConstraint.activate([
        rankStackView.widthAnchor.constraint(equalTo: self.widthAnchor, multiplier: 0.23),
        stackView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
        stackView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -(self.frame.width * 0.12)),
        stackView.topAnchor.constraint(equalTo: self.topAnchor, constant: 14),
        stackView.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -14),
        titleStackView.topAnchor.constraint(equalTo: stackView.topAnchor, constant: 5),
        titleStackView.bottomAnchor.constraint(equalTo: stackView.bottomAnchor, constant: -5)
    ])
    ```
    </details>

</br>

💡 **해결방법** <br>
- `Namespace` 열거형을 만들어서 직접적인 숫자는 파일 한 군데에서 다 수정할 수 있도록 구현하였습니다.
    <details>
        <summary> 코드 </summary>

    ```swift
    enum ConstraintsNamespace {
        static let rankStackViewFromCellWidth: CGFloat = 0.23
        static let stackViewFromCellTrailing: CGFloat = 0.12
        static let stackViewFromCellTop: CGFloat = 14
        static let stackViewFromCellBottom: CGFloat = -14
        static let titleViewFromCellTop: CGFloat = 5
        static let titleViewFromCellBottom: CGFloat = -5  
    }
    ```
    ```swift
    NSLayoutConstraint.activate([
        rankStackView.widthAnchor.constraint(
            equalTo: self.widthAnchor,
            multiplier: ConstraintsNamespace.rankStackViewFromCellWidth
        ),
        stackView.leadingAnchor.constraint(
            equalTo: self.leadingAnchor
        ),
        stackView.trailingAnchor.constraint(
            equalTo: self.trailingAnchor,
            constant: -(self.frame.width * ConstraintsNamespace.stackViewFromCellTrailing)
        ),
        stackView.topAnchor.constraint(
            equalTo: self.topAnchor,
            constant: ConstraintsNamespace.stackViewFromCellTop
        ),
        stackView.bottomAnchor.constraint(
            equalTo: self.bottomAnchor,
            constant: ConstraintsNamespace.stackViewFromCellBottom
        ),
        titleStackView.topAnchor.constraint(
            equalTo: stackView.topAnchor,
            constant: ConstraintsNamespace.titleViewFromCellTop
        ),
        titleStackView.bottomAnchor.constraint(
            equalTo: stackView.bottomAnchor,
            constant: ConstraintsNamespace.titleViewFromCellBottom
        )
    ])
    ```
    </details>


### 🔹 셀 재사용
🚨 **문제점** <br>
- 새로고침 시 `rankIntensityLabel`의 `text` 색상이 바뀌는 문제가 있었습니다.
    <img src = "https://github.com/WhalesJin/FireSaturdayStudyClassC/assets/124643545/04a41bb7-cde0-4203-a56c-6e5219280fed" width = "200">

</br>

💡 **해결방법** <br>
- 셀이 **재사용**이 되면서 벌어지는 문제여서 재사용 시 초기화를 해주는 코드로 해결하였습니다.

    ```swift
    //BoxOfficeCell
    override func prepareForReuse() {
        super.prepareForReuse()
        rankIntensityLabel.textColor = .black
    }
    ```

### 🔹 refreshControl 호출 시점
🚨 **문제점** <br>
- `configureRefreshControl` 메서드에서 `refreshControl`은 `collectionView`가 없으면 코드가 성립하지 않기에, **collectionView가 생성되기 전** 해당 메서드를 호출하면 `Fatal Error`가 발생합니다.
 
💡 **해결방법** <br>
- 호출 시점이 매우 중요하다는 것을 알게된 후, 기존에 `viewDidLoad`에서 호출해주었던 메서드를 `configureHierarchy` 메서드 내에서 호출해주었습니다.
- 그 이유는 **collectionView가 생성된 것이 보장된 이후**에 호출하는 것이 가장 안전하다고 판단하였기 때문입니다.
    ```swift
    private func configureHierarchy() {
        collectionView = UICollectionView(frame: view.bounds, collectionViewLayout: createLayout())
        collectionView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
        view.addSubview(collectionView)
        configureRefreshControl()
    }
    ```

## 🎙️ 조언을 얻고 싶은 점
### 🔸 Dynamic Type Error
- `Dynamic Type`이 요구사항에는 없었지만 적용해주고 싶어서 넣어보았으나 크기를 마구 늘리고 줄이다보면 셀이 제대로 표시되지않는 문제점을 발견했습니다. 이런저런 코드 수정을 해보고 검색을 해보았으나 원인과 해결책을 찾지 못하였습니다. 왜 그럴까요?🥺
    <img src = "https://github.com/WhalesJin/FireSaturdayStudyClassC/assets/124643545/b843772b-8716-42c4-8847-f69b10409539" width = "700">

</br>

### 🔸 날짜 함수명
- 날짜를 `2023-08-06`, `20230806` 두 가지 형태의 문자열로 반환하는 메서드를 구현하는데 이름을 짓는 게 너무너무 고민이었습니다. 둘 다 자주 쓰이는 형태라 `standardDate`, `numericDate` 등을 생각했으나 보편적으로 쓰는 날짜가 `2023.8.6` 일지, `2023.08.06` 일지, `2023-08-06` 일지, 또 미국은 월일년 순으로 적으니 `08-06-23` 일지, 한 눈에 알 수 없을 거라 생각해서 두 가지 다 쓰지 못하였습니다.
- 현재 가장 직관적이라고 생각되는 함수명으로 지었으나 가이드라인에 맞는지 확신이 들지 않습니다. 괜찮을까요? 아니라면 혹시 추천해주실만한 이름이 있을까요? 🙇🏻‍♀️
    ```swift
    func formatByHyphen() -> String {
        dateFormatter.dateFormat = "yyyy-MM-dd"

        return dateFormatter.string(from:Date(timeIntervalSinceNow: dayToSecond))
    }

    func formatNoSeparator() -> String {
        dateFormatter.dateFormat = "yyyyMMdd"

        return dateFormatter.string(from: Date(timeIntervalSinceNow: dayToSecond))
    }
    ```
