### PR TITLE
박스오피스 II [STEP 1] BMO, Serena

### DIFF
--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		CB30DA072A83555D002DE804 /* MovieDetailNameSpace.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB30DA062A83555D002DE804 /* MovieDetailNameSpace.swift */; };
 		CB30DA092A8359FF002DE804 /* DetailLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB30DA082A8359FF002DE804 /* DetailLabel.swift */; };
 		CB30DA0B2A835AB9002DE804 /* LabelsStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB30DA0A2A835AB9002DE804 /* LabelsStack.swift */; };
+		CB30DA0D2A8480B7002DE804 /* CalendarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB30DA0C2A8480B7002DE804 /* CalendarViewController.swift */; };
+		CB30DA0F2A850C1B002DE804 /* CalendarViewControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB30DA0E2A850C1B002DE804 /* CalendarViewControllerDelegate.swift */; };
 		CB31F7C62A738376001E9B21 /* CustomDateFormatStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB31F7C52A738376001E9B21 /* CustomDateFormatStyle.swift */; };
 		CB31F7C82A738397001E9B21 /* MimeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB31F7C72A738397001E9B21 /* MimeType.swift */; };
 		CB4CFDD32A6FA25200288EFA /* BoxOfficeResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB4CFDD22A6FA25200288EFA /* BoxOfficeResultTests.swift */; };
@@ -82,6 +84,8 @@
 		CB30DA062A83555D002DE804 /* MovieDetailNameSpace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieDetailNameSpace.swift; sourceTree = "<group>"; };
 		CB30DA082A8359FF002DE804 /* DetailLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailLabel.swift; sourceTree = "<group>"; };
 		CB30DA0A2A835AB9002DE804 /* LabelsStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelsStack.swift; sourceTree = "<group>"; };
+		CB30DA0C2A8480B7002DE804 /* CalendarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewController.swift; sourceTree = "<group>"; };
+		CB30DA0E2A850C1B002DE804 /* CalendarViewControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewControllerDelegate.swift; sourceTree = "<group>"; };
 		CB31F7C52A738376001E9B21 /* CustomDateFormatStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDateFormatStyle.swift; sourceTree = "<group>"; };
 		CB31F7C72A738397001E9B21 /* MimeType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MimeType.swift; sourceTree = "<group>"; };
 		CB4CFDD12A6FA16900288EFA /* BoxOfficeTestPlan.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = BoxOfficeTestPlan.xctestplan; sourceTree = "<group>"; };
@@ -189,6 +193,7 @@
 			isa = PBXGroup;
 			children = (
 				CB289C062A7F32AD007EBADA /* DaumSearchDocumentable.swift */,
+				CB30DA0E2A850C1B002DE804 /* CalendarViewControllerDelegate.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -224,6 +229,7 @@
 			children = (
 				63DF20F22970E1A0005DF7D1 /* BoxOfficeViewController.swift */,
 				D2D027CD2A7F291900456444 /* MovieDetailViewController.swift */,
+				CB30DA0C2A8480B7002DE804 /* CalendarViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -463,12 +469,14 @@
 				CB30DA092A8359FF002DE804 /* DetailLabel.swift in Sources */,
 				D2D027CA2A7BD57800456444 /* String+.swift in Sources */,
 				CB31F7C82A738397001E9B21 /* MimeType.swift in Sources */,
+				CB30DA0F2A850C1B002DE804 /* CalendarViewControllerDelegate.swift in Sources */,
 				D2A6AE482A73AA0100CE5903 /* NetworkManagerError.swift in Sources */,
 				D277169E2A6FFFAC005C0045 /* JSONDecoderError.swift in Sources */,
 				CB289C042A7F31C2007EBADA /* DaumSearchMeta.swift in Sources */,
 				D236E1B22A7356EA003D0F7A /* KobisNameSpace.swift in Sources */,
 				D2D027D22A813B7A00456444 /* UIFont+.swift in Sources */,
 				CB30DA072A83555D002DE804 /* MovieDetailNameSpace.swift in Sources */,
+				CB30DA0D2A8480B7002DE804 /* CalendarViewController.swift in Sources */,
 				63DF20F32970E1A0005DF7D1 /* BoxOfficeViewController.swift in Sources */,
 				D20B9F502A8214500035DEC4 /* KakaoNameSpace.swift in Sources */,
 				D236E1A52A734716003D0F7A /* ShowType.swift in Sources */,

--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -647,7 +647,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -677,7 +677,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		CB30DA0B2A835AB9002DE804 /* LabelsStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB30DA0A2A835AB9002DE804 /* LabelsStack.swift */; };
 		CB30DA0D2A8480B7002DE804 /* CalendarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB30DA0C2A8480B7002DE804 /* CalendarViewController.swift */; };
 		CB30DA0F2A850C1B002DE804 /* CalendarViewControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB30DA0E2A850C1B002DE804 /* CalendarViewControllerDelegate.swift */; };
+		CB30DA112A8517C6002DE804 /* DateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB30DA102A8517C6002DE804 /* DateManager.swift */; };
 		CB31F7C62A738376001E9B21 /* CustomDateFormatStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB31F7C52A738376001E9B21 /* CustomDateFormatStyle.swift */; };
 		CB31F7C82A738397001E9B21 /* MimeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB31F7C72A738397001E9B21 /* MimeType.swift */; };
 		CB4CFDD32A6FA25200288EFA /* BoxOfficeResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB4CFDD22A6FA25200288EFA /* BoxOfficeResultTests.swift */; };
@@ -86,6 +87,7 @@
 		CB30DA0A2A835AB9002DE804 /* LabelsStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelsStack.swift; sourceTree = "<group>"; };
 		CB30DA0C2A8480B7002DE804 /* CalendarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewController.swift; sourceTree = "<group>"; };
 		CB30DA0E2A850C1B002DE804 /* CalendarViewControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewControllerDelegate.swift; sourceTree = "<group>"; };
+		CB30DA102A8517C6002DE804 /* DateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateManager.swift; sourceTree = "<group>"; };
 		CB31F7C52A738376001E9B21 /* CustomDateFormatStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDateFormatStyle.swift; sourceTree = "<group>"; };
 		CB31F7C72A738397001E9B21 /* MimeType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MimeType.swift; sourceTree = "<group>"; };
 		CB4CFDD12A6FA16900288EFA /* BoxOfficeTestPlan.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = BoxOfficeTestPlan.xctestplan; sourceTree = "<group>"; };
@@ -211,6 +213,7 @@
 			children = (
 				D266DEC12A72269200DBB07F /* NetworkManager.swift */,
 				D20B9F512A8245130035DEC4 /* ImageCacheManager.swift */,
+				CB30DA102A8517C6002DE804 /* DateManager.swift */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -480,6 +483,7 @@
 				63DF20F32970E1A0005DF7D1 /* BoxOfficeViewController.swift in Sources */,
 				D20B9F502A8214500035DEC4 /* KakaoNameSpace.swift in Sources */,
 				D236E1A52A734716003D0F7A /* ShowType.swift in Sources */,
+				CB30DA112A8517C6002DE804 /* DateManager.swift in Sources */,
 				63DF20EF2970E1A0005DF7D1 /* AppDelegate.swift in Sources */,
 				D236E1A92A73472F003D0F7A /* Audit.swift in Sources */,
 				CB289C072A7F32AD007EBADA /* DaumSearchDocumentable.swift in Sources */,

--- a/BoxOffice/NameSpace/CustomDateFormatStyle.swift
+++ b/BoxOffice/NameSpace/CustomDateFormatStyle.swift
@@ -8,4 +8,7 @@
 enum CustomDateFormatStyle {
     static let yyyyMMdd: String = "yyyyMMdd"
     static let yyyyMMddWithHyphen: String = "yyyy-MM-dd"
+    static let year: String = "yyyy"
+    static let month: String = "MM"
+    static let day: String = "dd"
 }

--- a/BoxOffice/Protocol/CalendarViewControllerDelegate.swift
+++ b/BoxOffice/Protocol/CalendarViewControllerDelegate.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 protocol CalendarViewControllerDelegate: AnyObject {
-    func updateDate(dateComponents: DateComponents?)
+    func updateBoxOfficeDate()
 }

--- a/BoxOffice/Protocol/CalendarViewControllerDelegate.swift
+++ b/BoxOffice/Protocol/CalendarViewControllerDelegate.swift
@@ -1,0 +1,12 @@
+//
+//  CalendarViewControllerDelegate.swift
+//  BoxOffice
+//
+//  Created by Serena, BMO on 2023/08/10.
+//
+
+import Foundation
+
+protocol CalendarViewControllerDelegate: AnyObject {
+    func updateDate(dateComponents: DateComponents?)
+}

--- a/BoxOffice/Service/BoxOfficeService.swift
+++ b/BoxOffice/Service/BoxOfficeService.swift
@@ -8,8 +8,6 @@
 import Foundation
 
 struct BoxOfficeService {
-    
-    
     func loadDailyBoxOfficeData(_ completion: @escaping (Result<BoxOffice, NetworkManagerError>) -> Void) {
         var components = URLComponents()
         components.scheme = KobisNameSpace.scheme

--- a/BoxOffice/Service/BoxOfficeService.swift
+++ b/BoxOffice/Service/BoxOfficeService.swift
@@ -8,34 +8,7 @@
 import Foundation
 
 struct BoxOfficeService {
-    private let dateFormatter = DateFormatter()
     
-    var selectedDate: Date = Date() - (24 * 60 * 60)
-    
-    var year: String {
-        dateFormatter.dateFormat = CustomDateFormatStyle.year
-        return dateFormatter.string(from: selectedDate)
-    }
-    
-    var month: String {
-        dateFormatter.dateFormat = CustomDateFormatStyle.month
-        return dateFormatter.string(from: selectedDate)
-    }
-    
-    var day: String {
-        dateFormatter.dateFormat = CustomDateFormatStyle.day
-        return dateFormatter.string(from: selectedDate)
-    }
-    
-    private var formattedDate: String {
-        dateFormatter.dateFormat = CustomDateFormatStyle.yyyyMMdd
-        return dateFormatter.string(from: selectedDate)
-    }
-    
-    var formattedDateWithHyphen: String {
-        dateFormatter.dateFormat = CustomDateFormatStyle.yyyyMMddWithHyphen
-        return dateFormatter.string(from: selectedDate)
-    }
     
     func loadDailyBoxOfficeData(_ completion: @escaping (Result<BoxOffice, NetworkManagerError>) -> Void) {
         var components = URLComponents()
@@ -45,7 +18,7 @@ struct BoxOfficeService {
         
         let query = [
             KobisNameSpace.key : KobisNameSpace.keyValue,
-            KobisNameSpace.targetDt : formattedDate
+            KobisNameSpace.targetDt : DateManager.formattedDate
         ]
         
         guard let dailyBoxOfficeURL = components.url else { return }

--- a/BoxOffice/Service/BoxOfficeService.swift
+++ b/BoxOffice/Service/BoxOfficeService.swift
@@ -10,18 +10,31 @@ import Foundation
 struct BoxOfficeService {
     private let dateFormatter = DateFormatter()
     
-    private var yesterday: Date {
-        return Date() - (24 * 60 * 60)
+    var selectedDate: Date = Date() - (24 * 60 * 60)
+    
+    var year: String {
+        dateFormatter.dateFormat = CustomDateFormatStyle.year
+        return dateFormatter.string(from: selectedDate)
     }
     
-    private var formattedYesterday: String {
+    var month: String {
+        dateFormatter.dateFormat = CustomDateFormatStyle.month
+        return dateFormatter.string(from: selectedDate)
+    }
+    
+    var day: String {
+        dateFormatter.dateFormat = CustomDateFormatStyle.day
+        return dateFormatter.string(from: selectedDate)
+    }
+    
+    private var formattedDate: String {
         dateFormatter.dateFormat = CustomDateFormatStyle.yyyyMMdd
-        return dateFormatter.string(from: yesterday)
+        return dateFormatter.string(from: selectedDate)
     }
     
-    var formattedYesterdayWithHyphen: String {
+    var formattedDateWithHyphen: String {
         dateFormatter.dateFormat = CustomDateFormatStyle.yyyyMMddWithHyphen
-        return dateFormatter.string(from: yesterday)
+        return dateFormatter.string(from: selectedDate)
     }
     
     func loadDailyBoxOfficeData(_ completion: @escaping (Result<BoxOffice, NetworkManagerError>) -> Void) {
@@ -32,7 +45,7 @@ struct BoxOfficeService {
         
         let query = [
             KobisNameSpace.key : KobisNameSpace.keyValue,
-            KobisNameSpace.targetDt : formattedYesterday
+            KobisNameSpace.targetDt : formattedDate
         ]
         
         guard let dailyBoxOfficeURL = components.url else { return }

--- a/BoxOffice/Util/DateManager.swift
+++ b/BoxOffice/Util/DateManager.swift
@@ -10,7 +10,9 @@ import Foundation
 class DateManager {
     static private let dateFormatter = DateFormatter()
     
-    static var selectedDate: Date = Date() - (24 * 60 * 60)
+    static let yesterday: Date = .now - (24 * 60 * 60)
+    
+    static var selectedDate: Date = yesterday
     
     static var year: String {
         dateFormatter.dateFormat = CustomDateFormatStyle.year

--- a/BoxOffice/Util/DateManager.swift
+++ b/BoxOffice/Util/DateManager.swift
@@ -1,0 +1,41 @@
+//
+//  DateManager.swift
+//  BoxOffice
+//
+//  Created by Serena, BMO on 2023/08/10.
+//
+
+import Foundation
+
+class DateManager {
+    static private let dateFormatter = DateFormatter()
+    
+    static var selectedDate: Date = Date() - (24 * 60 * 60)
+    
+    static var year: String {
+        dateFormatter.dateFormat = CustomDateFormatStyle.year
+        return dateFormatter.string(from: selectedDate)
+    }
+    
+    static var month: String {
+        dateFormatter.dateFormat = CustomDateFormatStyle.month
+        return dateFormatter.string(from: selectedDate)
+    }
+    
+    static var day: String {
+        dateFormatter.dateFormat = CustomDateFormatStyle.day
+        return dateFormatter.string(from: selectedDate)
+    }
+    
+    static var formattedDate: String {
+        dateFormatter.dateFormat = CustomDateFormatStyle.yyyyMMdd
+        return dateFormatter.string(from: selectedDate)
+    }
+    
+    static var formattedDateWithHyphen: String {
+        dateFormatter.dateFormat = CustomDateFormatStyle.yyyyMMddWithHyphen
+        return dateFormatter.string(from: selectedDate)
+    }
+    
+    private init() {}
+}

--- a/BoxOffice/View/BoxOfficeCell.swift
+++ b/BoxOffice/View/BoxOfficeCell.swift
@@ -35,6 +35,7 @@ final class BoxOfficeCell: UICollectionViewListCell {
         let stackView = UIStackView()
         stackView.axis = .vertical
         stackView.alignment = .center
+        stackView.distribution = .fillProportionally
         stackView.spacing = 4
         
         return stackView

--- a/BoxOffice/View/BoxOfficeCell.swift
+++ b/BoxOffice/View/BoxOfficeCell.swift
@@ -49,26 +49,8 @@ final class BoxOfficeCell: UICollectionViewListCell {
         return label
     }()
     
-    let rankInformationLabel: UILabel = {
-        let label = UILabel()
-        label.font = UIFont.preferredFont(forTextStyle: .body)
-        label.adjustsFontForContentSizeCategory = true
-        label.adjustsFontSizeToFitWidth = true
-        
-        return label
-    }()
-    
-    // MARK: - Movie Name, Audience Information
-    let detailLabel: UILabel = {
-        let label = UILabel()
-        label.font = UIFont.preferredFont(forTextStyle: .title2)
-        label.numberOfLines = 0
-        label.font = UIFont.preferredFont(forTextStyle: .body)
-        label.adjustsFontForContentSizeCategory = true
-        label.adjustsFontSizeToFitWidth = true
-        
-        return label
-    }()
+    let rankInformationLabel: UILabel = DetailLabel()
+    let detailLabel: UILabel = DetailLabel()
     
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/BoxOffice/ViewController/BoxOfficeViewController.swift
+++ b/BoxOffice/ViewController/BoxOfficeViewController.swift
@@ -78,12 +78,12 @@ final class BoxOfficeViewController: UIViewController {
                     self.hideLoadingView()
                 }
             } else {
-                var snapshot = NSDiffableDataSourceSnapshot<Section, DailyBoxOffice>()
-                snapshot.appendSections([.dailyBoxOffice])
-                snapshot.appendItems(boxOffice.boxOfficeResult.dailyBoxOfficeList)
-                dataSource?.apply(snapshot, animatingDifferences: false)
-                
                 DispatchQueue.main.async {
+                    var snapshot = NSDiffableDataSourceSnapshot<Section, DailyBoxOffice>()
+                    snapshot.appendSections([.dailyBoxOffice])
+                    snapshot.appendItems(boxOffice.boxOfficeResult.dailyBoxOfficeList)
+                    self.dataSource?.apply(snapshot, animatingDifferences: false)
+                    
                     self.refresher.endRefreshing()
                 }
             }

--- a/BoxOffice/ViewController/BoxOfficeViewController.swift
+++ b/BoxOffice/ViewController/BoxOfficeViewController.swift
@@ -146,16 +146,20 @@ extension BoxOfficeViewController: UICollectionViewDelegate {
     }
 }
 
+// MARK: - CalendarViewController Delegate
+extension BoxOfficeViewController: CalendarViewControllerDelegate {
+    func updateBoxOfficeDate() {
+        setTitle()
+        loadDailyBoxOfficeData()
+    }
+}
+
 // MARK: - Functions
 extension BoxOfficeViewController {
     private func showCalendarViewController() -> UIAction {
         let action = UIAction() { _ in
-            guard let year = Int(DateManager.year),
-                  let month = Int(DateManager.month),
-                  let day = Int(DateManager.day)
-            else { return }
-            
-            let calendarViewController = CalendarViewController(year: year, month: month, day: day)
+            let calendarViewController = CalendarViewController()
+            calendarViewController.delegate = self
             
             self.present(calendarViewController, animated: true)
         }

--- a/BoxOffice/ViewController/BoxOfficeViewController.swift
+++ b/BoxOffice/ViewController/BoxOfficeViewController.swift
@@ -62,7 +62,7 @@ final class BoxOfficeViewController: UIViewController {
     }
     
     // MARK: - Load Data
-    @objc private func loadDailyBoxOfficeData() {
+    private func loadDailyBoxOfficeData() {
         boxOfficeService.loadDailyBoxOfficeData(fetchBoxOffice)
     }
     
@@ -109,8 +109,8 @@ extension BoxOfficeViewController {
         collectionView?.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         collectionView?.delegate = self
         collectionView?.refreshControl = refresher
-        collectionView?.refreshControl?.addTarget(self, action: #selector(loadDailyBoxOfficeData), for: .valueChanged)
-        collectionView?.refreshControl?.transform = CGAffineTransformMakeScale(0.6, 0.6);
+        collectionView?.refreshControl?.addAction(refreshData(), for: .valueChanged)
+        collectionView?.refreshControl?.transform = CGAffineTransformMakeScale (0.6, 0.6);
         
         view.addSubview(collectionView ?? UICollectionView())
     }
@@ -157,6 +157,14 @@ extension BoxOfficeViewController {
             let calendarViewController = CalendarViewController(year: year, month: month, day: day)
             
             self.present(calendarViewController, animated: true)
+        }
+        
+        return action
+    }
+    
+    private func refreshData() -> UIAction {
+        let action = UIAction { _ in
+            self.loadDailyBoxOfficeData()
         }
         
         return action

--- a/BoxOffice/ViewController/BoxOfficeViewController.swift
+++ b/BoxOffice/ViewController/BoxOfficeViewController.swift
@@ -29,6 +29,7 @@ final class BoxOfficeViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        setUpRightBarButton()
         showLoadingView()
         setTitle()
         configureBackgroundColor()
@@ -36,6 +37,10 @@ final class BoxOfficeViewController: UIViewController {
     }
     
     // MARK: - UI Configuration
+    private func setUpRightBarButton() {
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "날짜선택", primaryAction: showCalendarViewController())
+    }
+    
     private func showLoadingView() {
         view.addSubview(activityIndicatorView)
         
@@ -49,7 +54,7 @@ final class BoxOfficeViewController: UIViewController {
     }
     
     private func setTitle() {
-        self.title = boxOfficeService.formattedYesterdayWithHyphen
+        self.title = boxOfficeService.formattedDateWithHyphen
     }
     
     private func configureBackgroundColor() {
@@ -97,7 +102,6 @@ extension BoxOfficeViewController {
         let layout = UICollectionViewCompositionalLayout.list(using: config)
         
         return layout
-        
     }
     
     private func configureHierarchy() {
@@ -144,6 +148,20 @@ extension BoxOfficeViewController: UICollectionViewDelegate {
 
 // MARK: - Functions
 extension BoxOfficeViewController {
+    private func showCalendarViewController() -> UIAction {
+        let action = UIAction() { _ in
+            guard let year = Int(self.boxOfficeService.year),
+                  let month = Int(self.boxOfficeService.month),
+                  let day = Int(self.boxOfficeService.day) else { return }
+            
+            let calendarViewController = CalendarViewController(year: year, month: month, day: day)
+            
+            self.present(calendarViewController, animated: true)
+        }
+        
+        return action
+    }
+    
     private func changeRankInformation(in dailyBoxOffice: DailyBoxOffice) -> NSMutableAttributedString {
         if dailyBoxOffice.rankOldAndNew == "NEW" {
             return "신작".addAttributeFontForKeyword(keyword: "신작", color: .red)

--- a/BoxOffice/ViewController/BoxOfficeViewController.swift
+++ b/BoxOffice/ViewController/BoxOfficeViewController.swift
@@ -54,7 +54,7 @@ final class BoxOfficeViewController: UIViewController {
     }
     
     private func setTitle() {
-        self.title = boxOfficeService.formattedDateWithHyphen
+        self.title = DateManager.formattedDateWithHyphen
     }
     
     private func configureBackgroundColor() {
@@ -150,9 +150,10 @@ extension BoxOfficeViewController: UICollectionViewDelegate {
 extension BoxOfficeViewController {
     private func showCalendarViewController() -> UIAction {
         let action = UIAction() { _ in
-            guard let year = Int(self.boxOfficeService.year),
-                  let month = Int(self.boxOfficeService.month),
-                  let day = Int(self.boxOfficeService.day) else { return }
+            guard let year = Int(DateManager.year),
+                  let month = Int(DateManager.month),
+                  let day = Int(DateManager.day)
+            else { return }
             
             let calendarViewController = CalendarViewController(year: year, month: month, day: day)
             

--- a/BoxOffice/ViewController/CalendarViewController.swift
+++ b/BoxOffice/ViewController/CalendarViewController.swift
@@ -1,0 +1,55 @@
+//
+//  CalendarViewController.swift
+//  BoxOffice
+//
+//  Created by Serena, BMO on 2023/08/10.
+//
+
+import UIKit
+
+final class CalendarViewController: UIViewController {
+    weak var delegate: CalendarViewControllerDelegate?
+    
+    private var year, month, day: Int
+    
+    private lazy var calendarView: UICalendarView = {
+        let view = UICalendarView()
+        
+        return view
+    }()
+    
+    init(year: Int, month: Int, day: Int) {
+        self.year = year
+        self.month = month
+        self.day = day
+        
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func loadView() {
+        let dateSelection = UICalendarSelectionSingleDate(delegate: self)
+        
+        calendarView.selectionBehavior = dateSelection
+        calendarView.availableDateRange = DateInterval(start: .distantPast, end: .now - (24 * 60 * 60))
+        calendarView.visibleDateComponents = DateComponents(year: year, month: month, day: day)
+        
+        dateSelection.selectedDate = DateComponents(year: year, month: month, day: day)
+        
+        view = calendarView
+    }
+    
+    override func viewDidLoad() {
+        view.backgroundColor = .systemBackground
+    }
+}
+
+extension CalendarViewController: UICalendarSelectionSingleDateDelegate {
+    func dateSelection(_ selection: UICalendarSelectionSingleDate, didSelectDate dateComponents: DateComponents?) {
+        delegate?.updateDate(dateComponents: dateComponents)
+        self.dismiss(animated: true)
+    }
+}

--- a/BoxOffice/ViewController/CalendarViewController.swift
+++ b/BoxOffice/ViewController/CalendarViewController.swift
@@ -10,46 +10,56 @@ import UIKit
 final class CalendarViewController: UIViewController {
     weak var delegate: CalendarViewControllerDelegate?
     
-    private var year, month, day: Int
-    
     private lazy var calendarView: UICalendarView = {
         let view = UICalendarView()
         
         return view
     }()
     
-    init(year: Int, month: Int, day: Int) {
-        self.year = year
-        self.month = month
-        self.day = day
-        
-        super.init(nibName: nil, bundle: nil)
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
     override func loadView() {
-        let dateSelection = UICalendarSelectionSingleDate(delegate: self)
-        
-        calendarView.selectionBehavior = dateSelection
-        calendarView.availableDateRange = DateInterval(start: .distantPast, end: .now - (24 * 60 * 60))
-        calendarView.visibleDateComponents = DateComponents(year: year, month: month, day: day)
-        
-        dateSelection.selectedDate = DateComponents(year: year, month: month, day: day)
-        
         view = calendarView
     }
     
     override func viewDidLoad() {
+        configureBackgroundColor()
+        setCalendarRange()
+        showSelectedDate()
+    }
+    
+    private func configureBackgroundColor() {
         view.backgroundColor = .systemBackground
+    }
+    
+    private func setCalendarRange() {
+        calendarView.availableDateRange = DateInterval(start: .distantPast, end: DateManager.yesterday)
+    }
+    
+    private func showSelectedDate() {
+        guard let year = Int(DateManager.year),
+              let month = Int(DateManager.month),
+              let day = Int(DateManager.day)
+        else { return }
+        
+        let dateSelection = UICalendarSelectionSingleDate(delegate: self)
+        
+        calendarView.selectionBehavior = dateSelection
+        dateSelection.selectedDate = DateComponents(year: year, month: month, day: day)
+        
+        calendarView.visibleDateComponents = DateComponents(year: year, month: month, day: day)
+    }
+    
+    private func updateDate(_ dateComponents: DateComponents?) {
+        guard let date = dateComponents?.date else { return }
+        DateManager.selectedDate = date
     }
 }
 
+// MARK: - Delegate
 extension CalendarViewController: UICalendarSelectionSingleDateDelegate {
     func dateSelection(_ selection: UICalendarSelectionSingleDate, didSelectDate dateComponents: DateComponents?) {
-        delegate?.updateDate(dateComponents: dateComponents)
+        updateDate(dateComponents)
+        delegate?.updateBoxOfficeDate()
+        
         self.dismiss(animated: true)
     }
 }


### PR DESCRIPTION
@GREENOVER 
안녕하세요! 그린🌳
BMO🤖 & Serena🐷팀입니다!

박스오피스 프로젝트 II Step1 PR 보냅니다.
Step4 추가 수정 사항도 함께 정리하였습니다!

이번 리뷰도 잘 부탁드립니다!😆

-----

## 구현한 내용
- *Step4 추가 수정* : UIComponents 중복코드 삭제
- *Step4 추가 수정* : animatedImage 활용하여 Loading 화면 구성
- CalendarView 구현하기
- CalendarView에서 선택된 날짜에 맞추어 BoxOffice 업데이트 하기
> **주요 내용**
> Modal, UICalendarView, DateManager, Image Loading View

-----

## 고민한 부분
### 🔥 UIComponents 중복코드 삭제
- 코드로 `UI`를 구성하다보니 중복코드로 인해 코드양이 방대해지는 문제와 직면하였습니다.
- 이를 해결하기위해 `UIComponents`를 `override`하여 중복되는 코드를 별도의 서브 클래스를 생성하여 적용하였습니다.
    > 수정 전 코드
    ```swift
    let detailLabel: UILabel = {
        let label = UILabel()
        label.font = UIFont.preferredFont(forTextStyle: .title2)
        label.numberOfLines = 0
        label.font = UIFont.preferredFont(forTextStyle: .body)
        label.adjustsFontForContentSizeCategory = true
        label.adjustsFontSizeToFitWidth = true

        return label
    }()
        let detailLabel: UILabel = DetailLabel()
    ```
    > 수정 후 코드
    ```swift
    let detailLabel: UILabel = DetailLabel()
    ```

<br>

### 🔥 animatedImage를 활용하여 Loading 화면 구성
- 이미지 로딩 화면을 구성 시 어떤 방법을 사용할 지 고민이 많았습니다. `BoxOffice`처럼 `activityIndicatorView`를 사용할 수도 있었지만, 다른 종류의 로딩화면도 구현해보고자 하였습니다. 고민을 하던 중 통상적인 앱에서 로딩화면서 움직이는 이미지를 참고하여 이와 비슷하게 구현을 해보고자 하였습니다.
- `asset`에 `gif` 이미지를 `frame`별 `png`파일로 분리하여 저장하였습니다. 이를 `UIImage`에서 `animatedImage`를 활용하여 임의의 `duration`을 지정하여 자연스럽게 움직이는 형상을 보여줄 수 있도록 하였습니다.
- 현재 저희 프로젝트에서 로딩하는 이미지는 빠른 속도로 처리가 되기 때문에 저희가 구성한 `Image Loading`화면이 짧은 찰나에 깜빡이고 사라지는 형상을 띄게 되었습니다. 저희는 오히려 이렇게 짧은 로딩화면이 `user`에게 오류가 나는 형상처럼 보여질 수 있다 생각하였습니다. 하여 이미지가 로딩 중이라는 것을 `user`에게 명시하기 위해 `usleep(500000)`을 주어 `Image Loading`의 과정이 보다 저희의 의도와 맞게끔 조정하였습니다.
    <Img src = "https://hackmd.io/_uploads/BkRj2OG3n.gif" width="350"/>

<br>

### 🔥 Singleton 구조의 DateManager로 Date 관리 로직 분리
- 이전 Step에서는 어제의 날짜 기준으로 모든 데이터를 로드하면 되었으나, 이번 Step부터는 다양한 날짜를 대응해야 했습니다. 여러 `ViewController`에서 지정 날짜를 공유해야 하는 상황에서 어떤 방식으로 대응할지 고민을 했습니다.
- `ViewController`간 날짜 정보를 주고 받을 수 있지만, 날짜 정보를 가지고 있는 `ViewController`가 모두 메모리에서 해제되는 경우 날짜 정보가 초기화 되는 위험이 있었습니다.
- 기존에 생성한 `BoxOfficeService`는 앱의 생명주기와 함께하는 구조체이기 때문에, 기존 날짜 관련 로직을 이곳에서 관리하였습니다. 하지만 날짜 관련 로직이 증가하면서 이전과 같이 `BoxOfficeService`에서 이를 모두 관리하는 것은 적절하지 않다고 생각했습니다.
- 그에 따라 `DateManager`를 생성하여 날짜 관련 프로퍼티를 해당 클래스에서 처리하도록 했습니다.
    ```swift
    class DateManager {
        static private let dateFormatter = DateFormatter()
        static let yesterday: Date = .now - (24 * 60 * 60)
        static var selectedDate: Date = yesterday
        ...

        private init() {}
    }

    ```

<br>

### 🔥 UICalendarView
- 날짜선택 화면의 달력에는 현재 선택된 날짜가 미리 선택되어 있어야 한다는 내용이 있었습니다. 해당 요구사항을 구현하기 위해 `UICalendarView.Decoration`를 이용했습니다.
    > 커스텀 데코레이션에 적용한 코드
    ```swift
    private func customDecoration() -> UIView {
        let view = UIView()
        view.backgroundColor = .red
        view.clipsToBounds = false
        view.frame = CGRect(x: 0, y: 0, width: 50, height: 50)
        return view
    }
    ```
    <Img src = "https://hackmd.io/_uploads/B1snPOMnh.png" width="350"/>
- 결과는 날짜의 하단 일부 영역에만 커스텀을 할 수 있을 뿐, 날짜 자체가 선택된 효과를 줄 수 없었습니다.
- 하지만 `UICalendarSelectionSingleDate`를 인스턴스화 하고(`UICalendarSelectionSingleDateDelegate`도 채택합니다.) 아래 코드를 적용하면, 원하는 효과가 적용되는 것을 확인할 수 있었습니다.
    ```swift
    let dateSelection = UICalendarSelectionSingleDate(delegate: self)
    calendarView.selectionBehavior = dateSelection
    ```
- 추가로 아래 코드를 작성하여 캘린더뷰가 열릴 때부터 날짜가 선택된 효과를 적용할 수 있었습니다.
    ```swift
    dateSelection.selectedDate = DateComponents(year: year, month: month, day: day)
    ```

<br>

### 🔥 UIAction을 활용하여 @objc 키워드 삭제
- 기존 컬렉션뷰의 `refreshControl`은 [addTarget](https://developer.apple.com/documentation/uikit/uicontrol/1618259-addtarget)메서드를 이용하여 구현했습니다. `addTarget`메서드는 `action`에 `#selector`를 이용하여 사용할 메서드를 호출할 수 있는데, 여기에는 `@objc` 매서드만 올 수 있습니다.
    > 수정 전 코드
    ```swift
    @objc private func loadDailyBoxOfficeData() {...}
    
    private func configureHierarchy() {
        ...
        collectionView?.refreshControl?.addTarget(self, action: #selector(loadDailyBoxOfficeData), for: .valueChanged)
        ...
    }
    ```
- 저희는 `@objc` 사용을 지양하기 위해 [addAction](https://developer.apple.com/documentation/uikit/uicontrol/3600490-addaction)을 이용하는 것으로 수정했습니다.
    > 수정 후 코드
    ```swift
    private func loadDailyBoxOfficeData() {...}

    private func configureHierarchy() {
        ...
        collectionView?.refreshControl?.addAction(refreshData(), for: .valueChanged)
        ...
    }

    private func refreshData() -> UIAction {
        let action = UIAction { _ in
            self.loadDailyBoxOfficeData()
        }
        
        return action
    }
    ```

<br>

## 참고자료
- [🍎 Developer Apple: UICalendarView](https://developer.apple.com/documentation/uikit/uicalendarview)
- [🍎 Developer Apple: UICalendarView.Decoration](https://developer.apple.com/documentation/uikit/uicalendarview/decoration)
- [🍎 Developer Apple: addTarget](https://developer.apple.com/documentation/uikit/uicontrol/1618259-addtarget)
- [🍎 Developer Apple: addAction](https://developer.apple.com/documentation/uikit/uicontrol/3600490-addaction)
- [🍎 Developer Apple: UIRefreshControl](https://developer.apple.com/documentation/uikit/uirefreshcontrol)
- [📒 Blog:달력 UICalendarView Custom 예제](https://ohwhatisthis.tistory.com/23)
- [👾 Git:달력 로딩 이미지 애니메이션 팝업 쉽게 만들기](http://minsone.github.io/mac/ios/easy-make-loading-animation-popup-view-in-swift)
- [🌊 stack overflow: change size of UICalanderView Decofration](https://stackoverflow.com/questions/75470155/how-to-change-size-of-customview-passed-as-uicalanderview-decoration)
