### PR TITLE
박스오피스 [STEP 4] Yetti, Maxhyunm

### DIFF
--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		63DF20F32970E1A0005DF7D1 /* BoxOfficeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DF20F22970E1A0005DF7D1 /* BoxOfficeViewController.swift */; };
 		63DF20F82970E1A1005DF7D1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 63DF20F72970E1A1005DF7D1 /* Assets.xcassets */; };
 		63DF20FB2970E1A1005DF7D1 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 63DF20F92970E1A1005DF7D1 /* LaunchScreen.storyboard */; };
+		BA1A55AE2A81DF3D0012C89D /* MovieDetailStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1A55AD2A81DF3D0012C89D /* MovieDetailStackView.swift */; };
 		BAAC6F2E2A6E6B7700AD34ED /* box_office_sample.json in Resources */ = {isa = PBXBuildFile; fileRef = BAAC6F2D2A6E6B7700AD34ED /* box_office_sample.json */; };
 		BAAC6F302A6E6C4B00AD34ED /* BoxOfficeEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAAC6F2F2A6E6C4B00AD34ED /* BoxOfficeEntity.swift */; };
 		BAAC6F362A710D8100AD34ED /* MovieDetailEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAAC6F352A710D8100AD34ED /* MovieDetailEntity.swift */; };
@@ -62,6 +63,7 @@
 		63DF20F72970E1A1005DF7D1 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		63DF20FA2970E1A1005DF7D1 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		63DF20FC2970E1A1005DF7D1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		BA1A55AD2A81DF3D0012C89D /* MovieDetailStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieDetailStackView.swift; sourceTree = "<group>"; };
 		BAAC6F2D2A6E6B7700AD34ED /* box_office_sample.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = box_office_sample.json; sourceTree = "<group>"; };
 		BAAC6F2F2A6E6C4B00AD34ED /* BoxOfficeEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxOfficeEntity.swift; sourceTree = "<group>"; };
 		BAAC6F352A710D8100AD34ED /* MovieDetailEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieDetailEntity.swift; sourceTree = "<group>"; };
@@ -129,6 +131,7 @@
 			children = (
 				63DF20F92970E1A1005DF7D1 /* LaunchScreen.storyboard */,
 				3BF7D9AD2A79E69800996A5E /* BoxOfficeRankingCell.swift */,
+				BA1A55AD2A81DF3D0012C89D /* MovieDetailStackView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -305,6 +308,7 @@
 				3B8F5F9A2A70F69400D1A7F6 /* NetworkingManager.swift in Sources */,
 				BAAC6F362A710D8100AD34ED /* MovieDetailEntity.swift in Sources */,
 				3BF7D9B62A81C28400996A5E /* DaumImageEntity.swift in Sources */,
+				BA1A55AE2A81DF3D0012C89D /* MovieDetailStackView.swift in Sources */,
 				3BF714862A6E78E3006F274D /* DecodingManager.swift in Sources */,
 				3B8F5F9E2A72186D00D1A7F6 /* NetworkNamespace.swift in Sources */,
 				3B8F5F9C2A71032C00D1A7F6 /* Error.swift in Sources */,

--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		3BF7D9AE2A79E69800996A5E /* BoxOfficeRankingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF7D9AD2A79E69800996A5E /* BoxOfficeRankingCell.swift */; };
 		3BF7D9B12A7C7D0600996A5E /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF7D9B02A7C7D0600996A5E /* String+.swift */; };
 		3BF7D9B62A81C28400996A5E /* DaumImageEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF7D9B52A81C28400996A5E /* DaumImageEntity.swift */; };
+		3BF7D9B82A81D69300996A5E /* MovieDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF7D9B72A81D69300996A5E /* MovieDetailViewController.swift */; };
 		63DF20EF2970E1A0005DF7D1 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DF20EE2970E1A0005DF7D1 /* AppDelegate.swift */; };
 		63DF20F12970E1A0005DF7D1 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DF20F02970E1A0005DF7D1 /* SceneDelegate.swift */; };
 		63DF20F32970E1A0005DF7D1 /* BoxOfficeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DF20F22970E1A0005DF7D1 /* BoxOfficeViewController.swift */; };
@@ -53,6 +54,7 @@
 		3BF7D9AD2A79E69800996A5E /* BoxOfficeRankingCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxOfficeRankingCell.swift; sourceTree = "<group>"; };
 		3BF7D9B02A7C7D0600996A5E /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
 		3BF7D9B52A81C28400996A5E /* DaumImageEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaumImageEntity.swift; sourceTree = "<group>"; };
+		3BF7D9B72A81D69300996A5E /* MovieDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieDetailViewController.swift; sourceTree = "<group>"; };
 		63DF20EB2970E1A0005DF7D1 /* BoxOffice.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BoxOffice.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		63DF20EE2970E1A0005DF7D1 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		63DF20F02970E1A0005DF7D1 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -103,6 +105,7 @@
 			isa = PBXGroup;
 			children = (
 				63DF20F22970E1A0005DF7D1 /* BoxOfficeViewController.swift */,
+				3BF7D9B72A81D69300996A5E /* MovieDetailViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -294,6 +297,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BAAC6F4A2A734D1B00AD34ED /* URLSessionProtocol.swift in Sources */,
+				3BF7D9B82A81D69300996A5E /* MovieDetailViewController.swift in Sources */,
 				63DF20F32970E1A0005DF7D1 /* BoxOfficeViewController.swift in Sources */,
 				BAEB58522A7C811C0065A544 /* DateFormatter+.swift in Sources */,
 				63DF20EF2970E1A0005DF7D1 /* AppDelegate.swift in Sources */,

--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		3BF714862A6E78E3006F274D /* DecodingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF714852A6E78E3006F274D /* DecodingManager.swift */; };
 		3BF7D9AE2A79E69800996A5E /* BoxOfficeRankingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF7D9AD2A79E69800996A5E /* BoxOfficeRankingCell.swift */; };
 		3BF7D9B12A7C7D0600996A5E /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF7D9B02A7C7D0600996A5E /* String+.swift */; };
+		3BF7D9B62A81C28400996A5E /* DaumImageEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF7D9B52A81C28400996A5E /* DaumImageEntity.swift */; };
 		63DF20EF2970E1A0005DF7D1 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DF20EE2970E1A0005DF7D1 /* AppDelegate.swift */; };
 		63DF20F12970E1A0005DF7D1 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DF20F02970E1A0005DF7D1 /* SceneDelegate.swift */; };
 		63DF20F32970E1A0005DF7D1 /* BoxOfficeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DF20F22970E1A0005DF7D1 /* BoxOfficeViewController.swift */; };
@@ -51,6 +52,7 @@
 		3BF714852A6E78E3006F274D /* DecodingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodingManager.swift; sourceTree = "<group>"; };
 		3BF7D9AD2A79E69800996A5E /* BoxOfficeRankingCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxOfficeRankingCell.swift; sourceTree = "<group>"; };
 		3BF7D9B02A7C7D0600996A5E /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
+		3BF7D9B52A81C28400996A5E /* DaumImageEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaumImageEntity.swift; sourceTree = "<group>"; };
 		63DF20EB2970E1A0005DF7D1 /* BoxOffice.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BoxOffice.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		63DF20EE2970E1A0005DF7D1 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		63DF20F02970E1A0005DF7D1 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -110,6 +112,7 @@
 			children = (
 				BAAC6F2F2A6E6C4B00AD34ED /* BoxOfficeEntity.swift */,
 				BAAC6F352A710D8100AD34ED /* MovieDetailEntity.swift */,
+				3BF7D9B52A81C28400996A5E /* DaumImageEntity.swift */,
 				3BF714852A6E78E3006F274D /* DecodingManager.swift */,
 				3B8F5F992A70F69400D1A7F6 /* NetworkingManager.swift */,
 				3B8F5F9B2A71032C00D1A7F6 /* Error.swift */,
@@ -297,6 +300,7 @@
 				BAAC6F302A6E6C4B00AD34ED /* BoxOfficeEntity.swift in Sources */,
 				3B8F5F9A2A70F69400D1A7F6 /* NetworkingManager.swift in Sources */,
 				BAAC6F362A710D8100AD34ED /* MovieDetailEntity.swift in Sources */,
+				3BF7D9B62A81C28400996A5E /* DaumImageEntity.swift in Sources */,
 				3BF714862A6E78E3006F274D /* DecodingManager.swift in Sources */,
 				3B8F5F9E2A72186D00D1A7F6 /* NetworkNamespace.swift in Sources */,
 				3B8F5F9C2A71032C00D1A7F6 /* Error.swift in Sources */,

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -153,9 +153,7 @@ extension BoxOfficeViewController {
             switch result {
             case .success(let data):
                 do {
-                    guard let decodedData: BoxOfficeEntity = try DecodingManager.shared.decode(data) else {
-                        break
-                    }
+                    let decodedData: BoxOfficeEntity = try DecodingManager.shared.decode(data)
                     self?.setUpDataSnapshot(decodedData.boxOfficeResult.dailyBoxOfficeList)
                 } catch {
                     print(DecodingError.decodingFailure.description)

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -44,6 +44,7 @@ final class BoxOfficeViewController: UIViewController, URLSessionDelegate {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        collectionView.delegate = self
         isLoading = true
         setUpUI()
         setUpDate()
@@ -113,6 +114,19 @@ extension BoxOfficeViewController {
     }
 }
 
+extension BoxOfficeViewController: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard let movieCode = dataSource?.itemIdentifier(for: indexPath)?.movieCode,
+              let movieName = dataSource?.itemIdentifier(for: indexPath)?.movieName else {
+            return
+        }
+        
+        let movieDetailViewController = MovieDetailViewController(movieCode: movieCode, movieName: movieName)
+        
+        navigationController?.pushViewController(movieDetailViewController, animated: true)
+    }
+}
+
 extension BoxOfficeViewController {
     private func setUpNetwork() {
         let session: URLSession = {
@@ -158,3 +172,4 @@ extension BoxOfficeViewController {
         }
     }
 }
+

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -126,13 +126,17 @@ extension BoxOfficeViewController {
     }
     
     private func passFetchedData() {
-        guard let date = self.title?.replacingOccurrences(of: "-", with: "") else {
+        guard let date = self.title?.replacingOccurrences(of: "-", with: ""),
+              let url = URL(string: String(format: NetworkNamespace.boxOffice.url, NetworkNamespace.apiKey, date))
+        else {
+            print("?")
             return
         }
         
-        let url = String(format: NetworkNamespace.boxOffice.url, NetworkNamespace.apiKey, date)
+        let request = URLRequest(url: url)
         
-        networkingManager?.load(url) { [weak self] (result: Result<Data, NetworkingError>) in
+        
+        networkingManager?.load(request) { [weak self] (result: Result<Data, NetworkingError>) in
             switch result {
             case .success(let data):
                 do {

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -143,7 +143,6 @@ extension BoxOfficeViewController {
         guard let date = self.title?.replacingOccurrences(of: "-", with: ""),
               let url = URL(string: String(format: NetworkNamespace.boxOffice.url, NetworkNamespace.apiKey, date))
         else {
-            print("?")
             return
         }
         

--- a/BoxOffice/Controller/MovieDetailViewController.swift
+++ b/BoxOffice/Controller/MovieDetailViewController.swift
@@ -11,6 +11,37 @@ final class MovieDetailViewController: UIViewController {
     private let movieCode: String
     private let movieName: String
     
+    private let scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        
+        return scrollView
+    }()
+    
+    private let mainStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        stackView.alignment = .center
+        
+        return stackView
+    }()
+    
+    private let posterImageView: UIImageView = {
+        let imageView = UIImageView()
+        
+        return imageView
+    }()
+    
+    private let directorsStackView = MovieDetailStackView(title: "감독")
+    private let productionYearStackView = MovieDetailStackView(title: "제작년도")
+    private let openingDateStackView = MovieDetailStackView(title: "개봉일")
+    private let showTimeStackView = MovieDetailStackView(title: "상영시간")
+    private let auditsStackView = MovieDetailStackView(title: "관람등급")
+    private let nationsStackView = MovieDetailStackView(title: "제작국가")
+    private let genresStackView = MovieDetailStackView(title: "장르")
+    private let actorsStackView = MovieDetailStackView(title: "배우")
+    
     init(movieCode: String, movieName: String) {
         self.movieCode = movieCode
         self.movieName = movieName
@@ -24,7 +55,39 @@ final class MovieDetailViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        print(movieCode)
-        print(movieName)
+        addViews()
+        setUpUI()
+    }
+    
+    private func addViews() {
+        view.addSubview(scrollView)
+        scrollView.addSubview(mainStackView)
+        mainStackView.addArrangedSubview(posterImageView)
+        mainStackView.addArrangedSubview(directorsStackView)
+        mainStackView.addArrangedSubview(productionYearStackView)
+        mainStackView.addArrangedSubview(openingDateStackView)
+        mainStackView.addArrangedSubview(showTimeStackView)
+        mainStackView.addArrangedSubview(auditsStackView)
+        mainStackView.addArrangedSubview(nationsStackView)
+        mainStackView.addArrangedSubview(genresStackView)
+        mainStackView.addArrangedSubview(actorsStackView)
+    }
+    
+    private func setUpUI() {
+        self.title = movieName
+        let safeArea = view.safeAreaLayoutGuide
+        view.backgroundColor = .systemBackground
+
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: safeArea.topAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor),
+            
+            mainStackView.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            mainStackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+            mainStackView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            mainStackView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor)
+        ])
     }
 }

--- a/BoxOffice/Controller/MovieDetailViewController.swift
+++ b/BoxOffice/Controller/MovieDetailViewController.swift
@@ -1,0 +1,30 @@
+//
+//  MovieDetailViewController.swift
+//  BoxOffice
+//
+//  Created by Yetti, Maxhyunm on 2023/08/08.
+//
+
+import UIKit
+
+final class MovieDetailViewController: UIViewController {
+    private let movieCode: String
+    private let movieName: String
+    
+    init(movieCode: String, movieName: String) {
+        self.movieCode = movieCode
+        self.movieName = movieName
+        
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        print(movieCode)
+        print(movieName)
+    }
+}

--- a/BoxOffice/Controller/MovieDetailViewController.swift
+++ b/BoxOffice/Controller/MovieDetailViewController.swift
@@ -190,14 +190,16 @@ extension MovieDetailViewController: URLSessionDelegate {
     }
     
     private func setUpLabelText(_ data: MovieDetailEntity) {
-        directorsStackView.valueLabel.text = data.movieDetailData.movieInformation.directors.reduce("") { $0 + $1.name + ", " }
+        var formattedDate = data.movieDetailData.movieInformation.openingDate
+        
+        directorsStackView.valueLabel.text = data.movieDetailData.movieInformation.directors.map { $0.name }.joined(separator: ", ")
         productionYearStackView.valueLabel.text = data.movieDetailData.movieInformation.productionYear
-        openingDateStackView.valueLabel.text = data.movieDetailData.movieInformation.openingDate
+        openingDateStackView.valueLabel.text = formattedDate.changeDateFormat()
         showTimeStackView.valueLabel.text = data.movieDetailData.movieInformation.showTime
-        auditsStackView.valueLabel.text = data.movieDetailData.movieInformation.audits.reduce("") { $0 + $1.movieRating + ", " }
-        nationsStackView.valueLabel.text = data.movieDetailData.movieInformation.nations.reduce("") { $0 + $1.name + ", " }
-        genresStackView.valueLabel.text = data.movieDetailData.movieInformation.genres.reduce("") { $0 + $1.name + ", " }
-        actorsStackView.valueLabel.text = data.movieDetailData.movieInformation.actors.reduce("") { $0 + $1.name + ", " }
+        auditsStackView.valueLabel.text = data.movieDetailData.movieInformation.audits.map { $0.movieRating }.joined(separator: ", ")
+        nationsStackView.valueLabel.text = data.movieDetailData.movieInformation.nations.map { $0.name }.joined(separator: ", ")
+        genresStackView.valueLabel.text = data.movieDetailData.movieInformation.genres.map { $0.name }.joined(separator: ", ")
+        actorsStackView.valueLabel.text = data.movieDetailData.movieInformation.actors.map { $0.name }.joined(separator: ", ")
 
     }
 }

--- a/BoxOffice/Extension/String+.swift
+++ b/BoxOffice/Extension/String+.swift
@@ -19,4 +19,16 @@ extension String {
         
         return numberFormatter.string(for: NSNumber(value: intData)) ?? self
     }
+    
+    mutating func changeDateFormat() -> String {
+        let index1 = self.index(self.startIndex, offsetBy: 4)
+        let index2 = self.index(self.startIndex, offsetBy: 6)
+
+        self.insert("-", at: index2)
+        self.insert("-", at: index1)
+
+        return self
+    }
 }
+
+

--- a/BoxOffice/Extension/String+.swift
+++ b/BoxOffice/Extension/String+.swift
@@ -19,5 +19,4 @@ extension String {
         
         return numberFormatter.string(for: NSNumber(value: intData)) ?? self
     }
-
 }

--- a/BoxOffice/Info.plist
+++ b/BoxOffice/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>DAUM_API_KEY</key>
+	<string>$(DAUM_API_KEY)</string>
 	<key>API_KEY</key>
 	<string>$(API_KEY)</string>
 	<key>NSAppTransportSecurity</key>

--- a/BoxOffice/Model/DaumImageEntity.swift
+++ b/BoxOffice/Model/DaumImageEntity.swift
@@ -1,0 +1,41 @@
+//
+//  DaumImageEntity.swift
+//  BoxOffice
+//
+//  Created by Yetti, Maxhyunm on 2023/08/08.
+//
+import Foundation
+
+struct DaumImageEntity: Decodable {
+    let meta: Meta
+    let documents: [Document]
+}
+
+extension DaumImageEntity {
+    struct Meta: Decodable {
+        let totalCount, pageableCount: Int
+        let isEnd: Bool
+        
+        enum CodingKeys: String, CodingKey {
+            case totalCount = "total_count"
+            case pageableCount = "pageable_count"
+            case isEnd = "is_end"
+        }
+    }
+}
+
+extension DaumImageEntity {
+    struct Document: Decodable {
+        let collection, thumbnailURL, imageURL, displaySitename, documentURL: String
+        let width, height: Int
+        let datetime: Date
+        
+        enum CodingKeys: String, CodingKey {
+            case collection, width, height, datetime
+            case thumbnailURL = "thumbnail_url"
+            case imageURL = "image_url"
+            case displaySitename = "display_sitename"
+            case documentURL = "doc_url"
+        }
+    }
+}

--- a/BoxOffice/Model/DaumImageEntity.swift
+++ b/BoxOffice/Model/DaumImageEntity.swift
@@ -26,9 +26,8 @@ extension DaumImageEntity {
 
 extension DaumImageEntity {
     struct Document: Decodable {
-        let collection, thumbnailURL, imageURL, displaySitename, documentURL: String
+        let collection, thumbnailURL, imageURL, displaySitename, documentURL, datetime: String
         let width, height: Int
-        let datetime: Date
         
         enum CodingKeys: String, CodingKey {
             case collection, width, height, datetime

--- a/BoxOffice/Model/DecodingManager.swift
+++ b/BoxOffice/Model/DecodingManager.swift
@@ -18,7 +18,6 @@ final class DecodingManager {
               let decodedData = try? decoder.decode(T.self, from: data) else {
             throw DecodingError.decodingFailure
         }
-        
         return decodedData
     }
 }

--- a/BoxOffice/Model/NetworkingManager.swift
+++ b/BoxOffice/Model/NetworkingManager.swift
@@ -14,12 +14,8 @@ struct NetworkingManager {
         self.session = session
     }
     
-    func load(_ urlString: String, completion: @escaping (Result<Data, NetworkingError>) -> Void) {
-        guard let url = URL(string: urlString) else {
-            return
-        }
-
-        let task = session.dataTask(with: url) { data, response, error in
+    func load(_ request: URLRequest, completion: @escaping (Result<Data, NetworkingError>) -> Void) {
+        let task = session.dataTask(with: request) { data, response, error in
             if error != nil {
                 completion(.failure(NetworkingError.connectionFailure))
                 return

--- a/BoxOffice/Model/URLSessionProtocol.swift
+++ b/BoxOffice/Model/URLSessionProtocol.swift
@@ -10,7 +10,7 @@ import Foundation
 typealias NetworkingCompletionHandler = @Sendable (Data?, URLResponse?, Error?) -> Void
 
 protocol URLSessionProtocol {
-    func dataTask(with url: URL, completionHandler: @escaping NetworkingCompletionHandler) -> URLSessionDataTask
+    func dataTask(with: URLRequest, completionHandler: @escaping NetworkingCompletionHandler) -> URLSessionDataTask
 }
 
 extension URLSession: URLSessionProtocol {}

--- a/BoxOffice/Resource/Assets.xcassets/daum_image_sample.dataset/Contents.json
+++ b/BoxOffice/Resource/Assets.xcassets/daum_image_sample.dataset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "data" : [
+    {
+      "filename" : "daum_image_sample.json",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/BoxOffice/Resource/Assets.xcassets/daum_image_sample.dataset/daum_image_sample.json
+++ b/BoxOffice/Resource/Assets.xcassets/daum_image_sample.dataset/daum_image_sample.json
@@ -1,0 +1,809 @@
+{
+    "documents": [
+        {
+            "collection": "cafe",
+            "datetime": "2023-06-10T12:36:51.000+09:00",
+            "display_sitename": "Daum카페",
+            "doc_url": "https://cafe.daum.net/subdued20club/ReHf/4436482",
+            "height": 1474,
+            "image_url": "https://t1.daumcdn.net/cafeattach/1IHuH/f7f31ed51da240282d463ad00ef2c274d167de7a",
+            "thumbnail_url": "https://search4.kakaocdn.net/argon/130x130_85_c/5kEtQJmJL9F",
+            "width": 1024
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-07-10T14:50:55.000+09:00",
+            "display_sitename": "티스토리",
+            "doc_url": "http://moneymakingsadangbug.tistory.com/409",
+            "height": 285,
+            "image_url": "https://blog.kakaocdn.net/dn/lFc7z/btsmZfuSq5D/MoH5E18dspEhKaxJ29KilK/img.png",
+            "thumbnail_url": "https://search4.kakaocdn.net/argon/130x130_85_c/vtemnLpX1B",
+            "width": 600
+        },
+        {
+            "collection": "cafe",
+            "datetime": "2023-06-10T12:36:51.000+09:00",
+            "display_sitename": "Daum카페",
+            "doc_url": "https://cafe.daum.net/subdued20club/ReHf/4436482",
+            "height": 850,
+            "image_url": "https://t1.daumcdn.net/cafeattach/1IHuH/aa0d807980cba1b2e3ad2443c97a44de36cc799a",
+            "thumbnail_url": "https://search4.kakaocdn.net/argon/130x130_85_c/8GKusOYYFnS",
+            "width": 660
+        },
+        {
+            "collection": "news",
+            "datetime": "2023-06-17T08:03:02.000+09:00",
+            "display_sitename": "스타투데이",
+            "doc_url": "http://v.media.daum.net/v/20230617080302768",
+            "height": 350,
+            "image_url": "https://t1.daumcdn.net/news/202306/17/startoday/20230617080307222zcws.jpg",
+            "thumbnail_url": "https://search4.kakaocdn.net/argon/130x130_85_c/48iLbws2b1c",
+            "width": 600
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-07-10T22:51:00.000+09:00",
+            "display_sitename": "네이버블로그",
+            "doc_url": "http://blog.naver.com/albireo486/223152359195",
+            "height": 699,
+            "image_url": "https://postfiles.pstatic.net/MjAyMzA3MTBfMTc1/MDAxNjg4OTk2OTA1MDQw.DjMUFlwSonfLao9aeiOqqtTpA9SIOJK5cldoeA0BdYcg.EBD4JJOOLc0a3i7MDpqaZIqRQ93XwAeuSUAt_YKCoygg.PNG.albireo486/%EC%BA%90%EB%A6%AD%ED%84%B0_%ED%8F%AC%EC%8A%A4%ED%84%B0_-_6%EC%9D%B8.png?type=w773",
+            "thumbnail_url": "https://search3.kakaocdn.net/argon/130x130_85_c/ANveL4fLFy2",
+            "width": 740
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-07-04T17:35:00.000+09:00",
+            "display_sitename": "네이버블로그",
+            "doc_url": "http://blog.naver.com/albireo486/223146727604",
+            "height": 300,
+            "image_url": "https://dthumb-phinf.pstatic.net/?src=%22https%3A%2F%2Fblogthumb.pstatic.net%2FMjAyMzA0MThfMzAw%2FMDAxNjgxNzkzNTAyMjI3.12ESyy-OUS5rgJDQKFEV_nmmK5ggltXPPyuwBiY1AJQg.XHyI_EsMkSJpLjacvsS6wEk3EtNsrV3dhjCJD0eqTNsg.JPEG.albireo486%2F%25B9%25D0%25BC%25F6_%25C6%25F7%25BD%25BA%25C5%25CD.jpg%3Ftype%3Dw2%22&type=ff500_300",
+            "thumbnail_url": "https://search3.kakaocdn.net/argon/130x130_85_c/51wiFPDgmZf",
+            "width": 500
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-07-04T17:35:00.000+09:00",
+            "display_sitename": "네이버블로그",
+            "doc_url": "http://blog.naver.com/albireo486/223146727604",
+            "height": 740,
+            "image_url": "https://postfiles.pstatic.net/MjAyMzA3MDRfMjY0/MDAxNjg4NDU4Mzg3MTgx.SqbCHhdOc7LAJIBfGDWF8QGiOyzaxahqd0Jkn_Ig4bUg.gEWZKQoDb6vPd6uvxW6ltCPIk_gbRJNPCUoNq17vmXog.JPEG.albireo486/KakaoTalk_20230617_071658073.jpg?type=w773",
+            "thumbnail_url": "https://search3.kakaocdn.net/argon/130x130_85_c/4mzQd2mXRoN",
+            "width": 517
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-07-04T17:35:00.000+09:00",
+            "display_sitename": "네이버블로그",
+            "doc_url": "http://blog.naver.com/albireo486/223146727604",
+            "height": 631,
+            "image_url": "https://postfiles.pstatic.net/MjAyMzA3MDRfODkg/MDAxNjg4NDU4OTM1OTQ0.S_QxQ8T3hFPXSkfaYpjjvge4KRf0wGckPazuoKDFj40g.hGqX2xdhauqkryfp0i2rjYgsRFiFGMsJD4bLPIrZWR0g.JPEG.albireo486/Screenshot_2023-07-04_at_13.39.21.JPG?type=w773",
+            "thumbnail_url": "https://search1.kakaocdn.net/argon/130x130_85_c/HSNuVTR7Qhs",
+            "width": 740
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-06-16T19:10:01.000+09:00",
+            "display_sitename": "티스토리",
+            "doc_url": "http://ani-movie.tistory.com/1062",
+            "height": 1080,
+            "image_url": "https://blog.kakaocdn.net/dn/qccvq/btske593tLk/TLOLDkaeR9W98s6SIfPXPk/img.jpg",
+            "thumbnail_url": "https://search3.kakaocdn.net/argon/130x130_85_c/FTD74juyG5G",
+            "width": 1920
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-07-31T00:48:00.000+09:00",
+            "display_sitename": "네이버블로그",
+            "doc_url": "https://blog.naver.com/juheekims/223170377920",
+            "height": 300,
+            "image_url": "https://dthumb-phinf.pstatic.net/?src=%22https%3A%2F%2Fsmugglers.kr%2Fviews%2Fres%2Fimgs%2Fcommon%2Fog.png%3Fv%3D45%22&type=ff500_300",
+            "thumbnail_url": "https://search1.kakaocdn.net/argon/130x130_85_c/7c4yOL5qHIT",
+            "width": 500
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-07-12T23:23:23.000+09:00",
+            "display_sitename": "티스토리",
+            "doc_url": "http://jjobanjang.tistory.com/14",
+            "height": 777,
+            "image_url": "https://blog.kakaocdn.net/dn/buUVDO/btsnjb7xHGO/l2N7znwKPTVXkNMxbHuD1K/img.png",
+            "thumbnail_url": "https://search1.kakaocdn.net/argon/130x130_85_c/BWezOc940oR",
+            "width": 546
+        },
+        {
+            "collection": "cafe",
+            "datetime": "2023-07-10T10:57:21.000+09:00",
+            "display_sitename": "Daum카페",
+            "doc_url": "https://cafe.daum.net/SoulDresser/FLTB/742992",
+            "height": 720,
+            "image_url": "http://scrap.kakaocdn.net/dn/d0u97H/hyTfBGKMrl/S8Yno6txcrszAjp5fYIEf1/img.jpg?width=1280&height=720&face=62_252_106_300",
+            "thumbnail_url": "https://search2.kakaocdn.net/argon/130x130_85_c/3NewHQlDbvH",
+            "width": 1280
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-07-29T17:18:18.000+09:00",
+            "display_sitename": "티스토리",
+            "doc_url": "http://a-life-challenger.tistory.com/44",
+            "height": 819,
+            "image_url": "https://blog.kakaocdn.net/dn/ObsY9/btspmXdig7G/okcFjijiioKhP17Txy8DM0/img.png",
+            "thumbnail_url": "https://search3.kakaocdn.net/argon/130x130_85_c/4pIF4q6mIMs",
+            "width": 546
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-06-16T19:10:01.000+09:00",
+            "display_sitename": "티스토리",
+            "doc_url": "http://ani-movie.tistory.com/1062",
+            "height": 1080,
+            "image_url": "https://blog.kakaocdn.net/dn/cEysSN/btskhKv7fxl/pzhlbD4ilRM0zgnCMKY9e1/img.jpg",
+            "thumbnail_url": "https://search4.kakaocdn.net/argon/130x130_85_c/7VuQo4gpdwz",
+            "width": 1920
+        },
+        {
+            "collection": "cafe",
+            "datetime": "2023-07-10T10:57:21.000+09:00",
+            "display_sitename": "Daum카페",
+            "doc_url": "https://cafe.daum.net/SoulDresser/FLTB/742992",
+            "height": 1716,
+            "image_url": "https://t1.daumcdn.net/cafeattach/1D7bO/fa5a8fb4da1b33057d1350daaa664091410ab1dd",
+            "thumbnail_url": "https://search4.kakaocdn.net/argon/130x130_85_c/J4hUfp0etgt",
+            "width": 1200
+        },
+        {
+            "collection": "blog",
+            "datetime": "2021-09-06T14:56:00.000+09:00",
+            "display_sitename": "네이버블로그",
+            "doc_url": "http://blog.naver.com/ggamuger/222496815042",
+            "height": 435,
+            "image_url": "https://postfiles.pstatic.net/MjAyMTA5MDRfMTk4/MDAxNjMwNzMwNjA5Mjcy.rup-ZiltLA_EjKj_2s2IPlgdFBqGyfEvkoAfnAWGHnQg.BXlv6TkosmAfV002eaA3f1pBrlTM_nSj8KbRwjsdVAEg.PNG.ggamuger/1630730487026.png?type=w773",
+            "thumbnail_url": "https://search2.kakaocdn.net/argon/130x130_85_c/8ARP6pMeo3b",
+            "width": 773
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-07-30T19:14:50.000+09:00",
+            "display_sitename": "티스토리",
+            "doc_url": "http://apple.presentcool.com/3",
+            "height": 512,
+            "image_url": "https://blog.kakaocdn.net/dn/cp4C3R/btsplbjspzR/dLC5YLhfHUeKANkbG8m6KK/img.jpg",
+            "thumbnail_url": "https://search2.kakaocdn.net/argon/130x130_85_c/8CSFVXXxwl6",
+            "width": 512
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-07-26T22:01:00.000+09:00",
+            "display_sitename": "네이버블로그",
+            "doc_url": "https://blog.naver.com/analogseoul/223166965751",
+            "height": 515,
+            "image_url": "https://postfiles.pstatic.net/MjAyMzA3MjZfMjU2/MDAxNjkwMzczNzI1MDYw.UZKGZx0hB-9Qb6FxKpeyAEEyh06TYOJH3nA1JAJXw3kg.0I5X_5DdB3Eq-P40uncGdSnnSFxtM-ppQRP1ilmtVy0g.JPEG.analogseoul/common.jpeg?type=w773",
+            "thumbnail_url": "https://search3.kakaocdn.net/argon/130x130_85_c/BYedLOP3Xsc",
+            "width": 773
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-07-26T22:01:00.000+09:00",
+            "display_sitename": "네이버블로그",
+            "doc_url": "https://blog.naver.com/analogseoul/223166965751",
+            "height": 515,
+            "image_url": "https://postfiles.pstatic.net/MjAyMzA3MjZfNTgg/MDAxNjkwMzczNzI0Nzc2.5uKabsbVSd5MMhNuhO00fV6zZ7n6Z0fGMIjACR99wQ4g.Vtj1RI4ke0K-oM7Ar5vK5Hu1pm3egKF-YYL5jgL5GYgg.JPEG.analogseoul/common.jpeg?type=w773",
+            "thumbnail_url": "https://search4.kakaocdn.net/argon/130x130_85_c/4PbzV3W4Jic",
+            "width": 773
+        },
+        {
+            "collection": "blog",
+            "datetime": "2021-09-06T14:56:00.000+09:00",
+            "display_sitename": "네이버블로그",
+            "doc_url": "http://blog.naver.com/ggamuger/222496815042",
+            "height": 1373,
+            "image_url": "https://postfiles.pstatic.net/MjAyMTA5MDJfMjky/MDAxNjMwNTg1Njg2Nzc3.bqzV3i7zWDXjJVf8uCQsUoW6MMDs9g-6tdpy59JvWwkg.-bg6EKNoGMSKAZGyy6CXXXtFahcE9y9a7gavKN1zAC8g.JPEG.ggamuger/20210902%EF%BC%BF124453.jpg?type=w773",
+            "thumbnail_url": "https://search3.kakaocdn.net/argon/130x130_85_c/HkvRPV38UNv",
+            "width": 773
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-07-14T16:00:00.000+09:00",
+            "display_sitename": "네이버블로그",
+            "doc_url": "http://blog.naver.com/mullgyeol/223156033817",
+            "height": 644,
+            "image_url": "https://postfiles.pstatic.net/MjAyMzA3MTRfMTg0/MDAxNjg5MzEwMjI5Njkw.PJxtxs8CV5sch5JORSch_dSNpUuuwBzXrwEwGE-M1XAg.fm5OMCI2lP-xXbdl26CbcYJFNVZrK-zGZjxbE3qo5EAg.JPEG.shim_000/common_(26).jpeg?type=w966",
+            "thumbnail_url": "https://search3.kakaocdn.net/argon/130x130_85_c/IyNXLLCgOcT",
+            "width": 966
+        },
+        {
+            "collection": "news",
+            "datetime": "2023-01-26T13:40:29.000+09:00",
+            "display_sitename": "한국경제TV",
+            "doc_url": "http://v.media.daum.net/v/20230126134029149",
+            "height": 250,
+            "image_url": "https://t1.daumcdn.net/news/202301/26/kedtv/20230126134033794vdiw.jpg",
+            "thumbnail_url": "https://search1.kakaocdn.net/argon/130x130_85_c/1BNduwQzYbk",
+            "width": 540
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-06-27T07:06:10.000+09:00",
+            "display_sitename": "티스토리",
+            "doc_url": "http://dd.1cozy.com/27",
+            "height": 772,
+            "image_url": "https://blog.kakaocdn.net/dn/bPXZZF/btslaHlPhuP/xqy6q5q3LLTWFNzn7v6Qd0/img.png",
+            "thumbnail_url": "https://search3.kakaocdn.net/argon/130x130_85_c/3FIPPj8ngyF",
+            "width": 536
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-07-27T00:38:00.000+09:00",
+            "display_sitename": "네이버블로그",
+            "doc_url": "https://blog.naver.com/yxlog23/223167096939",
+            "height": 727,
+            "image_url": "https://postfiles.pstatic.net/MjAyMzA3MjZfMTUz/MDAxNjkwMzQ2MzQ0OTY2.Gaw52yk5tOIfn9KOSXswszG3tFryUsFVCkVvekd4wqYg.WY8gd39T7rw1k34V0u7rXFZ20NIMrf0n1BGLpL--x-8g.JPEG.wl2312/IMG_6930.JPG?type=w580",
+            "thumbnail_url": "https://search3.kakaocdn.net/argon/130x130_85_c/3w4RuGk6Mfc",
+            "width": 510
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-05-30T20:30:15.000+09:00",
+            "display_sitename": "티스토리",
+            "doc_url": "http://dbc.sfanxi.com/127",
+            "height": 858,
+            "image_url": "https://blog.kakaocdn.net/dn/Np3k3/btsh3D0Ivbx/ev0dv5iAQw0oXkiX9yHGR0/img.jpg",
+            "thumbnail_url": "https://search3.kakaocdn.net/argon/130x130_85_c/GSAaNhRU6PO",
+            "width": 600
+        },
+        {
+            "collection": "blog",
+            "datetime": "2021-09-06T14:56:00.000+09:00",
+            "display_sitename": "네이버블로그",
+            "doc_url": "http://blog.naver.com/ggamuger/222496815042",
+            "height": 1373,
+            "image_url": "https://postfiles.pstatic.net/MjAyMTA5MDJfMTc3/MDAxNjMwNTg1NjczNDY2.ZVROz_yifrEDvrF2IRvoA2KXcCtYlDKX1mpnwLj5vcQg.iwGU1Lb-OVMxyK48ANEXwgaK6DJu4ilOuLZMMccOmO8g.JPEG.ggamuger/20210902%EF%BC%BF160400.jpg?type=w773",
+            "thumbnail_url": "https://search3.kakaocdn.net/argon/130x130_85_c/K0DTbNpf0zy",
+            "width": 773
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-07-19T22:45:00.000+09:00",
+            "display_sitename": "네이버블로그",
+            "doc_url": "http://blog.naver.com/yunjuuuup/223160955445",
+            "height": 300,
+            "image_url": "https://dthumb-phinf.pstatic.net/?src=%22https%3A%2F%2Fphinf.pstatic.net%2Ftvcast%2F20230707_153%2FQLYcE_1688709478975OKsa4_JPEG%2Ff166453c-1c8a-11ee-9868-505dacfbaa5c_07.jpg%3Ftype%3Df880_495_blend%22&type=ff500_300",
+            "thumbnail_url": "https://search2.kakaocdn.net/argon/130x130_85_c/DVVxtM6OAMC",
+            "width": 500
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-01-26T08:00:00.000+09:00",
+            "display_sitename": "네이버블로그",
+            "doc_url": "http://blog.naver.com/emfj7/222994460586",
+            "height": 320,
+            "image_url": "https://postfiles.pstatic.net/MjAyMzAxMjZfMTY0/MDAxNjc0NjY3MjI3OTY3.3aZiKDchlZVsMStnaXw4E9JkpmK-3E-_ztpJpVW1NAsg.S2sbjzorpf4UehHgm8f0186MBO75W9KJX6grBGLNCewg.JPEG.emfj7/%EC%98%81%ED%99%94_%27%EB%B0%80%EC%88%98%27_%EB%9F%B0%EC%B9%AD_%EC%98%88%EA%B3%A0%ED%8E%B8.mp4_20230126_021854.795.jpg?type=w773",
+            "thumbnail_url": "https://search1.kakaocdn.net/argon/130x130_85_c/GUgycXg1Xft",
+            "width": 773
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-07-12T14:36:00.000+09:00",
+            "display_sitename": "네이버블로그",
+            "doc_url": "http://blog.naver.com/k-review/223154018490",
+            "height": 310,
+            "image_url": "https://postfiles.pstatic.net/MjAyMzA3MTJfMjg3/MDAxNjg5MTM0OTYyOTk3.3PYf4QrR9BV3fdQUBnsHpHcT7Kx7IRc0JIWIzX3rVYUg.JzDPSDJCiYm_5HFbvRXcCI9sXg13dd4KmhmaPaOBRH0g.PNG.bins9012/image.png?type=w466",
+            "thumbnail_url": "https://search4.kakaocdn.net/argon/130x130_85_c/9k94cV7pU6R",
+            "width": 466
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-07-26T22:01:00.000+09:00",
+            "display_sitename": "네이버블로그",
+            "doc_url": "https://blog.naver.com/analogseoul/223166965751",
+            "height": 541,
+            "image_url": "https://postfiles.pstatic.net/MjAyMzA3MjZfOTIg/MDAxNjkwMzczNjQ5NzQz.pLOiSs2QAHlbiV3xVqVe8ioBs3VQaUlO0o4DGhKV8rgg.iZBN6-MNqkFTmKsh8kl8zRoWYabjE1JRpN6p9s9kTO8g.JPEG.analogseoul/common.jpeg?type=w773",
+            "thumbnail_url": "https://search3.kakaocdn.net/argon/130x130_85_c/Lu9hTDNzziN",
+            "width": 773
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-07-12T01:19:12.000+09:00",
+            "display_sitename": "티스토리",
+            "doc_url": "http://jobdahanjisick.tistory.com/53",
+            "height": 715,
+            "image_url": "https://blog.kakaocdn.net/dn/s9K7g/btsni88QBpD/wpbm3BSYW9Ri0wcp0wYhs0/img.jpg",
+            "thumbnail_url": "https://search1.kakaocdn.net/argon/130x130_85_c/4wswvVtsXmd",
+            "width": 700
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-05-18T09:59:00.000+09:00",
+            "display_sitename": "네이버블로그",
+            "doc_url": "http://blog.naver.com/siniljang21/223105253474",
+            "height": 340,
+            "image_url": "https://postfiles.pstatic.net/MjAyMzA1MjBfMTA5/MDAxNjg0NTY1Mzg0MDUw.dqCPjc9_OMmcraasy5Q6RlW6bO306TUsrDKjbwoDqyMg.IrM4SCmgB36plz7tVUFlvPi28wK5KmQatubpVOODvkAg.JPEG.siniljang21/%EB%8B%A4%EC%9A%B4%EB%A1%9C%EB%93%9C_(2).jpg?type=w580",
+            "thumbnail_url": "https://search3.kakaocdn.net/argon/130x130_85_c/7qgRfcFviGa",
+            "width": 340
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-06-10T17:51:01.000+09:00",
+            "display_sitename": "티스토리",
+            "doc_url": "http://jmsy0519.tistory.com/756",
+            "height": 800,
+            "image_url": "https://blog.kakaocdn.net/dn/bPMN9f/btskeKXYz1z/7tjIFSFqakIQO1hxn8Wy3k/img.jpg",
+            "thumbnail_url": "https://search1.kakaocdn.net/argon/130x130_85_c/B3tO1W6Zyh8",
+            "width": 704
+        },
+        {
+            "collection": "cafe",
+            "datetime": "2023-07-05T09:53:51.000+09:00",
+            "display_sitename": "Daum카페",
+            "doc_url": "https://cafe.daum.net/weareshower/ZEmx/310249",
+            "height": 1080,
+            "image_url": "https://t1.daumcdn.net/cafeattach/1ZL5Z/4a812b0dcabd6ee4aa338270a57a16f2acbe0aa6",
+            "thumbnail_url": "https://search4.kakaocdn.net/argon/130x130_85_c/eI5CuN6Ito",
+            "width": 751
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-07-17T00:20:34.000+09:00",
+            "display_sitename": "티스토리",
+            "doc_url": "http://lemi100.com/42",
+            "height": 312,
+            "image_url": "https://blog.kakaocdn.net/dn/Ty9x5/btsnLalavw7/cBKllOlPAPF1WjPGHG0Is0/img.png",
+            "thumbnail_url": "https://search3.kakaocdn.net/argon/130x130_85_c/2T4scXwpLyd",
+            "width": 466
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-07-27T18:09:20.000+09:00",
+            "display_sitename": "티스토리",
+            "doc_url": "http://relaxmylife.tistory.com/123",
+            "height": 638,
+            "image_url": "https://blog.kakaocdn.net/dn/dmR4Az/btspd4X07TZ/dV0ftq5qYCwy1ZKKLulwfk/img.png",
+            "thumbnail_url": "https://search4.kakaocdn.net/argon/130x130_85_c/9MOuAeMVFjy",
+            "width": 671
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-07-11T00:45:47.000+09:00",
+            "display_sitename": "티스토리",
+            "doc_url": "http://eatclimber.tistory.com/5",
+            "height": 427,
+            "image_url": "https://blog.kakaocdn.net/dn/b9B5Ng/btsm8g1tOK8/IxlRcPDuZ1kXOmqBCAs0N1/img.jpg",
+            "thumbnail_url": "https://search2.kakaocdn.net/argon/130x130_85_c/PfT8jGNmSG",
+            "width": 340
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-07-28T01:44:23.000+09:00",
+            "display_sitename": "티스토리",
+            "doc_url": "http://mazino.tistory.com/53",
+            "height": 853,
+            "image_url": "https://blog.kakaocdn.net/dn/kA37e/btso936N2HJ/MxtrkaL6XoaMZxdOaCsq9K/img.jpg",
+            "thumbnail_url": "https://search4.kakaocdn.net/argon/130x130_85_c/AFlhX3JReeF",
+            "width": 1280
+        },
+        {
+            "collection": "blog",
+            "datetime": "2017-08-26T17:06:00.000+09:00",
+            "display_sitename": "네이버블로그",
+            "doc_url": "http://blog.naver.com/jrkimceo/221082723135",
+            "height": 996,
+            "image_url": "https://postfiles.pstatic.net/MjAxNzA4MjZfMjgx/MDAxNTAzNzI3Mjg2OTg1.cj5ZmDTS6KOV5TK_INxiK66KpIsU_QRrSVIZUhIlD_wg.9YdjFo8gXFwl-Yh1kjA9WPmxGqehuQyy3we0Fm-tDnYg.JPEG.jrkimceo/minimalist_movie_posters7.jpg?type=w773",
+            "thumbnail_url": "https://search1.kakaocdn.net/argon/130x130_85_c/AtZS3iMviq9",
+            "width": 773
+        },
+        {
+            "collection": "blog",
+            "datetime": "2017-08-26T17:06:00.000+09:00",
+            "display_sitename": "네이버블로그",
+            "doc_url": "http://blog.naver.com/jrkimceo/221082723135",
+            "height": 1051,
+            "image_url": "https://postfiles.pstatic.net/MjAxNzA4MjZfMTQ4/MDAxNTAzNzI3MjE3OTgx.cLZFvs7Hd8CoGMCMfufNaiifChndERwUnz0u4_zsuwYg.R3o7j5krM95XieJlNyygBNvMHdSBBR5uTP9w0L8Cg8cg.JPEG.jrkimceo/minimalist_movie_posters6.jpg?type=w773",
+            "thumbnail_url": "https://search4.kakaocdn.net/argon/130x130_85_c/Ejkm6UQ0KLr",
+            "width": 773
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-07-22T21:40:00.000+09:00",
+            "display_sitename": "네이버블로그",
+            "doc_url": "http://blog.naver.com/jnnnn1/223163385011",
+            "height": 773,
+            "image_url": "https://postfiles.pstatic.net/MjAyMzA3MjJfMjI3/MDAxNjkwMDIxMzI0NTc0.WE6p2aAocYBWoDVGR9pU3yGR_epT02PFyRFbNujlEZkg.PPzzeNflmreiNMD7byGZzd4Slb8PgEaQ_hRjUmxZJdIg.PNG.kiki0_8802/smugglers.PNG?type=w773",
+            "thumbnail_url": "https://search4.kakaocdn.net/argon/130x130_85_c/CXhHdNCEF35",
+            "width": 773
+        },
+        {
+            "collection": "news",
+            "datetime": "2023-04-30T10:03:00.000+09:00",
+            "display_sitename": "SBS",
+            "doc_url": "http://v.media.daum.net/v/20230430100300933",
+            "height": 900,
+            "image_url": "https://t1.daumcdn.net/news/202304/30/sbsi/20230430100303565uils.png",
+            "thumbnail_url": "https://search4.kakaocdn.net/argon/130x130_85_c/G9c8deddak3",
+            "width": 1600
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-06-17T23:07:00.000+09:00",
+            "display_sitename": "네이버블로그",
+            "doc_url": "http://blog.naver.com/hijames_/223131655570",
+            "height": 515,
+            "image_url": "https://postfiles.pstatic.net/MjAyMzA2MTdfMjQ4/MDAxNjg3MDEwNTkyMTUy.NSPDLNNYlFCly8nJn2umbnNJqJEzNzjtvJlwbrZyScIg.SHvot4IFmtRlGneSYuu8uNVlYY7gPoCXZ0AKioeGsYAg.JPEG.hijames_/3.jpg?type=w773",
+            "thumbnail_url": "https://search3.kakaocdn.net/argon/130x130_85_c/5H36WJFxBYd",
+            "width": 773
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-07-23T21:33:00.000+09:00",
+            "display_sitename": "네이버블로그",
+            "doc_url": "http://blog.naver.com/wjdalss2/223164085682",
+            "height": 1100,
+            "image_url": "https://postfiles.pstatic.net/MjAyMzA3MjNfMTU0/MDAxNjkwMTEyNzYxNzMz.9lB6SiRGb7N0yPnN82sB1KmYs9GF-PPPWaK6J_zAup4g.676E5zUlDaxNR6_AZCpHtCF_MIDt5LlZZdO1zjGz24Yg.JPEG.wjdalss2/IMG_2709.jpg?type=w773",
+            "thumbnail_url": "https://search2.kakaocdn.net/argon/130x130_85_c/4001Hji9mHG",
+            "width": 773
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-05-23T19:33:43.000+09:00",
+            "display_sitename": "티스토리",
+            "doc_url": "http://enigma0326.com/122",
+            "height": 720,
+            "image_url": "https://blog.kakaocdn.net/dn/bugBGD/btsg7HjeYNL/7QH0MMu3NAufc13okYotH0/img.jpg",
+            "thumbnail_url": "https://search4.kakaocdn.net/argon/130x130_85_c/BPPXyH4VJ9v",
+            "width": 1280
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-07-11T22:23:49.000+09:00",
+            "display_sitename": "티스토리",
+            "doc_url": "http://globalissu.tistory.com/51",
+            "height": 478,
+            "image_url": "https://blog.kakaocdn.net/dn/1HgXF/btsng7pf4AJ/l5PGn6W8pqc7nKqfA3GfkK/img.jpg",
+            "thumbnail_url": "https://search4.kakaocdn.net/argon/130x130_85_c/L8LY06u7G6G",
+            "width": 540
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-07-31T20:50:48.000+09:00",
+            "display_sitename": "티스토리",
+            "doc_url": "http://kani8274.tistory.com/78",
+            "height": 564,
+            "image_url": "https://blog.kakaocdn.net/dn/bTd8KL/btspmWNi3Hd/u5PREke0dtkKKC6G5Wt5dK/img.jpg",
+            "thumbnail_url": "https://search3.kakaocdn.net/argon/130x130_85_c/AoD2uAiEmTA",
+            "width": 395
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-01-29T22:34:00.000+09:00",
+            "display_sitename": "네이버블로그",
+            "doc_url": "http://blog.naver.com/albireo486/222998468135",
+            "height": 779,
+            "image_url": "https://postfiles.pstatic.net/MjAyMzAxMjlfMTgy/MDAxNjc0OTk3NzIwNTUy.DrIeBGByiWddxPO73HRPgKrFyrfH2BRMBoF_OPICeGUg.6csPH59gZ_5StrjqhcUuM40-Bp5iqH6l6MsTssPwYXIg.PNG.albireo486/%EB%B0%80%EC%88%98.png?type=w773",
+            "thumbnail_url": "https://search2.kakaocdn.net/argon/130x130_85_c/3iIZkTTenUp",
+            "width": 591
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-07-22T00:00:00.000+09:00",
+            "display_sitename": "뉴스컬처",
+            "doc_url": "http://post.naver.com/viewer/postView.nhn?memberNo=3613482&volumeNo=36249483",
+            "height": 300,
+            "image_url": "https://dthumb-phinf.pstatic.net/?src=%22http%3A%2F%2Fwww.newsculture.press%2Fnews%2Fphoto%2F202307%2F528590_655502_634.jpg%22&type=ff500_300",
+            "thumbnail_url": "https://search2.kakaocdn.net/argon/130x130_85_c/A1YoNWNngSj",
+            "width": 500
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-07-22T04:54:38.000+09:00",
+            "display_sitename": "티스토리",
+            "doc_url": "http://moviedive.tistory.com/7",
+            "height": 712,
+            "image_url": "https://blog.kakaocdn.net/dn/pr6Qo/btsoyW0vVUK/Z1tRtbtiMzkVNB8bUKTwqK/img.png",
+            "thumbnail_url": "https://search4.kakaocdn.net/argon/130x130_85_c/G7RkvDTRKYY",
+            "width": 500
+        },
+        {
+            "collection": "news",
+            "datetime": "2023-05-21T12:45:52.000+09:00",
+            "display_sitename": "한국일보",
+            "doc_url": "http://v.media.daum.net/v/20230521124552633",
+            "height": 457,
+            "image_url": "https://t1.daumcdn.net/news/202305/21/hankooki/20230521124556714gcse.jpg",
+            "thumbnail_url": "https://search3.kakaocdn.net/argon/130x130_85_c/KAmz3bymNWL",
+            "width": 640
+        },
+        {
+            "collection": "etc",
+            "datetime": "2017-06-17T23:16:57.000+09:00",
+            "display_sitename": "",
+            "doc_url": "http://movie.daum.net/moviedb/main?movieId=21516",
+            "height": 225,
+            "image_url": "http://img1.daumcdn.net/thumb/C155x225/?fname=http%3A%2F%2Fcfile189.uf.daum.net%2Fimage%2F1165F51749AB1B1D99543D",
+            "thumbnail_url": "https://search3.kakaocdn.net/argon/130x130_85_c/4p3m5V2ib0w",
+            "width": 155
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-01-25T12:40:00.000+09:00",
+            "display_sitename": "네이버블로그",
+            "doc_url": "http://blog.naver.com/duswns202/222993415145",
+            "height": 273,
+            "image_url": "https://postfiles.pstatic.net/MjAyMzAxMjVfMTUg/MDAxNjc0NjE2MzYzMzE1.bn2sV67oujVo0YI3GWHtFEK1VG7PLhIXSNZnXwXqsnUg.SXY0Jgmy099kp8xqAZ5PuPRs3qAgFScoRdtWZjctgm8g.JPEG.duswns202/3_-_%EB%B3%B5%EC%82%AC%EB%B3%B8.JPG?type=w580",
+            "thumbnail_url": "https://search4.kakaocdn.net/argon/130x130_85_c/6E4AuCWmrTt",
+            "width": 580
+        },
+        {
+            "collection": "blog",
+            "datetime": "2022-07-31T00:23:00.000+09:00",
+            "display_sitename": "네이버블로그",
+            "doc_url": "http://blog.naver.com/kyh3522/222834964918",
+            "height": 645,
+            "image_url": "https://pbs.twimg.com/media/FLN1tCGUUAARrFF?format=jpg&name=medium",
+            "thumbnail_url": "https://search2.kakaocdn.net/argon/130x130_85_c/AyxZNopJrkP",
+            "width": 1024
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-07-26T15:35:00.000+09:00",
+            "display_sitename": "네이버블로그",
+            "doc_url": "https://blog.naver.com/manduk0715/223166664289",
+            "height": 311,
+            "image_url": "https://postfiles.pstatic.net/MjAyMzA3MjZfNjIg/MDAxNjkwMzUyOTE3MTQ0.tlEecL_JhJbBC2bg5CXraIlWK9a8MHJXztrZ8qyBeC4g.qKhYVGybR-DIOQmPwdbDjjzObPy_oFoYx6epR8f8lzEg.JPEG.manduk0715/common.jpg?type=w466",
+            "thumbnail_url": "https://search2.kakaocdn.net/argon/130x130_85_c/70gM3yIIuGs",
+            "width": 466
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-07-26T15:35:00.000+09:00",
+            "display_sitename": "네이버블로그",
+            "doc_url": "https://blog.naver.com/manduk0715/223166664289",
+            "height": 311,
+            "image_url": "https://postfiles.pstatic.net/MjAyMzA3MjZfMTIy/MDAxNjkwMzUyOTA1ODc0.dYfs2xZ8YLErLe0VTPw3FanzehR1pi9T6eJPHT_ZBz4g.AxTYbLuRoGX9Z_KYfwbwjqlHdCmSX_9WUMIBu04Jhs0g.JPEG.manduk0715/common.jpg?type=w466",
+            "thumbnail_url": "https://search1.kakaocdn.net/argon/130x130_85_c/7I2GacDGngo",
+            "width": 466
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-07-26T15:35:00.000+09:00",
+            "display_sitename": "네이버블로그",
+            "doc_url": "https://blog.naver.com/manduk0715/223166664289",
+            "height": 311,
+            "image_url": "https://postfiles.pstatic.net/MjAyMzA3MjZfMjEy/MDAxNjkwMzUxNjg4ODk5.aq7jqvB9h0SeAqi2eejG0gXbrGh_JTW0AfQSCVTen84g.hfe3-PAvJDQT_XegjtKcFS1c9V8qp1R_8GRE4zn9qdYg.JPEG.manduk0715/common.jpg?type=w466",
+            "thumbnail_url": "https://search3.kakaocdn.net/argon/130x130_85_c/K0WbIcYYzyU",
+            "width": 466
+        },
+        {
+            "collection": "cafe",
+            "datetime": "2023-04-15T23:10:09.000+09:00",
+            "display_sitename": "Daum카페",
+            "doc_url": "https://cafe.daum.net/subdued20club/ReHf/4353714",
+            "height": 720,
+            "image_url": "http://scrap.kakaocdn.net/dn/Qr8hI/hyRoGVReSw/yKgCafpX04WGkyAkKcNWMk/img.jpg?width=1280&height=720&face=0_0_1280_720",
+            "thumbnail_url": "https://search2.kakaocdn.net/argon/130x130_85_c/7IQ84SRkgN8",
+            "width": 1280
+        },
+        {
+            "collection": "news",
+            "datetime": "2023-07-04T10:17:02.000+09:00",
+            "display_sitename": "텐아시아",
+            "doc_url": "http://v.media.daum.net/v/20230704101702724",
+            "height": 400,
+            "image_url": "https://t1.daumcdn.net/news/202307/04/10asia/20230704101707888vohn.jpg",
+            "thumbnail_url": "https://search1.kakaocdn.net/argon/130x130_85_c/Bkn7ng1rhpJ",
+            "width": 800
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-07-28T01:44:23.000+09:00",
+            "display_sitename": "티스토리",
+            "doc_url": "http://mazino.tistory.com/53",
+            "height": 853,
+            "image_url": "https://blog.kakaocdn.net/dn/dQn3de/btso7ip4N3Y/kP648knw9Hldnom6BLlpf0/img.jpg",
+            "thumbnail_url": "https://search4.kakaocdn.net/argon/130x130_85_c/4AQkwuZTcaX",
+            "width": 1280
+        },
+        {
+            "collection": "news",
+            "datetime": "2023-07-10T14:23:56.000+09:00",
+            "display_sitename": "스포티비뉴스",
+            "doc_url": "http://v.media.daum.net/v/20230710142356211",
+            "height": 1931,
+            "image_url": "https://t1.daumcdn.net/news/202307/10/spotvnews/20230710142402254fxuw.jpg",
+            "thumbnail_url": "https://search3.kakaocdn.net/argon/130x130_85_c/6o0wG6WCbTR",
+            "width": 900
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-07-18T22:52:00.000+09:00",
+            "display_sitename": "네이버블로그",
+            "doc_url": "http://blog.naver.com/withinnews/223159978839",
+            "height": 1105,
+            "image_url": "https://postfiles.pstatic.net/MjAyMzA3MThfNTAg/MDAxNjg5Njg4MzI2MDU1.VfhdHz9cCbLBr4LW7EJ8wysAdnWFkhbBn5g6HbTRnqcg.MPgZWCYhDKYqQrhQqTEh1mkr5eG2UERRM2HraF46fgsg.JPEG.withinnews/58967a19773257ff7987d2765ce4d4ae.jpg?type=w773",
+            "thumbnail_url": "https://search3.kakaocdn.net/argon/130x130_85_c/Dc1Blh9LxE4",
+            "width": 773
+        },
+        {
+            "collection": "news",
+            "datetime": "2023-01-25T17:10:03.000+09:00",
+            "display_sitename": "더팩트",
+            "doc_url": "http://v.media.daum.net/v/20230125171003536",
+            "height": 400,
+            "image_url": "https://t1.daumcdn.net/news/202301/25/THEFACT/20230125171005717rmnq.jpg",
+            "thumbnail_url": "https://search2.kakaocdn.net/argon/130x130_85_c/9LO3bu0zwOj",
+            "width": 640
+        },
+        {
+            "collection": "news",
+            "datetime": "2023-06-16T13:43:59.000+09:00",
+            "display_sitename": "스포츠한국",
+            "doc_url": "http://v.media.daum.net/v/20230616134359175",
+            "height": 625,
+            "image_url": "https://t1.daumcdn.net/news/202306/16/SpoHankook/20230616134404405jjsp.jpg",
+            "thumbnail_url": "https://search4.kakaocdn.net/argon/130x130_85_c/IeC0BcgPgsY",
+            "width": 600
+        },
+        {
+            "collection": "news",
+            "datetime": "2023-06-16T12:46:58.000+09:00",
+            "display_sitename": "엑스포츠뉴스",
+            "doc_url": "http://v.media.daum.net/v/20230616124658182",
+            "height": 1157,
+            "image_url": "https://t1.daumcdn.net/news/202306/16/xportsnews/20230616124702782ovbb.jpg",
+            "thumbnail_url": "https://search2.kakaocdn.net/argon/130x130_85_c/FGEAiWisJzG",
+            "width": 550
+        },
+        {
+            "collection": "news",
+            "datetime": "2023-07-10T09:38:13.000+09:00",
+            "display_sitename": "뉴스엔",
+            "doc_url": "http://v.media.daum.net/v/20230710093813314",
+            "height": 1025,
+            "image_url": "https://t1.daumcdn.net/news/202307/10/newsen/20230710093813712oirp.jpg",
+            "thumbnail_url": "https://search2.kakaocdn.net/argon/130x130_85_c/I2fdTfnrWjp",
+            "width": 1000
+        },
+        {
+            "collection": "news",
+            "datetime": "2023-01-26T13:40:29.000+09:00",
+            "display_sitename": "한국경제TV",
+            "doc_url": "http://v.media.daum.net/v/20230126134029149",
+            "height": 253,
+            "image_url": "https://t1.daumcdn.net/news/202301/26/kedtv/20230126134033969mebu.jpg",
+            "thumbnail_url": "https://search4.kakaocdn.net/argon/130x130_85_c/KpSQytaM7fq",
+            "width": 540
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-07-10T13:15:00.000+09:00",
+            "display_sitename": "네이버블로그",
+            "doc_url": "http://blog.naver.com/to-do-leader/223151812436",
+            "height": 537,
+            "image_url": "https://postfiles.pstatic.net/MjAyMzA3MTBfNTEg/MDAxNjg4OTYxNzk2NzMz.NBsjZBZldSADDr_UglVMp-8yIjLcZGz3MnoimkyvfScg.9w44CE3BCeb0_4PyfH-rPuoFH9Sf0b8-S3o27SQrVOUg.JPEG.to-do-leader/news-p.v1.20230710.9974606024714e72811e1c0af553a119_P1.jpg?type=w966",
+            "thumbnail_url": "https://search1.kakaocdn.net/argon/130x130_85_c/ExgK0O9j0P8",
+            "width": 700
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-08-04T19:20:49.000+09:00",
+            "display_sitename": "티스토리",
+            "doc_url": "http://zureivew.com/200",
+            "height": 399,
+            "image_url": "https://blog.kakaocdn.net/dn/xsv1i/btsp8ct2fli/MOxzEQbmYkJJ0eT9q8IsKK/img.png",
+            "thumbnail_url": "https://search4.kakaocdn.net/argon/130x130_85_c/6Usj1ey6ZB",
+            "width": 600
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-06-17T23:50:00.000+09:00",
+            "display_sitename": "네이버블로그",
+            "doc_url": "http://blog.naver.com/gimpobest/223131431200",
+            "height": 300,
+            "image_url": "https://dthumb-phinf.pstatic.net/?src=%22https%3A%2F%2Fmimgnews.pstatic.net%2Fimage%2Forigin%2F076%2F2023%2F06%2F16%2F4020256.jpg%22&type=ff500_300",
+            "thumbnail_url": "https://search2.kakaocdn.net/argon/130x130_85_c/DEyb6aNSkCw",
+            "width": 500
+        },
+        {
+            "collection": "news",
+            "datetime": "2023-07-06T09:23:04.000+09:00",
+            "display_sitename": "뉴스1",
+            "doc_url": "http://v.media.daum.net/v/20230706092304013",
+            "height": 1287,
+            "image_url": "https://t1.daumcdn.net/news/202307/06/NEWS1/20230706092305700tsnl.jpg",
+            "thumbnail_url": "https://search3.kakaocdn.net/argon/130x130_85_c/DpCYzv9hxBA",
+            "width": 900
+        },
+        {
+            "collection": "news",
+            "datetime": "2023-06-13T06:00:10.000+09:00",
+            "display_sitename": "스타뉴스",
+            "doc_url": "http://v.media.daum.net/v/20230613060010029",
+            "height": 1464,
+            "image_url": "https://t1.daumcdn.net/news/202306/13/starnews/20230613060013290ioxo.jpg",
+            "thumbnail_url": "https://search1.kakaocdn.net/argon/130x130_85_c/IkRxkFqKIum",
+            "width": 1024
+        },
+        {
+            "collection": "blog",
+            "datetime": "2019-10-09T23:34:00.000+09:00",
+            "display_sitename": "네이버블로그",
+            "doc_url": "http://blog.naver.com/conradmajors/221673135948",
+            "height": 500,
+            "image_url": "https://blogfiles.pstatic.net/MjAxOTEwMDlfMTEz/MDAxNTcwNjMxMzA4NDYw.m4CTIauewbgLum4C3lj0RJPrj61omLMzhmP0W1n4m8cg.7HRNybJmtPfIvWmgh4lblD2EwIISLI7kydS4qftpOGgg.JPEG.conradmajors/MV5BMjE1Mzg2MTMxOF5BMl5BanBnXkFtZTgwNzcxMzkwMzE__V1_.jpg?type=w2",
+            "thumbnail_url": "https://search2.kakaocdn.net/argon/130x130_85_c/WRYiIvA9I6",
+            "width": 333
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-07-31T00:48:00.000+09:00",
+            "display_sitename": "네이버블로그",
+            "doc_url": "https://blog.naver.com/juheekims/223170377920",
+            "height": 653,
+            "image_url": "https://postfiles.pstatic.net/MjAyMzA3MzFfMjE4/MDAxNjkwNzMxNDU1NDY2.w-Tgs88OitII1d-J_2yRqXaDjJW5Ik-8no7QFZWaJPIg.qnsGYwl4hIpzOdcLZJIVxK5ObncVEanY0PqB46FvsuUg.PNG.juheekims/image.png?type=w466",
+            "thumbnail_url": "https://search3.kakaocdn.net/argon/130x130_85_c/9bbLmbZkK8k",
+            "width": 466
+        },
+        {
+            "collection": "news",
+            "datetime": "2023-01-25T14:12:03.000+09:00",
+            "display_sitename": "텐아시아",
+            "doc_url": "http://v.media.daum.net/v/20230125141203733",
+            "height": 1122,
+            "image_url": "https://t1.daumcdn.net/news/202301/25/10asia/20230125141207753kggy.jpg",
+            "thumbnail_url": "https://search4.kakaocdn.net/argon/130x130_85_c/CV41PKxoZO3",
+            "width": 600
+        },
+        {
+            "collection": "blog",
+            "datetime": "2021-10-07T16:15:00.000+09:00",
+            "display_sitename": "네이버블로그",
+            "doc_url": "http://blog.naver.com/taebin_06/222529887943",
+            "height": 484,
+            "image_url": "https://postfiles.pstatic.net/MjAyMTEwMDdfMTUw/MDAxNjMzNTg1NjA4ODc5.IHFrsn8CYA4DQMvTDyBLTQ0prfGeZdrUXzRPPGFJSbIg.3nKerIHIMCDGoks2ZAQCOYV0ErcuI4M86rjrF2YWTQ4g.PNG.taebin_06/%EB%B0%80%EC%88%98.png?type=w966",
+            "thumbnail_url": "https://search3.kakaocdn.net/argon/130x130_85_c/GKMU3NCc5u9",
+            "width": 720
+        },
+        {
+            "collection": "news",
+            "datetime": "2023-06-29T08:25:52.000+09:00",
+            "display_sitename": "스포츠경향",
+            "doc_url": "http://v.media.daum.net/v/20230629082552328",
+            "height": 466,
+            "image_url": "https://t1.daumcdn.net/news/202306/29/sportskhan/20230629082554863uout.jpg",
+            "thumbnail_url": "https://search2.kakaocdn.net/argon/130x130_85_c/51lAxxnQBmE",
+            "width": 700
+        },
+        {
+            "collection": "news",
+            "datetime": "2023-01-25T16:30:16.000+09:00",
+            "display_sitename": "MK스포츠",
+            "doc_url": "http://v.media.daum.net/v/20230125163016199",
+            "height": 464,
+            "image_url": "https://t1.daumcdn.net/news/202301/25/mksports/20230125163018691bmqb.jpg",
+            "thumbnail_url": "https://search4.kakaocdn.net/argon/130x130_85_c/AGIHKi9SPY2",
+            "width": 500
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-05-06T07:37:00.000+09:00",
+            "display_sitename": "네이버블로그",
+            "doc_url": "http://blog.naver.com/jesssummer7/223094663431",
+            "height": 592,
+            "image_url": "https://postfiles.pstatic.net/MjAyMzA1MDNfMjM0/MDAxNjgzMTIwOTAwMjY2.qWCnK73IAmUocQm3BTRBKBjmxG9M1O3uXiv7eClPUY4g.u-WiEXdCV_2ZC2vgEKgyx1gJHneXp1V4s_uMrXOs1Qgg.PNG.jesssummer7/20230503_223424_2.png?type=w773",
+            "thumbnail_url": "https://search4.kakaocdn.net/argon/130x130_85_c/GKzBAckdHHJ",
+            "width": 593
+        },
+        {
+            "collection": "blog",
+            "datetime": "2023-07-14T18:02:18.000+09:00",
+            "display_sitename": "티스토리",
+            "doc_url": "http://ch32.tistory.com/42",
+            "height": 1280,
+            "image_url": "https://blog.kakaocdn.net/dn/O1A74/btsnDnlVwHa/k3GaPzMd46l2yxP1HemzD1/img.jpg",
+            "thumbnail_url": "https://search2.kakaocdn.net/argon/130x130_85_c/D7MxccQLVKW",
+            "width": 894
+        }
+    ],
+    "meta": {
+        "is_end": false,
+        "pageable_count": 1610,
+        "total_count": 1797
+    }
+}

--- a/BoxOffice/Resource/NetworkNamespace.swift
+++ b/BoxOffice/Resource/NetworkNamespace.swift
@@ -10,6 +10,7 @@ import Foundation
 enum NetworkNamespace {
     case boxOffice
     case movieDetail
+    case daumImage
     
     var url: String {
         switch self {
@@ -17,11 +18,19 @@ enum NetworkNamespace {
             return "http://kobis.or.kr/kobisopenapi/webservice/rest/boxoffice/searchDailyBoxOfficeList.json?key=%@&targetDt=%@"
         case .movieDetail:
             return "http://www.kobis.or.kr/kobisopenapi/webservice/rest/movie/searchMovieInfo.json?key=%@&movieCd=%@"
+        case .daumImage:
+            return "https://dapi.kakao.com/v2/search/image"
         }
     }
 
     static var apiKey: String {
         guard let keyPath = Bundle.main.infoDictionary?["API_KEY"] as? String else {
+            return ""
+        }
+        return keyPath
+    }
+    static var daumApiKey: String {
+        guard let keyPath = Bundle.main.infoDictionary?["DAUM_API_KEY"] as? String else {
             return ""
         }
         return keyPath

--- a/BoxOffice/View/MovieDetailStackView.swift
+++ b/BoxOffice/View/MovieDetailStackView.swift
@@ -12,12 +12,15 @@ class MovieDetailStackView: UIStackView {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = .preferredFont(forTextStyle: .headline)
+        label.textAlignment = .center
         
         return label
     }()
     let valueLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
+        label.lineBreakMode = .byWordWrapping
+        label.numberOfLines = 0
         
         return label
     }()
@@ -38,6 +41,11 @@ class MovieDetailStackView: UIStackView {
         self.axis = .horizontal
         self.addArrangedSubview(titleLabel)
         self.addArrangedSubview(valueLabel)
+        
+        NSLayoutConstraint.activate([
+            titleLabel.widthAnchor.constraint(equalTo: self.widthAnchor, multiplier: 0.22),
+            valueLabel.widthAnchor.constraint(equalTo: self.widthAnchor, multiplier: 0.78),
+        ])
     }
     
 }

--- a/BoxOffice/View/MovieDetailStackView.swift
+++ b/BoxOffice/View/MovieDetailStackView.swift
@@ -1,0 +1,43 @@
+//
+//  MovieDetailStackView.swift
+//  BoxOffice
+//
+//  Created by Yetti, Maxhyunm on 2023/08/08.
+//
+
+import UIKit
+
+class MovieDetailStackView: UIStackView {
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = .preferredFont(forTextStyle: .headline)
+        
+        return label
+    }()
+    let valueLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        
+        return label
+    }()
+    
+    init(title: String) {
+        self.titleLabel.text = title
+        
+        super.init(frame: .init())
+        setUpUI()
+    }
+    
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setUpUI() {
+        self.translatesAutoresizingMaskIntoConstraints = false
+        self.axis = .horizontal
+        self.addArrangedSubview(titleLabel)
+        self.addArrangedSubview(valueLabel)
+    }
+    
+}

--- a/BoxOfficeTests/TestDouble.swift
+++ b/BoxOfficeTests/TestDouble.swift
@@ -26,7 +26,7 @@ final class StubURLSession: URLSessionProtocol {
         self.dummyResponse = dummy
     }
     
-    func dataTask(with url: URL, completionHandler: @escaping NetworkingCompletionHandler) -> URLSessionDataTask {
+    func dataTask(with: URLRequest, completionHandler: @escaping NetworkingCompletionHandler) -> URLSessionDataTask {
         dummyResponse?.completionHandler = completionHandler
         
         return StubURLSessionDataTask(dummyResponse)


### PR DESCRIPTION
안녕하세요 델마!(@delmaSong)
Step4 PR을 드디어ㅠㅠ! 보내드립니다.
남은 박스오피스 리뷰도 델마께 받을 수 있어서 기쁩니다🙂
 리뷰 잘 부탁드립니다🙇‍♀️!!

## 고민했던 점
### 1. `네트워크 연결시 URL 전달 방식`
기존에는 `dataTask` 메서드에 `URL` 타입을 전달하여 네트워크 연결을 진행하도록 구현했었습니다. 하지만 이번에 `Daum API`가 추가되면서 `Authorization` 헤더를 추가해야 했기 때문에 해당 정보를 어떻게 전달할지 고민하였습니다.

```swift
var request = URLRequest(url: url)
request.setValue("KakaoAK \(NetworkNamespace.daumApiKey)", forHTTPHeaderField: "Authorization")
```
`URLRequest`를 활용하면 `setValue`를 통해 헤더 정보를 추가할 수 있음을 확인하였습니다. 이에 따라 기존 테스트더블 및 테스트코드 모두 `URLRequest`에 맞게 수정을 진행하였습니다.

또한 `Daum API`에 전달할 쿼리 내용에는 띄어쓰기가 추가되어 있어, `URL`에 붙여서 보내기보다는 `URLComponents`를 사용해 필요한 쿼리 아이템을 추가하는 게 좋겠다는 생각이 들었습니다.
해당 내용은 아래와 같이 구현하였습니다.
```swift
var urlComponents = URLComponents(string: NetworkNamespace.daumImage.url)
urlComponents?.queryItems = [URLQueryItem(name: "query", value: "\(movieName) 영화 포스터")]
```
### 2. `반복적인 UI 처리`
`MovieDetailViewController`에는 감독, 상영시간, 배우 등 `Horizontal` 방향으로 두 레이블이 나란히 들어가는 구성이 반복적으로 사용됩니다. 이 부분을 보다 간편히 구현하기 위하여 `MovieDetailStackView `타입을 분리하였습니다.
```swift
private let directorsStackView = MovieDetailStackView(title: "감독")
private let productionYearStackView = MovieDetailStackView(title: "제작년도")
private let openingDateStackView = MovieDetailStackView(title: "개봉일")
private let showTimeStackView = MovieDetailStackView(title: "상영시간")
private let auditsStackView = MovieDetailStackView(title: "관람등급")
private let nationsStackView = MovieDetailStackView(title: "제작국가")
private let genresStackView = MovieDetailStackView(title: "장르")
private let actorsStackView = MovieDetailStackView(title: "배우")
```
이에 따라 처음 UI를 구성할 때는 각 `titleLabel`에 들어갈 내용만 `init`을 통해 전달해 주고, 데이터가 `load`된 뒤에 `valueLabel`의 값을 변경할 수 있도록 구현할 수 있었습니다.

### 3. `로딩 방식`
요구사항에 `'이미지가 로드되기 전에는 이미지가 로드중임을 알 수 있도록 적절히 처리해주세요'` 라고 작성되어 있었기에 처음에는 이미지를 위한 API 처리가 완료될 때까지 상단에 `indicator view`가 돌아가도록 만들면 어떨까 생각하였습니다. 하지만 저희가 STEP4 작업을 진행한 오늘은 영화진흥위원회의 API 속도가 다른 때에 비하여 현저히 느린 상태였습니다(혹시 코드의 문제일까 싶어 Postman과 URL 직접 접속을 시도해 본 결과, 모두 랜덤하게 느려지는 현상이 나타나는 것을 확인했습니다.) 때문에 둘 중 어느 한 가지 데이터라도 로딩이 되지 않았다면 화면 중앙에 `indicator view`가 돌아가도록 구현하는 편이 좀 더 깔끔할 것 같다는 결론을 내렸습니다. 이에 따라 로딩이 완료될 때까지 화면을 보이지 않게 만들기 위해 비어있는 `View`를 추가해 화면 전체를 덮어 주었습니다.(해당 `View`의 투명도를 조절하여 로딩 완료된 데이터를 바탕에 보이게 만들까도 고민해 보았는데, 빈 `View`와 비교하여 특별한 이점은 없는 것 같아서 불투명한 상태로 두었습니다!)
```swift
private let blankView: UIView = {
    ...
}()

...

view.addSubview(blankView)

...

blankView.widthAnchor.constraint(equalTo: safeArea.widthAnchor),
blankView.heightAnchor.constraint(equalTo: safeArea.heightAnchor),
blankView.centerXAnchor.constraint(equalTo: safeArea.centerXAnchor),
blankView.centerYAnchor.constraint(equalTo: safeArea.centerYAnchor),
```

또한 아래와 같이 `Bool` 타입 프로퍼티를 만들어 이를 제어할 수 있도록 하였습니다.

```swift
private var isImageLoaded: Bool = false {
        willSet(newValue) {
            if newValue == true {
                if self.isDataLoaded == true {
                    self.isLoading = false
    ...
                    
    private var isDataLoaded: Bool = false {
        willSet(newValue) {
            if newValue == true {
                if self.isImageLoaded == true {
                    self.isLoading = false
    ...

    private var isLoading: Bool = true {
        willSet(newValue) {
            if newValue == true {
                indicatorView.isHidden = false
                indicatorView.startAnimating()
            } else {
                indicatorView.isHidden = true
                indicatorView.stopAnimating()
                blankView.removeFromSuperview()
     ...
                
    }
```


## 조언을 얻고 싶은 점
### 1. 영화진흥위원회 API 속도 이슈
- 프로젝트를 진행하며 평소엔 데이터를 가져오는데에 느리거나 하는 이슈는 없었는데 오늘은 영화진흥위원회 API에서 데이터를 가져올 때 너무 느려 테스트를 위해 빌드할 때마다 한참 기다려야하는 문제가 있었습니다. API 자체의 이슈로 가끔 이렇게 데이터를 가져오는 속도가 느린 경우에 대처 방법이 있는지 궁금합니다.

2. 고민했던 점 3번에서처럼 저희는 해당 뷰 컨트롤러가 로딩 중일 때 로딩을 위해 비어있는 `View`를 추가해주었는데 혹시 다른 방법에는 어떤게 있는지 궁금합니다.