### PR TITLE
박스오피스II [STEP 2] Erick, kyungmin

### DIFF
--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -32,7 +32,7 @@
 		CD1AFC292A6E86B8001C50A7 /* BoxOfficeDataTransferObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD1AFC282A6E86B8001C50A7 /* BoxOfficeDataTransferObjectTests.swift */; };
 		CD23029E2A78F2E5003B654C /* DailyBoxOffice.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD23029D2A78F2E5003B654C /* DailyBoxOffice.swift */; };
 		CD2302A02A78FC19003B654C /* UILabel+.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD23029F2A78FC19003B654C /* UILabel+.swift */; };
-		CD24DE742A77AF2C0076442B /* BoxOfficeCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD24DE732A77AF2C0076442B /* BoxOfficeCollectionViewCell.swift */; };
+		CD24DE742A77AF2C0076442B /* BoxOfficeCollectionViewListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD24DE732A77AF2C0076442B /* BoxOfficeCollectionViewListCell.swift */; };
 		CD8564412A736C1500B5EFF8 /* URL+.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8564402A736C1500B5EFF8 /* URL+.swift */; };
 		CDCCAEA32A79E44B008811C3 /* DataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDCCAEA22A79E44B008811C3 /* DataManager.swift */; };
 		CDDD7B032A70B8C700F471C8 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDDD7B022A70B8C700F471C8 /* NetworkManager.swift */; };
@@ -90,7 +90,7 @@
 		CD1AFC2F2A6E8758001C50A7 /* BoxOffice.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = BoxOffice.xctestplan; sourceTree = "<group>"; };
 		CD23029D2A78F2E5003B654C /* DailyBoxOffice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyBoxOffice.swift; sourceTree = "<group>"; };
 		CD23029F2A78FC19003B654C /* UILabel+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+.swift"; sourceTree = "<group>"; };
-		CD24DE732A77AF2C0076442B /* BoxOfficeCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxOfficeCollectionViewCell.swift; sourceTree = "<group>"; };
+		CD24DE732A77AF2C0076442B /* BoxOfficeCollectionViewListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxOfficeCollectionViewListCell.swift; sourceTree = "<group>"; };
 		CD8564402A736C1500B5EFF8 /* URL+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+.swift"; sourceTree = "<group>"; };
 		CDCCAEA22A79E44B008811C3 /* DataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataManager.swift; sourceTree = "<group>"; };
 		CDCCAEA42A79ED04008811C3 /* API_KEY.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = API_KEY.xcconfig; sourceTree = "<group>"; };
@@ -217,7 +217,7 @@
 		CD1AFC1B2A6E776F001C50A7 /* View */ = {
 			isa = PBXGroup;
 			children = (
-				CD24DE732A77AF2C0076442B /* BoxOfficeCollectionViewCell.swift */,
+				CD24DE732A77AF2C0076442B /* BoxOfficeCollectionViewListCell.swift */,
 				CDEC11FE2A7E27F2000EC8FC /* MovieDetailScrollView.swift */,
 			);
 			path = View;
@@ -453,7 +453,7 @@
 				4541D5972A73953A00E6D276 /* DataError.swift in Sources */,
 				CDEC11FF2A7E27F2000EC8FC /* MovieDetailScrollView.swift in Sources */,
 				45BFE47B2A85EE6300342484 /* URLRequest+.swift in Sources */,
-				CD24DE742A77AF2C0076442B /* BoxOfficeCollectionViewCell.swift in Sources */,
+				CD24DE742A77AF2C0076442B /* BoxOfficeCollectionViewListCell.swift in Sources */,
 				63DF20EF2970E1A0005DF7D1 /* AppDelegate.swift in Sources */,
 				45BD07D12A7E70F6006B8467 /* PosterImageInformation.swift in Sources */,
 				63DF20F12970E1A0005DF7D1 /* SceneDelegate.swift in Sources */,

--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		CD23029E2A78F2E5003B654C /* DailyBoxOffice.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD23029D2A78F2E5003B654C /* DailyBoxOffice.swift */; };
 		CD2302A02A78FC19003B654C /* UILabel+.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD23029F2A78FC19003B654C /* UILabel+.swift */; };
 		CD24DE742A77AF2C0076442B /* BoxOfficeCollectionViewListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD24DE732A77AF2C0076442B /* BoxOfficeCollectionViewListCell.swift */; };
+		CD8284BC2A8B0DE3005145D0 /* BoxOfficeCollectionViewGridCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8284BB2A8B0DE3005145D0 /* BoxOfficeCollectionViewGridCell.swift */; };
 		CD8564412A736C1500B5EFF8 /* URL+.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD8564402A736C1500B5EFF8 /* URL+.swift */; };
 		CDCCAEA32A79E44B008811C3 /* DataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDCCAEA22A79E44B008811C3 /* DataManager.swift */; };
 		CDDD7B032A70B8C700F471C8 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDDD7B022A70B8C700F471C8 /* NetworkManager.swift */; };
@@ -91,6 +92,7 @@
 		CD23029D2A78F2E5003B654C /* DailyBoxOffice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyBoxOffice.swift; sourceTree = "<group>"; };
 		CD23029F2A78FC19003B654C /* UILabel+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+.swift"; sourceTree = "<group>"; };
 		CD24DE732A77AF2C0076442B /* BoxOfficeCollectionViewListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxOfficeCollectionViewListCell.swift; sourceTree = "<group>"; };
+		CD8284BB2A8B0DE3005145D0 /* BoxOfficeCollectionViewGridCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxOfficeCollectionViewGridCell.swift; sourceTree = "<group>"; };
 		CD8564402A736C1500B5EFF8 /* URL+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+.swift"; sourceTree = "<group>"; };
 		CDCCAEA22A79E44B008811C3 /* DataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataManager.swift; sourceTree = "<group>"; };
 		CDCCAEA42A79ED04008811C3 /* API_KEY.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = API_KEY.xcconfig; sourceTree = "<group>"; };
@@ -218,6 +220,7 @@
 			isa = PBXGroup;
 			children = (
 				CD24DE732A77AF2C0076442B /* BoxOfficeCollectionViewListCell.swift */,
+				CD8284BB2A8B0DE3005145D0 /* BoxOfficeCollectionViewGridCell.swift */,
 				CDEC11FE2A7E27F2000EC8FC /* MovieDetailScrollView.swift */,
 			);
 			path = View;
@@ -437,6 +440,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CD8284BC2A8B0DE3005145D0 /* BoxOfficeCollectionViewGridCell.swift in Sources */,
 				CDE52AAB2A81D29600183990 /* CacheManager.swift in Sources */,
 				CD2302A02A78FC19003B654C /* UILabel+.swift in Sources */,
 				CD23029E2A78F2E5003B654C /* DailyBoxOffice.swift in Sources */,

--- a/BoxOffice/App/SceneDelegate.swift
+++ b/BoxOffice/App/SceneDelegate.swift
@@ -18,7 +18,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         }
         
         window = UIWindow(windowScene: windowScene)
-        let boxOfficeViewController = BoxOfficeViewController(boxOfficeManager: BoxOfficeManager())
+        let boxOfficeViewController = BoxOfficeViewController(boxOfficeManager: BoxOfficeManager(),
+                                                              collectionViewMode: BoxOfficeViewController.CollectionViewMode.list)
         
         window?.rootViewController = UINavigationController(rootViewController: boxOfficeViewController)
         window?.makeKeyAndVisible()

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -85,7 +85,8 @@ extension BoxOfficeViewController {
         boxOfficeManager.fetchBoxOffice { result in
             if result == false {
                 DispatchQueue.main.async {
-                    let alert = UIAlertController.errorAlert(NameSpace.fail, NameSpace.loadDataFail, actionTitle: NameSpace.check, actionType: .default)
+                    let alertAction = UIAlertAction(title: NameSpace.check, style: .default)
+                    let alert = UIAlertController.customAlert(alertTile: NameSpace.fail, alertMessage: NameSpace.loadDataFail, preferredStyle: .alert, alertActions: [alertAction])
                     
                     self.collectionView.refreshControl?.endRefreshing()
                     self.activityIndicator.stopAnimating()

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -63,7 +63,7 @@ extension BoxOfficeViewController {
     }
     
     private func setupToolbar() {
-        let changeViewModeButton = UIBarButtonItem(title: "화면 모드 변경", style: .plain, target: self, action: #selector(didTapChangeViewModeButton))
+        let changeViewModeButton = UIBarButtonItem(title: NameSpace.changeMode, style: .plain, target: self, action: #selector(didTapChangeViewModeButton))
         let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: self, action: nil)
         
         toolbarItems = [flexibleSpace, changeViewModeButton, flexibleSpace]
@@ -143,7 +143,7 @@ extension BoxOfficeViewController {
         let action: UIAlertAction = {
             switch collectionViewMode {
             case .list:
-                return  UIAlertAction(title: "아이콘", style: .default) { [weak self] _ in
+                return  UIAlertAction(title: NameSpace.icon, style: .default) { [weak self] _ in
                     guard let self else {
                         return
                     }
@@ -153,7 +153,7 @@ extension BoxOfficeViewController {
                     self.collectionView.reloadData()
                 }
             case .grid:
-                return UIAlertAction(title: "리스트", style: .default) { [weak self] _ in
+                return UIAlertAction(title: NameSpace.list, style: .default) { [weak self] _ in
                     guard let self else {
                         return
                     }
@@ -165,8 +165,8 @@ extension BoxOfficeViewController {
             }
         }()
         
-        let cancelAction = UIAlertAction(title: "취소", style: .cancel)
-        let changeModeAlert = UIAlertController.customAlert(alertTile: "화면모드선택", alertMessage: nil, preferredStyle: .actionSheet, alertActions: [action, cancelAction])
+        let cancelAction = UIAlertAction(title: NameSpace.cancel, style: .cancel)
+        let changeModeAlert = UIAlertController.customAlert(alertTile: NameSpace.selectMode, alertMessage: nil, preferredStyle: .actionSheet, alertActions: [action, cancelAction])
         
         present(changeModeAlert, animated: true)
     }
@@ -303,6 +303,11 @@ extension BoxOfficeViewController {
         static let fail = "실패"
         static let loadDataFail = "데이터 로드에 실패했습니다."
         static let check = "확인"
+        static let changeMode = "화면 모드 변경"
+        static let icon = "아이콘"
+        static let list = "리스트"
+        static let cancel = "취소"
+        static let selectMode = "화면모드선택"
     }
 }
 

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -175,9 +175,9 @@ extension BoxOfficeViewController {
 // MARK: CollectionView Layout
 extension BoxOfficeViewController {
     private func listLayout() -> UICollectionViewCompositionalLayout {
-        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(0.1))
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(80))
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
-        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(1.2))
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(80))
         let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
         let section = NSCollectionLayoutSection(group: group)
         

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 final class BoxOfficeViewController: UIViewController {
     private let boxOfficeManager: BoxOfficeManager
     private var collectionView: UICollectionView!
+    private var collectionViewMode: CollectionViewMode = .list
     private var dailyBoxOfficeDataSource: UICollectionViewDiffableDataSource<Section, DailyBoxOffice>!
     private let activityIndicator: UIActivityIndicatorView = {
         let activityIndicator = UIActivityIndicatorView(style: .large)
@@ -148,6 +149,18 @@ extension BoxOfficeViewController {
         
         return UICollectionViewCompositionalLayout(section: section)
     }
+    
+    private func gridLayout() -> UICollectionViewCompositionalLayout {
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.5), heightDimension: .fractionalHeight(1.0))
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        item.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8)
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(0.3))
+        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
+        group.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 8, bottom: 0, trailing: 8)
+        let section = NSCollectionLayoutSection(group: group)
+        
+        return UICollectionViewCompositionalLayout(section: section)
+    }
 }
 
 // MARK: CollectionView DataSource
@@ -252,5 +265,13 @@ extension BoxOfficeViewController {
 extension BoxOfficeViewController {
     private enum Section {
         case main
+    }
+}
+
+// MARK: CollectionView Mode
+extension BoxOfficeViewController {
+    private enum CollectionViewMode {
+        case list
+        case grid
     }
 }

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -188,7 +188,7 @@ extension BoxOfficeViewController {
         let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.5), heightDimension: .fractionalHeight(1.0))
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
         item.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8)
-        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(0.3))
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalWidth(0.5))
         let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
         group.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 8, bottom: 0, trailing: 8)
         let section = NSCollectionLayoutSection(group: group)

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -9,8 +9,8 @@ import UIKit
 
 final class BoxOfficeViewController: UIViewController {
     private let boxOfficeManager: BoxOfficeManager
+    private var collectionViewMode: CollectionViewMode
     private var collectionView: UICollectionView!
-    private var collectionViewMode: CollectionViewMode = .list
     private var dailyBoxOfficeDataSource: UICollectionViewDiffableDataSource<Section, DailyBoxOffice>!
     private let activityIndicator: UIActivityIndicatorView = {
         let activityIndicator = UIActivityIndicatorView(style: .large)
@@ -19,8 +19,9 @@ final class BoxOfficeViewController: UIViewController {
         return activityIndicator
     }()
     
-    init(boxOfficeManager: BoxOfficeManager) {
+    init(boxOfficeManager: BoxOfficeManager, collectionViewMode: CollectionViewMode) {
         self.boxOfficeManager = boxOfficeManager
+        self.collectionViewMode = collectionViewMode
 
         super.init(nibName: nil, bundle: nil)
     }
@@ -335,7 +336,7 @@ extension BoxOfficeViewController {
 
 // MARK: CollectionView Mode
 extension BoxOfficeViewController {
-    private enum CollectionViewMode {
+    enum CollectionViewMode {
         case list
         case grid
     }

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -69,9 +69,9 @@ extension BoxOfficeViewController {
     }
     
     private func setupCollectionView() {
-        collectionView = UICollectionView(frame: .zero, collectionViewLayout: verticalLayout())
+        collectionView = UICollectionView(frame: .zero, collectionViewLayout: listLayout())
         collectionView.translatesAutoresizingMaskIntoConstraints = false
-        collectionView.register(BoxOfficeCollectionViewCell.self, forCellWithReuseIdentifier: BoxOfficeCollectionViewCell.identifier)
+        collectionView.register(BoxOfficeCollectionViewListCell.self, forCellWithReuseIdentifier: BoxOfficeCollectionViewListCell.identifier)
         collectionView.delegate = self
     }
     
@@ -139,7 +139,7 @@ extension BoxOfficeViewController {
 
 // MARK: CollectionView Layout
 extension BoxOfficeViewController {
-    private func verticalLayout() -> UICollectionViewCompositionalLayout {
+    private func listLayout() -> UICollectionViewCompositionalLayout {
         let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(0.1))
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
         let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(1.2))
@@ -154,7 +154,7 @@ extension BoxOfficeViewController {
 extension BoxOfficeViewController {
     private func setupDataSource() {
         dailyBoxOfficeDataSource = UICollectionViewDiffableDataSource<Section, DailyBoxOffice>(collectionView: collectionView) { collectionView, indexPath, dailyBoxOffice in
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: BoxOfficeCollectionViewCell.identifier, for: indexPath) as? BoxOfficeCollectionViewCell else {
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: BoxOfficeCollectionViewListCell.identifier, for: indexPath) as? BoxOfficeCollectionViewListCell else {
                 return UICollectionViewCell()
             }
             

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -38,6 +38,12 @@ final class BoxOfficeViewController: UIViewController {
         configureUI()
         setupConstraint()
     }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        setupNavigation()
+    }
 }
 
 // MARK: setup Components

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -22,10 +22,10 @@ final class BoxOfficeViewController: UIViewController {
     init(boxOfficeManager: BoxOfficeManager, collectionViewMode: CollectionViewMode) {
         self.boxOfficeManager = boxOfficeManager
         self.collectionViewMode = collectionViewMode
-
+        
         super.init(nibName: nil, bundle: nil)
     }
-
+    
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -84,13 +84,8 @@ extension BoxOfficeViewController {
         collectionView.delegate = self
     }
     
-    private func setupCollectionViewLayout() {
-        switch collectionViewMode {
-        case .list:
-            collectionView.setCollectionViewLayout(listLayout(), animated: true)
-        case .grid:
-            collectionView.setCollectionViewLayout(gridLayout(), animated: true)
-        }
+    private func setupCollectionViewLayout(_ layout: UICollectionViewLayout) {
+        collectionView.setCollectionViewLayout(layout, animated: true)
     }
     
     private func setupRefreshControl() {
@@ -156,7 +151,7 @@ extension BoxOfficeViewController {
                     }
                     
                     self.collectionViewMode = .grid
-                    self.setupCollectionViewLayout()
+                    self.setupCollectionViewLayout(gridLayout())
                     self.applyReloadSnapshot()
                 }
             case .grid:
@@ -166,7 +161,7 @@ extension BoxOfficeViewController {
                     }
                     
                     self.collectionViewMode = .list
-                    self.setupCollectionViewLayout()
+                    self.setupCollectionViewLayout(listLayout())
                     self.applyReloadSnapshot()
                 }
             }

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -80,9 +80,9 @@ extension BoxOfficeViewController {
     private func setupCollectionViewLayout() {
         switch collectionViewMode {
         case .list:
-            collectionView.collectionViewLayout = listLayout()
+            collectionView.setCollectionViewLayout(listLayout(), animated: true)
         case .grid:
-            collectionView.collectionViewLayout = gridLayout()
+            collectionView.setCollectionViewLayout(gridLayout(), animated: true)
         }
     }
     
@@ -150,7 +150,7 @@ extension BoxOfficeViewController {
                     
                     self.collectionViewMode = .grid
                     self.setupCollectionViewLayout()
-                    self.collectionView.reloadData()
+                    self.applyReloadSnapshot()
                 }
             case .grid:
                 return UIAlertAction(title: NameSpace.list, style: .default) { [weak self] _ in
@@ -160,7 +160,7 @@ extension BoxOfficeViewController {
                     
                     self.collectionViewMode = .list
                     self.setupCollectionViewLayout()
-                    self.collectionView.reloadData()
+                    self.applyReloadSnapshot()
                 }
             }
         }()
@@ -240,6 +240,15 @@ extension BoxOfficeViewController {
         var snapshot = NSDiffableDataSourceSnapshot<Section, DailyBoxOffice>()
         snapshot.appendSections([.main])
         snapshot.appendItems(boxOfficeManager.dailyBoxOffices, toSection: .main)
+        
+        dailyBoxOfficeDataSource.apply(snapshot, animatingDifferences: true)
+    }
+    
+    private func applyReloadSnapshot() {
+        var snapshot = NSDiffableDataSourceSnapshot<Section, DailyBoxOffice>()
+        snapshot.appendSections([.main])
+        snapshot.appendItems(boxOfficeManager.dailyBoxOffices, toSection: .main)
+        snapshot.reloadSections([.main])
         
         dailyBoxOfficeDataSource.apply(snapshot, animatingDifferences: true)
     }

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -44,6 +44,7 @@ extension BoxOfficeViewController {
     private func setupComponents() {
         setupView()
         setupNavigation()
+        setupToolbar()
         setupCollectionView()
         setupRefreshControl()
     }
@@ -57,6 +58,14 @@ extension BoxOfficeViewController {
         
         navigationItem.title = DateFormatter().dateString(from: boxOfficeManager.targetDate, with: DateFormatter.FormatCase.hyphen)
         navigationItem.rightBarButtonItem = selectDateButton
+        navigationController?.setToolbarHidden(false, animated: false)
+    }
+    
+    private func setupToolbar() {
+        let changeViewModeButton = UIBarButtonItem(title: "화면 모드 변경", style: .plain, target: self, action: #selector(didTapChangeViewModeButton))
+        let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: self, action: nil)
+        
+        toolbarItems = [flexibleSpace, changeViewModeButton, flexibleSpace]
     }
     
     private func setupCollectionView() {
@@ -117,6 +126,14 @@ extension BoxOfficeViewController {
         } else {
             return
         }
+    }
+    
+    @objc private func didTapChangeViewModeButton() {
+        let action = UIAlertAction(title: "아이콘", style: .default)
+        let cancelAction = UIAlertAction(title: "취소", style: .cancel)
+        let changeModeAlert = UIAlertController.customAlert(alertTile: "화면모드선택", alertMessage: nil, preferredStyle: .actionSheet, alertActions: [action, cancelAction])
+        
+        present(changeModeAlert, animated: true)
     }
 }
 

--- a/BoxOffice/Extension/UIAlertController+.swift
+++ b/BoxOffice/Extension/UIAlertController+.swift
@@ -7,10 +7,12 @@
 
 import UIKit
 
-extension UIAlertController {
-    static func errorAlert(_ alertTitle: String?, _ alertMessage: String?, actionTitle: String?, actionType: UIAlertAction.Style) -> UIAlertController {
-        let alert = UIAlertController(title: alertTitle, message: alertMessage, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: actionTitle, style: actionType))
+extension UIAlertController {    
+    static func customAlert(alertTile: String?, alertMessage: String?, preferredStyle: UIAlertController.Style, alertActions: [UIAlertAction]) -> UIAlertController {
+        let alert = UIAlertController(title: alertTile, message: alertMessage, preferredStyle: preferredStyle)
+        alertActions.forEach {
+            alert.addAction($0)
+        }
         
         return alert
     }

--- a/BoxOffice/View/BoxOfficeCollectionViewGridCell.swift
+++ b/BoxOffice/View/BoxOfficeCollectionViewGridCell.swift
@@ -24,7 +24,6 @@ final class BoxOfficeCollectionViewGridCell: UICollectionViewCell {
     private let rankLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.preferredFont(forTextStyle: .largeTitle)
-        label.adjustsFontForContentSizeCategory = true
         label.textAlignment = .center
         
         return label
@@ -33,8 +32,10 @@ final class BoxOfficeCollectionViewGridCell: UICollectionViewCell {
     private let movieTitleLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.preferredFont(forTextStyle: .title3)
-        label.adjustsFontForContentSizeCategory = true
         label.textAlignment = .center
+        label.numberOfLines = 2
+        label.adjustsFontSizeToFitWidth = true
+        label.minimumScaleFactor = 0.5
         
         return label
     }()
@@ -42,7 +43,6 @@ final class BoxOfficeCollectionViewGridCell: UICollectionViewCell {
     private let rankChangeLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.preferredFont(forTextStyle: .body)
-        label.adjustsFontForContentSizeCategory = true
         label.textAlignment = .center
         
         return label
@@ -51,7 +51,8 @@ final class BoxOfficeCollectionViewGridCell: UICollectionViewCell {
     private let audienceCountLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.preferredFont(forTextStyle: .body)
-        label.adjustsFontForContentSizeCategory = true
+        label.adjustsFontSizeToFitWidth = true
+        label.minimumScaleFactor = 0.5
         
         return label
     }()

--- a/BoxOffice/View/BoxOfficeCollectionViewGridCell.swift
+++ b/BoxOffice/View/BoxOfficeCollectionViewGridCell.swift
@@ -93,12 +93,11 @@ extension BoxOfficeCollectionViewGridCell {
 // MARK: setup Data
 extension BoxOfficeCollectionViewGridCell {
     func setupLabels(_ dailyBoxOffice: DailyBoxOffice) {
+        let rankStateColor = dailyBoxOffice.rankStateColor
         rankLabel.text = dailyBoxOffice.rank
         rankChangeLabel.text = dailyBoxOffice.rankState
         movieTitleLabel.text = dailyBoxOffice.movieTitle
         audienceCountLabel.text = dailyBoxOffice.dailyAndTotalAudience
-        
-        let rankStateColor = dailyBoxOffice.rankStateColor
         
         rankChangeLabel.convertColor(target: rankStateColor.targetString, as: rankStateColor.color)
     }

--- a/BoxOffice/View/BoxOfficeCollectionViewGridCell.swift
+++ b/BoxOffice/View/BoxOfficeCollectionViewGridCell.swift
@@ -1,0 +1,135 @@
+//
+//  BoxOfficeCollectionViewGridCell.swift
+//  BoxOffice
+//
+//  Created by kyungmin on 2023/08/15.
+//
+
+import UIKit
+
+final class BoxOfficeCollectionViewGridCell: UICollectionViewCell {
+    static let identifier = String(describing: BoxOfficeCollectionViewGridCell.self)
+    
+    private let totalStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        stackView.alignment = .fill
+        stackView.distribution = .fillEqually
+        stackView.spacing = 4
+        
+        return stackView
+    }()
+    
+    private let rankLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.preferredFont(forTextStyle: .largeTitle)
+        label.textAlignment = .center
+        
+        return label
+    }()
+    
+    private let movieTitleLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.preferredFont(forTextStyle: .title3)
+        label.textAlignment = .center
+        
+        return label
+    }()
+    
+    private let rankChangeLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.preferredFont(forTextStyle: .body)
+        label.textAlignment = .center
+        
+        return label
+    }()
+    
+    private let audienceCountLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.preferredFont(forTextStyle: .body)
+        
+        return label
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        configureUI()
+        setupConstraint()
+        setupComponent()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        rankChangeLabel.attributedText = nil
+    }
+}
+
+// MARK: setup Component
+extension BoxOfficeCollectionViewGridCell {
+    private func setupComponent() {
+        setupContentView()
+    }
+    
+    private func setupContentView() {
+        contentView.layer.cornerRadius = 4
+        contentView.layer.borderWidth = 2
+        contentView.layer.borderColor = UIColor.systemGray.cgColor
+
+    }
+}
+
+// MARK: setup Data
+extension BoxOfficeCollectionViewGridCell {
+    func setupLabels(_ dailyBoxOffice: DailyBoxOffice) {
+        rankLabel.text = dailyBoxOffice.rank
+        rankChangeLabel.text = dailyBoxOffice.rankState
+        movieTitleLabel.text = dailyBoxOffice.movieTitle
+        audienceCountLabel.text = dailyBoxOffice.dailyAndTotalAudience
+        
+        let rankStateColor = dailyBoxOffice.rankStateColor
+        
+        rankChangeLabel.convertColor(target: rankStateColor.targetString, as: rankStateColor.color)
+    }
+}
+
+// MARK: configure UI
+extension BoxOfficeCollectionViewGridCell {
+    private func configureUI() {
+        configureContentView()
+        configureTotalStackView()
+    }
+    
+    private func configureContentView() {
+        contentView.addSubview(totalStackView)
+    }
+    
+    private func configureTotalStackView() {
+        totalStackView.addArrangedSubview(rankLabel)
+        totalStackView.addArrangedSubview(movieTitleLabel)
+        totalStackView.addArrangedSubview(rankChangeLabel)
+        totalStackView.addArrangedSubview(audienceCountLabel)
+    }
+}
+ 
+// MARK: setup Constraint
+extension BoxOfficeCollectionViewGridCell {
+    private func setupConstraint() {
+        setupTotalStackVeiwConstraint()
+    }
+    
+    private func setupTotalStackVeiwConstraint() {
+        NSLayoutConstraint.activate([
+            totalStackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 4),
+            totalStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 4),
+            totalStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -4),
+            totalStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -4)
+        ])
+    }
+}

--- a/BoxOffice/View/BoxOfficeCollectionViewGridCell.swift
+++ b/BoxOffice/View/BoxOfficeCollectionViewGridCell.swift
@@ -84,6 +84,7 @@ extension BoxOfficeCollectionViewGridCell {
     
     private func setupContentView() {
         contentView.layer.cornerRadius = 4
+        contentView.layer.masksToBounds = true
         contentView.layer.borderWidth = 2
         contentView.layer.borderColor = UIColor.systemGray.cgColor
 

--- a/BoxOffice/View/BoxOfficeCollectionViewGridCell.swift
+++ b/BoxOffice/View/BoxOfficeCollectionViewGridCell.swift
@@ -24,6 +24,7 @@ final class BoxOfficeCollectionViewGridCell: UICollectionViewCell {
     private let rankLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.preferredFont(forTextStyle: .largeTitle)
+        label.adjustsFontForContentSizeCategory = true
         label.textAlignment = .center
         
         return label
@@ -32,6 +33,7 @@ final class BoxOfficeCollectionViewGridCell: UICollectionViewCell {
     private let movieTitleLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.preferredFont(forTextStyle: .title3)
+        label.adjustsFontForContentSizeCategory = true
         label.textAlignment = .center
         
         return label
@@ -40,6 +42,7 @@ final class BoxOfficeCollectionViewGridCell: UICollectionViewCell {
     private let rankChangeLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.preferredFont(forTextStyle: .body)
+        label.adjustsFontForContentSizeCategory = true
         label.textAlignment = .center
         
         return label
@@ -48,6 +51,7 @@ final class BoxOfficeCollectionViewGridCell: UICollectionViewCell {
     private let audienceCountLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.preferredFont(forTextStyle: .body)
+        label.adjustsFontForContentSizeCategory = true
         
         return label
     }()

--- a/BoxOffice/View/BoxOfficeCollectionViewGridCell.swift
+++ b/BoxOffice/View/BoxOfficeCollectionViewGridCell.swift
@@ -35,7 +35,7 @@ final class BoxOfficeCollectionViewGridCell: UICollectionViewCell {
         label.textAlignment = .center
         label.numberOfLines = 2
         label.adjustsFontSizeToFitWidth = true
-        label.minimumScaleFactor = 0.5
+        label.minimumScaleFactor = 0.1
         
         return label
     }()
@@ -52,7 +52,7 @@ final class BoxOfficeCollectionViewGridCell: UICollectionViewCell {
         let label = UILabel()
         label.font = UIFont.preferredFont(forTextStyle: .body)
         label.adjustsFontSizeToFitWidth = true
-        label.minimumScaleFactor = 0.5
+        label.minimumScaleFactor = 0.1
         
         return label
     }()

--- a/BoxOffice/View/BoxOfficeCollectionViewListCell.swift
+++ b/BoxOffice/View/BoxOfficeCollectionViewListCell.swift
@@ -166,7 +166,8 @@ extension BoxOfficeCollectionViewListCell {
     private func setupRankStackVeiwConstraint() {
         NSLayoutConstraint.activate([
             rankStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 32),
-            rankStackView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor)
+            rankStackView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            rankStackView.widthAnchor.constraint(greaterThanOrEqualToConstant: 40)
         ])
     }
     

--- a/BoxOffice/View/BoxOfficeCollectionViewListCell.swift
+++ b/BoxOffice/View/BoxOfficeCollectionViewListCell.swift
@@ -108,12 +108,11 @@ final class BoxOfficeCollectionViewListCell: UICollectionViewCell {
 // MARK: setup Data
 extension BoxOfficeCollectionViewListCell {
     func setupLabels(_ dailyBoxOffice: DailyBoxOffice) {
+        let rankStateColor = dailyBoxOffice.rankStateColor
         rankLabel.text = dailyBoxOffice.rank
         rankChangeLabel.text = dailyBoxOffice.rankState
         movieTitleLabel.text = dailyBoxOffice.movieTitle
         audienceCountLabel.text = dailyBoxOffice.dailyAndTotalAudience
-        
-        let rankStateColor = dailyBoxOffice.rankStateColor
         
         rankChangeLabel.convertColor(target: rankStateColor.targetString, as: rankStateColor.color)
     }

--- a/BoxOffice/View/BoxOfficeCollectionViewListCell.swift
+++ b/BoxOffice/View/BoxOfficeCollectionViewListCell.swift
@@ -31,18 +31,20 @@ final class BoxOfficeCollectionViewListCell: UICollectionViewCell {
     
     private let rankLabel: UILabel = {
         let label = UILabel()
-        label.translatesAutoresizingMaskIntoConstraints = false
         label.font = UIFont.preferredFont(forTextStyle: .largeTitle)
+        label.adjustsFontForContentSizeCategory = true
         label.textAlignment = .center
+        label.setContentCompressionResistancePriority(.required, for: .horizontal)
         
         return label
     }()
     
     private let rankChangeLabel: UILabel = {
         let label = UILabel()
-        label.translatesAutoresizingMaskIntoConstraints = false
         label.font = UIFont.preferredFont(forTextStyle: .body)
+        label.adjustsFontForContentSizeCategory = true
         label.textAlignment = .center
+        label.setContentCompressionResistancePriority(.required, for: .horizontal)
         
         return label
     }()
@@ -60,16 +62,18 @@ final class BoxOfficeCollectionViewListCell: UICollectionViewCell {
     
     private let movieTitleLabel: UILabel = {
         let label = UILabel()
-        label.translatesAutoresizingMaskIntoConstraints = false
         label.font = UIFont.preferredFont(forTextStyle: .title3)
+        label.adjustsFontForContentSizeCategory = true
+        label.numberOfLines = 0
         
         return label
     }()
     
     private let audienceCountLabel: UILabel = {
         let label = UILabel()
-        label.translatesAutoresizingMaskIntoConstraints = false
         label.font = UIFont.preferredFont(forTextStyle: .body)
+        label.adjustsFontForContentSizeCategory = true
+        label.numberOfLines = 0
         
         return label
     }()
@@ -162,21 +166,22 @@ extension BoxOfficeCollectionViewListCell {
     private func setupRankStackVeiwConstraint() {
         NSLayoutConstraint.activate([
             rankStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 32),
-            rankStackView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-            rankStackView.widthAnchor.constraint(equalToConstant: 40)
+            rankStackView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor)
         ])
     }
     
     private func setupMovieInfomationStackViewConstraint() {
         NSLayoutConstraint.activate([
             movieInfomationStackView.leadingAnchor.constraint(equalTo: rankStackView.trailingAnchor, constant: 32),
-            movieInfomationStackView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor)
+            movieInfomationStackView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            movieInfomationStackView.topAnchor.constraint(greaterThanOrEqualTo: contentView.topAnchor, constant: 16),
+            movieInfomationStackView.bottomAnchor.constraint(greaterThanOrEqualTo: contentView.bottomAnchor, constant: -16)
         ])
     }
     
     private func setupForwardImageViewConstraint() {
         NSLayoutConstraint.activate([
-            forwardImageView.leadingAnchor.constraint(greaterThanOrEqualTo: movieInfomationStackView.trailingAnchor, constant: 32),
+            forwardImageView.leadingAnchor.constraint(greaterThanOrEqualTo: movieInfomationStackView.trailingAnchor, constant: 16),
             forwardImageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
             forwardImageView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
             forwardImageView.widthAnchor.constraint(equalToConstant: 12),

--- a/BoxOffice/View/BoxOfficeCollectionViewListCell.swift
+++ b/BoxOffice/View/BoxOfficeCollectionViewListCell.swift
@@ -7,8 +7,8 @@
 
 import UIKit
 
-final class BoxOfficeCollectionViewCell: UICollectionViewCell {
-    static let identifier = String(describing: BoxOfficeCollectionViewCell.self)
+final class BoxOfficeCollectionViewListCell: UICollectionViewCell {
+    static let identifier = String(describing: BoxOfficeCollectionViewListCell.self)
     
     private let seperatorView: UIView = {
         let view = UIView()
@@ -102,7 +102,7 @@ final class BoxOfficeCollectionViewCell: UICollectionViewCell {
 }
 
 // MARK: setup Data
-extension BoxOfficeCollectionViewCell {
+extension BoxOfficeCollectionViewListCell {
     func setupLabels(_ dailyBoxOffice: DailyBoxOffice) {
         rankLabel.text = dailyBoxOffice.rank
         rankChangeLabel.text = dailyBoxOffice.rankState
@@ -116,7 +116,7 @@ extension BoxOfficeCollectionViewCell {
 }
 
 // MARK: configure UI
-extension BoxOfficeCollectionViewCell {
+extension BoxOfficeCollectionViewListCell {
     private func configureUI() {
         configureRankStackView()
         configureMovieInfomationStackView()
@@ -142,7 +142,7 @@ extension BoxOfficeCollectionViewCell {
 }
  
 // MARK: setup Constraint
-extension BoxOfficeCollectionViewCell {
+extension BoxOfficeCollectionViewListCell {
     private func setupConstraint() {
         setupSeperatorVeiwConstraint()
         setupRankStackVeiwConstraint()

--- a/BoxOffice/View/MovieDetailScrollView.swift
+++ b/BoxOffice/View/MovieDetailScrollView.swift
@@ -94,14 +94,14 @@ extension MovieDetailScrollView {
     private func informationStackView(title: String, information: String) -> UIStackView {
         let stackView = UIStackView()
         stackView.axis = .horizontal
-        stackView.alignment = .fill
+        stackView.alignment = .center
         stackView.distribution = .fill
         stackView.spacing = 8
         
         let titleLabel = UILabel()
-        let titleLabelConstraint = titleLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: self.frame.width * 0.2)
+        let titleLabelConstraint = titleLabel.widthAnchor.constraint(equalTo: titleLabel.heightAnchor, multiplier: 3)
         titleLabelConstraint.isActive = true
-        titleLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+        titleLabel.setContentCompressionResistancePriority(.required, for: .vertical)
         titleLabel.font = UIFont.preferredFont(forTextStyle: .headline)
         titleLabel.adjustsFontForContentSizeCategory = true
         titleLabel.textAlignment = .center

--- a/BoxOffice/View/MovieDetailScrollView.swift
+++ b/BoxOffice/View/MovieDetailScrollView.swift
@@ -96,11 +96,12 @@ extension MovieDetailScrollView {
         stackView.axis = .horizontal
         stackView.alignment = .fill
         stackView.distribution = .fill
-        stackView.spacing = 4
+        stackView.spacing = 8
         
         let titleLabel = UILabel()
-        let titleLabelConstraint = titleLabel.widthAnchor.constraint(equalToConstant: self.frame.width * 0.2)
+        let titleLabelConstraint = titleLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: self.frame.width * 0.2)
         titleLabelConstraint.isActive = true
+        titleLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
         titleLabel.font = UIFont.preferredFont(forTextStyle: .headline)
         titleLabel.adjustsFontForContentSizeCategory = true
         titleLabel.textAlignment = .center

--- a/BoxOffice/View/MovieDetailScrollView.swift
+++ b/BoxOffice/View/MovieDetailScrollView.swift
@@ -102,11 +102,13 @@ extension MovieDetailScrollView {
         let titleLabelConstraint = titleLabel.widthAnchor.constraint(equalToConstant: self.frame.width * 0.2)
         titleLabelConstraint.isActive = true
         titleLabel.font = UIFont.preferredFont(forTextStyle: .headline)
+        titleLabel.adjustsFontForContentSizeCategory = true
         titleLabel.textAlignment = .center
         titleLabel.text = title
         
         let informationLabel = UILabel()
         informationLabel.font = UIFont.preferredFont(forTextStyle: .body)
+        informationLabel.adjustsFontForContentSizeCategory = true
         informationLabel.textAlignment = .left
         informationLabel.numberOfLines = 0
         informationLabel.text = information

--- a/BoxOffice/View/MovieDetailViewController.swift
+++ b/BoxOffice/View/MovieDetailViewController.swift
@@ -65,7 +65,8 @@ extension MovieDetailViewController {
         boxOfficeManager.fetchMovie(movieCode) { result in
             if result == false {
                 DispatchQueue.main.async {
-                    let alert = UIAlertController.errorAlert(NameSpace.fail, NameSpace.loadDataFail, actionTitle: NameSpace.check, actionType: .default)
+                    let alertAction = UIAlertAction(title: NameSpace.check, style: .default)
+                    let alert = UIAlertController.customAlert(alertTile: NameSpace.fail, alertMessage: NameSpace.loadDataFail, preferredStyle: .alert, alertActions: [alertAction])
                     
                     self.present(alert, animated: false)
                 }
@@ -87,7 +88,8 @@ extension MovieDetailViewController {
         boxOfficeManager.fetchPosterImage(movieName) { result in
             if result == false {
                 DispatchQueue.main.async {
-                    let alert = UIAlertController.errorAlert(NameSpace.fail, NameSpace.loadDataFail, actionTitle: NameSpace.check, actionType: .default)
+                    let alertAction = UIAlertAction(title: NameSpace.check, style: .default)
+                    let alert = UIAlertController.customAlert(alertTile: NameSpace.fail, alertMessage: NameSpace.loadDataFail, preferredStyle: .alert, alertActions: [alertAction])
                     
                     self.movieDetailView.stopActivityIndicator()
                     self.present(alert, animated: false)

--- a/BoxOffice/View/MovieDetailViewController.swift
+++ b/BoxOffice/View/MovieDetailViewController.swift
@@ -50,6 +50,7 @@ extension MovieDetailViewController {
     
     private func setupNavigation() {
         navigationItem.title = movieName
+        navigationController?.setToolbarHidden(true, animated: true)
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 4. [📊 UML & 파일트리](#4.)
 5. [📱 실행 화면](#5.)
 6. [🧨 트러블 슈팅](#6.)
-7. [🔗 참고 링크](#7.)
+7. [👬 팀 회고](#7.)
+8. [🔗 참고 링크](#8.)
 
 <br>
 
@@ -25,17 +26,20 @@
 >   - `TestDouble` 객체를 이용하여 네트워크가 연결되어 있지 않은 경우에도 테스트
 > - **DTO**
 >   - `JSON` 데이터를 디코딩할 `DTO` 객체 구현
->     - 사용할 데이터만으로 이루어진 `Entity` 객체 구현
+>     - 사용할 데이터만으로 이루어진 `Model` 객체 구현
 > - **CollectionView**
 >   - `CollectionView`를 활용한 UI구현
 >   - `CompositionalLayout`를 활용한 `Layout` 설정
 >   - `DiffableDataSource`를 활용한 UI 업데이트
+>   - `Grid` 모드 구현
 > - **MVC**
 >   - `MVC`패턴을 활용하여 객체를 역할에 알맞게 분리하여 프로젝트 구현
 > - **NSCache**
 >   - `NSCache`를 활용하여 받아온 이미지를 재사용
 > - **UICalendarView**
 >   - `UICalendarView`를 활용하여 달력 구현
+> - **UIAlertController**
+>   - `actionSheet` 활용
 
 <br>
 
@@ -52,7 +56,7 @@
 <a id="3."></a>
 ## 3. ⏱️ 타임라인
 
-> 프로젝트 기간 :  2023.07.24 ~ 2023.08.04
+> 프로젝트 기간 :  2023.07.24 ~ 2023.08.18
 
 |날짜|내용|
 |:---:|---|
@@ -70,6 +74,9 @@
 | **2023.08.08** |▫️ 이미지 캐싱을 위한 `CacheManager` 구현 <br> ▫️ `CalendarView`및 `Controller` 구현 <br>|
 | **2023.08.09** |▫️ 코드 개선을 위한 리펙토링 <br> |
 | **2023.08.11** |▫️ 코드 개선을 위한 리펙토링 <br> ▫️ README 작성 <br>|
+| **2023.08.15** |▫️ `CollectionView`의 `listMode`와 `gridMode` 구현 <br> ▫️ `actionSheet`으로 사용자가 `listMode`와 `gridMode`를 선택할 수 있도록 구현 <br> ▫️ `listMode` 및 `DetailView`의 다이나믹 타입 구현 <br>|
+| **2023.08.17** |▫️ 코드 개선을 위한 리펙토링 <br> |
+| **2023.08.18** |▫️ README 작성 <br> |
 
 <br>
 
@@ -88,27 +95,28 @@ BoxOffice
 ├── App
 │   ├── AppDelegate.swift
 │   └── SceneDelegate.swift
+├── Controller
+│   ├── BoxOfficeViewController.swift
+│   ├── CalendarViewController.swift
+│   └── MovieDetailViewController.swift
 ├── Model
+│   ├── Manager
+│   │   ├── BoxOfficeManager.swift
+│   │   ├── CacheManager.swift
+│   │   └── DataManager.swift
 │   ├── DTO
 │   │   ├── BoxOffice.swift
 │   │   ├── Movie.swift
 │   │   └── PosterImageInformation.swift
 │   ├── DailyBoxOffice.swift
-│   ├── Manager
-│   │   ├── BoxOfficeManager.swift
-│   │   ├── CacheManager.swift
-│   │   └── DataManager.swift
 │   ├── MovieInformation.swift
 │   └── TestDouble
 │       ├── StubURLSession.swift
 │       └── URLSessionProtocol.swift
-├── Controller
-│   ├── BoxOfficeViewController.swift
-│   └── CalendarViewController.swift
 ├── View
-│   ├── BoxOfficeCollectionViewCell.swift
-│   ├── MovieDetailScrollView.swift
-│   └── MovieDetailViewController.swift
+│   ├── BoxOfficeCollectionViewGridCell.swift
+│   ├── BoxOfficeCollectionViewListCell.swift
+│   └── MovieDetailScrollView.swift
 ├── Extension
 │   ├── Date+.swift
 │   ├── DateFormatter+.swift
@@ -131,27 +139,47 @@ BoxOffice
 
 <a id="5."></a>
 ## 5. 📱 실행 화면
-| 박스오피스 데이터 로드 | 화면을 당겨 데이터 리로드 | 데이터 로드에 실패했을 때 알림화면 |
-| :--------------: | :-------: |  :-------: | 
-| <Img src = "https://hackmd.io/_uploads/BJdHyz9i3.gif" width="225"/> | <Img src = "https://hackmd.io/_uploads/ByZ1xfqi2.gif" width="225"/>  | <Img src = "https://hackmd.io/_uploads/H12xlf5jn.gif" width="225"/> |
-| **영화 상세화면** | **날짜선택** |
-| <Img src = "https://hackmd.io/_uploads/HJd7lDQ2n.gif" width="225"/> | <Img src = "https://hackmd.io/_uploads/r1FOxvQ3n.gif" width="225"/>  |
+| 박스오피스 데이터 로드 | 화면을 당겨 데이터 리로드 |
+| :--------------: | :-------: |
+| <Img src = "https://hackmd.io/_uploads/BJdHyz9i3.gif" width="300"/> | <Img src = "https://hackmd.io/_uploads/ByZ1xfqi2.gif" width="300"/>  |
+| **데이터 로드에 실패했을 때 알림화면** | **영화 상세화면** |
+| <Img src = "https://hackmd.io/_uploads/H12xlf5jn.gif" width="300"/> | <Img src = "https://hackmd.io/_uploads/HJd7lDQ2n.gif" width="300"/> |
+| **날짜선택** | **화면 모드 변경** |
+| <Img src = "https://hackmd.io/_uploads/r1FOxvQ3n.gif" width="300"/>  | <Img src = "https://hackmd.io/_uploads/r1PEKBh3n.gif" width="300"/> |
 
 <br>
 
 <a id="6."></a>
 ## 6. 🧨 트러블 슈팅
 
-### [📎 Step3 트러블 슈팅 보러가기](https://github.com/h-suo/ios-box-office/blob/step3/README.md#6--트러블-슈팅)
-
-<br>
-
-### 1️⃣ VC의 기능 분리
+### 1️⃣ 객체 분리
 
 #### 🔥 문제점
-많은 기능들을 구현하다 보니 `Model`쪽으로 기능 분리를 많이 했음에도 불구하고 `VC`의 코드가 길어져 가독성이 떨어지는 문제가 있었습니다.
+`Controller`나 하나의 `Model`에서 많은 로직을 처리하는 것보단 자신의 역할을 가진 객체들을 잘 구현하여 필요할때만 불러 사용한다면 객체간의 의존성도 낮추고 코드를 재사용하는 측면에 좋을 것 같아 객체 분리에 대한 고민을 많이 했습니다.
+
+많은 기능들을 구현하다 보니 `Model`쪽에서 기능 분리를 많이 했음에도 불구하고 `VC`의 코드가 길어져 가독성이 떨어지는 문제가 있었습니다.
 
 #### 🧯 해결방법
+**1. Model의 기능 분리**
+다음과 같이 자신의 역할을 가진 객체를 만들어 프로젝트를 구현하였습니다.
+
+> - **DTO** : 서버로부터 받은 `Data`를 `Decode`할때 쓰는 타입
+> - **Model Data** : 실제 `App`에서 사용할 `Data` 타입
+> - **DataManager** : `DTO`를 `Model Data`로 변환해주는 역활
+> - **NetworkManager** : 서버로부터 `Data`를 받아오는 역할
+> - **BoxOfficeManager** : `Controller`에서 필요한 데이터를 받아 관리하는 타입
+> - **Extension**
+>   - URLSession : 테스트를 위해 `URLSeesionProtocol`을 채택하기 위한 `extension`
+>   - URLRequest : `Header`값을 지정한 `URLRequest`를 반환해주는 `kakaoURLRequest` 메서드 추가
+>   - URL : `URL`을 생성하는 `kobisURL`, `kakaoURL` 메서드 추가
+>   - UILabel : `attributedText`의 부분 색을 변경해주는 `convertColor`메서드 추가
+>   - UIAlertController : 커스텀한 `UIAlertController`을 반환하는 `customAlert` 메서드 추가
+>   - Date : `Date`를 반환해주는 `date`메서드 추가
+>   - DateFormatter : 오늘로부터 원하는 만큼 떨어진 날짜를 원하는 포멧으로 반환하는 `dateString` 메서드 추가
+>   - NumberFormatter : 숫자로 이루어진 `String`을 받아 `Decimal`스타일로 포멧해주는 `decimalString` 메서드 추가
+
+
+**2. VC 기능 분리**
 `extension`과 `MARK`를 이용해 기능 분리를 해서 코드의 가독성을 높였습니다.
 
 >#### 🔺extension 하지 않은 부분
@@ -171,7 +199,128 @@ BoxOffice
 
 <br>
 
-### 2️⃣ Hashable
+### 2️⃣ Test Double
+
+#### 🔥 문제점
+네트워크가 연결되어 있지 않은 상황에서도 `NetworkManager`의 `startLoad` 로직이 잘 작동하는지 테스트를 하고 싶었습니다. 하지만 `URLSession`의 `dataTask` 메서드를 사용하고 있었기 때문에 네트워크가 연결되어 있지 않은 상황에서는 테스트가 어려웠습니다.
+
+#### 🧯 해결방법
+테스트가 어려운 경우 사용할 수 있는 `Test Double` 객체 `StubURLSession`을 구현하여 테스트를 진행하였습니다. `StubURLSession`는 실제 `dataTask`의 역할을 수행하진 않지만 껍데기 `dataTask`를 가지고 있어 넣어준 `Dummy Data`를 반환하는 객체입니다.
+
+**💉 의존성 주입**
+```swift
+protocol URLSessionProtocol {
+    func dataTask(with urlRequest: URLRequest,  completionHandler: @escaping DataTaskCompletionHandler) -> URLSessionDataTask
+}
+```
+
+```swift
+struct NetworkManager {
+    private let urlSession: URLSessionProtocol
+    
+    // ...
+}
+```
+- `URLSessionProtocol`을 만들어 `NetworkManager`가 프로퍼티로 해당 타입을 가지고 있도록 하여 `URLSession`뿐만 아니라 `StubURLSession`을 주입할 수 있도록 하여 테스트했습니다.
+
+**✅ 테스트**
+
+```swift
+// given
+// 받아올 데이터를 임의로 생성
+let dummy = DummyData(data: data, response: response, error: nil)
+let stubUrlSession = StubURLSession(dummy: dummy)
+sut = NetworkManager(urlSession: stubURLSession)
+
+// when
+sut?.requestData(from: url, completion: { result in
+    // then
+    // startLoad로 받아온 데이터는 DummyData의 데이터
+    XCTAssertEqual(data, dataAsset.data)
+    expectation.fulfill()
+})
+```
+- `StubURLSession`는 `DummyData`를 가지고 `dataTask` 메서드를 실행시 `StubURLSessionDataTask`을 이용해서 `DummyData`만 던져주도록 구현했습니다.
+
+<br>
+
+### 3️⃣ Closure Capture
+
+#### 🔥 문제점
+`BoxOfficeManager`의 `fetchBoxOffice`에서 `requestData`로 네트워킹을하여 데이터를 받아오는 로직에 클로져 내에서 `BoxOfficeManager`의 프로퍼티인 `dailyBoxOffices`로 접근하여 프로퍼티를 변경하는 로직이 있었습니다. 이때 클로져가 `self`를 캡쳐하면서 RC가 올라가 메모리 해제가 안되는 강한참조순환이 발생할 수 있다는 문제가 있었습니다.
+
+```swift
+final class BoxOfficeManager {
+    private(set) var dailyBoxOffices: [DailyBoxOffice] = []
+    
+    // ...
+    func fetchBoxOffice(completion: @escaping (Bool) -> Void) {
+        
+        // ...
+        networkManager.requestData(from: url) { result in
+            switch result {
+            case .success(let data):
+                do {
+                    let boxOffice = try JSONDecoder().decode(BoxOffice.self, from: data)
+                    self.dailyBoxOffices = DataManager.boxOfficeTransferDailyBoxOfficeData(boxOffice: boxOffice)
+                    completion(true)
+                } // ...
+            }
+        }
+    }
+}
+```
+
+#### 🧯 해결방법
+클로져의 캡쳐로 `self`의 RC가 올라가는 것을 막아주기 위해 `[weak self]`로 클로져를 캡쳐하여 강한순환참조를 예방하였습니다.
+
+```swift
+final class BoxOfficeManager {
+    private(set) var dailyBoxOffices: [DailyBoxOffice] = []
+    
+    // ...
+    func fetchBoxOffice(completion: @escaping (Bool) -> Void) {
+        
+        // ...
+        networkManager.requestData(from: url) { [weak self] result in
+            guard let self else {
+                return
+            }
+                                               
+            switch result {
+            case .success(let data):
+                do {
+                    let boxOffice = try JSONDecoder().decode(BoxOffice.self, from: data)
+                    self.dailyBoxOffices = DataManager.boxOfficeTransferDailyBoxOfficeData(boxOffice: boxOffice)
+                    completion(true)
+                } // ...
+            }
+        }
+    }
+}
+```
+
+<br>
+
+### 4️⃣ endRefreshing
+
+#### 🔥 문제점
+화면을 위로 드레그하여 데이터를 리로드할 때 데이터 로드에 실패하면 `alert`이 뜨는데 이때 `refreshControl?.endRefreshing()`이 안되는 문제가 있었습니다.
+
+<Img src = "https://hackmd.io/_uploads/Hyq_Iz9o3.gif" width="300"/>
+
+#### 🧯 해결방법
+`endRefreshing`의 애니메이션 효과와 `present`의 애니메이션 효과를 동시에 처리하지 못하여 발생하는 에러였습니다.
+`present`의 `animated`를 `false`로 설정하여 해결하였습니다.
+
+```swift
+present(alert, animated: false)
+```
+<Img src = "https://hackmd.io/_uploads/rkRtvMqi3.gif" width="300"/>
+
+<br>
+
+### 5️⃣ Hashable
 
 #### 🔥 문제점
 기존의 `CollectionView`에 `CompositionalLayout`와 `DiffableDataSource`를 적용하는 과정에서 `DailyBoxOffice` 객체가 `Hashable`을 채택해야 했습니다.
@@ -211,128 +360,7 @@ struct DailyBoxOffice: Hashable {
 }
 ```
 
-### 3️⃣ URLRequest
-
-#### 🔥 문제점
-영화 포스터 이미지를 가져올 때 [다음 이미지 검색 API](https://developers.kakao.com/docs/latest/ko/daum-search/dev-guide#search-image) 이용해야 했습니다.
-기존 `API`는 `URLRequest`를 설정할 필요 없이 `URL`의 `QureyItem`만을 설정하여 데이터를 요청할 수 있었지만 `다음 이미지 검색 API`는 `Request Header`에 `Key`를 담아서 보내야 했습니다.
-
-#### 🧯 해결방법
-`NetworkManager`에 `URLRequest`를 받을 수 있도록 `requestData(from urlRequest:, completion:)` 메서드를 추가하였습니다.
-
-```swift
-func requestData(from urlRequest: URLRequest, completion: @escaping (Result<Data, NetworkError>) -> Void) {
-    let task = urlSession.dataTask(with: urlRequest) { data, response, error in
-        // ...
-    }
-    // ...
-}
-```
-
-### 4️⃣ NSCache
-
-#### 🔥 문제점
-데이터가 큰 이미지를 계속해서 네트워킹을 통해 받아오는 것은 효율적이지 못하다고 생각하였습니다.
-
-```swift
-func fetchPosterImage(_ movieName: String, completion: @escaping (Bool) -> Void) {
-        
-        // ...
-        networkManager.requestData(from: urlRequest) { [weak self] result in
-            
-            // ...
-            }
-        }
-    }
-```
-- `fetchPosterImage`를 호출하면 무조건 `requestData`로 네트워킹을 하여 이미지를 가져옵니다.
-
-#### 🧯 해결방법
-데이터가 큰 이미지는 한번 받아온 후 재사용할 수 있도록 `CacheManager`를 만들어 관리해주었습니다.
-
-```swift
-final class CacheManager {
-    static let shared = CacheManager()
-    private let imageCache = NSCache<NSString, UIImage>()
-    
-    private init() {}
-    
-    
-    func setCacheImage(_ image: UIImage, forKey: String) {
-        imageCache.setObject(image, forKey: forKey as NSString)
-    }
-    
-    func cacheImage(forKey: String) -> UIImage? {
-        return imageCache.object(forKey: forKey as NSString)
-    }
-}
-```
-- `NSString`을 키값으로 `UIImage`를 저장하는 `NSCache`를 싱글톤 패턴을 이용하여 구현했습니다.
-
-```swift
-func fetchPosterImage(_ movieName: String, completion: @escaping (Bool) -> Void) {
-    if let cacheImage = CacheManager.shared.cacheImage(forKey: movieName) {
-        posterImage = cacheImage
-        completion(true)
-        return
-    }
-    
-    // ...
-    networkManager.requestData(from: urlRequest) { [weak self] result in
-        // ...
-        switch result {
-        case .success(let data):
-            do {
-                // ...
-                CacheManager.shared.setCacheImage(image, forKey: movieName)
-                self.posterImage = image
-                completion(true)
-            } catch {
-                // ...
-            }
-        case .failure(let error):
-            // ...
-        }
-    }
-}
-```
-- 실제 캐싱을 하는 위치는 `BoxOfficeManager`의 `fetchPosterImage`에서 이미지를 받아오기 전에 `movieName`을 `cacheKey`로 캐싱된 이미지가 있다면 `requestData`를 호출하지 않고 캐싱된 이미지를 사용합니다.
-- 캐싱된 이미지가 없다면 `requestData`로 이미지를 받아와 캐싱하도록 구현했습니다.
-
-### 5️⃣ 날짜선택
-
-#### 🔥 문제점
-`UICalendarView`를 사용하여 달력을 구현하였습니다.
-이 때 처음 달력이 보였을 때 선택된 날짜 달력에 표시하고, 사용자가 선택한 날짜를 `BoxOfficeViewController`로 보내기 위해 고민했습니다.
-
-#### 🧯 해결방법
-`BoxOfficeViewContorller`에서는 선택된 날짜를 `init`의 파라미터로 주입하여 전달하고, `CalendarViewController`에서는 `Delegate` 패턴을 사용하여 사용자가 선택한 날짜를 `BoxOfficeViewController`에서 사용할 수 있도록 했습니다.
-
-```swift
-private func setupCalendarView() {
-    
-    // ...
-    let dateSelection = UICalendarSelectionSingleDate(delegate: self)
-    dateSelection.selectedDate = selectedDate
-    calendarView.selectionBehavior = dateSelection
-}
-```
-- `BoxOfficeViewController`에서 `init`을 통해 받아온 `selectedDate`를 선택된 날짜로 선택하도록 했습니다.
-- `UICalendarSelectionSingleDate`로 단일 선택만 가능하도록 설정했습니다.
-
-```swift
-protocol CalendarViewControllerDelegate: AnyObject {
-    func calendarViewController(_ calendarViewController: UIViewController, didSelectDate dateComponents: DateComponents?)
-}
-
-extension CalendarViewController: UICalendarSelectionSingleDateDelegate {
-    func dateSelection(_ selection: UICalendarSelectionSingleDate, didSelectDate dateComponents: DateComponents?) {
-        delegate?.calendarViewController(self, didSelectDate: dateComponents)
-        dismiss(animated: true)
-    }
-}
-```
-- `UICalendarSelectionSingleDateDelegate`를 채택하여 날짜가 선택되었을 때 `Delegate` 패턴을 이용하여 선택된 `DateComponents`를 넘겨주었습니다.
+<br>
 
 ### 6️⃣ Delegate패턴 순환참조
 
@@ -417,10 +445,87 @@ final class CalendarViewController: UIViewController {
 }
 ```
 
+<br>
+
+### 7️⃣ 화면 모드 변경 애니메이션
+
+#### 🔥 문제점
+처음에는 모드 변경을 할 때 `collectionView.reloadData()`로 모든 셀을 다시 로드하였습니다. 
+이럴 경우 애니메이션 없이 화면이 바로 바껴 사용자 경험을 저하시킬 수 있다는 단점이 있었습니다.
+
+<Img src = "https://hackmd.io/_uploads/rkA6tFnnn.gif" width="300"/>
+
+#### 🧯 해결방법
+`setCollectionViewLayout`과 `reloadSections`을 사용하여 `layout`이 바뀌는 순간과 `section`이 리로드 되는 순간에 애니메이션 효과를 주었습니다.
+
+**layout이 업데이트 될 때 애니메이션**
+```swift
+switch collectionViewMode {
+case .list:
+    collectionView.setCollectionViewLayout(listLayout(), animated: true)
+case .grid:
+    collectionView.setCollectionViewLayout(gridLayout(), animated: true)
+}
+```
+
+**reloadSections와 apply를 사용하여 section이 업데이트 될 때 애니메이션**
+```swift
+var snapshot = NSDiffableDataSourceSnapshot<Section, DailyBoxOffice>()
+snapshot.appendSections([.main])
+snapshot.appendItems(boxOfficeManager.dailyBoxOffices, toSection: .main)
+snapshot.reloadSections([.main])
+
+dailyBoxOfficeDataSource.apply(snapshot, animatingDifferences: true)
+```
+
+<br>
+
+### 8️⃣ dynamic type과 label의 너비
+
+#### 🔥 문제점
+`DetailView`에 `dynamic type`을 적용했을때 글씨가 커질 경우 감독, 제작년도, 개봉일 등의 `titleLabel`의 크기가 동일한 비율을 유지하며 커지지 않는 문제가 있었습니다.
+
+<Img src = "https://hackmd.io/_uploads/H1QcsYn33.png" width="300"/>
+
+#### 🧯 해결방법
+`titleLabel`의 `widthAnchor`를 `heightAnchor`의 3배로 설정하여 비율을 주고 `setContentCompressionResistancePriority`로 높이가 우선적으로 늘어날 수 있게 하여 글씨가 커질 경우에도 비율에 맞게 `label`의 너비가 늘어날 수 있도록 하였습니다.
+
+```swift
+let titleLabelConstraint = titleLabel.widthAnchor.constraint(equalTo: titleLabel.heightAnchor, multiplier: 3)
+titleLabel.setContentCompressionResistancePriority(.required, for: .vertical)
+```
+
+<Img src = "https://hackmd.io/_uploads/Hy5JhYhn2.png" width="300"/>
+
+<br>
+
 <a id="7."></a>
-## 7. 🔗 참고 링크
+## 7. 👬 팀 회고
+### 😃 잘한 점
+- 객체분리에 대해 많이 고민했습니다. 다른 객체와의 결합도를 낮추는데 집중했고, 이로인해 가독성과 유지보수성이 높은 코드를 작성했습니다. 
+- 이해되지 않는 부분은 시간이 걸리더라도 최대한 이해하려고 노력했습니다.
+- 새로운 기술 스택을 사용할 때, 해당 기술의 공식 문서를 꼼꼼히 읽고 사용했습니다.
+- 프로젝트 진행 중 문제가 발생하거나 버그를 해결할 때 공식문서를 잘 활용했습니다.
+
+### 😢 아쉬웠던 점
+- `Protocol`을 많이 활용하지 못한 부분이 아쉬웠습니다.
+- `POP`에 대한 고민을 하지 못한 점이 아쉬웠습니다.
+
+<br>
+
+<a id="8."></a>
+## 8. 🔗 참고 링크
+- [🍎Apple: CodingKey](https://developer.apple.com/documentation/swift/codingkey)
+- [🍎Apple: URLSession](https://developer.apple.com/documentation/foundation/urlsession)
+- [🍎Apple: Fetching Website Data into Memory](https://developer.apple.com/documentation/foundation/url_loading_system/fetching_website_data_into_memory)
+- [🍎Apple: Capturing Values](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/closures/#Capturing-Values)
+- [🍎Apple: UICollectionViewCompositionalLayout](https://developer.apple.com/documentation/uikit/uicollectionviewcompositionallayout)
 - [🍎Apple: UICollectionViewDiffableDataSource](https://developer.apple.com/documentation/uikit/uicollectionviewdiffabledatasource)
 - [🍎Apple: NSDiffableDataSourceSnapshot](https://developer.apple.com/documentation/uikit/nsdiffabledatasourcesnapshot)
 - [🍎Apple: Hashable](https://developer.apple.com/documentation/swift/hashable)
 - [🍎Apple: UICalendarView](https://developer.apple.com/documentation/uikit/uicalendarview#3992448)
+- [🍎Apple: estimated(_:)](https://developer.apple.com/documentation/uikit/nscollectionlayoutdimension/3199057-estimated)
+- [🍎Apple: setCollectionViewLayout(_:animated:)](https://developer.apple.com/documentation/uikit/uicollectionview/1618086-setcollectionviewlayout)
+- [🍎Apple: reloadSections(_:)](https://developer.apple.com/documentation/uikit/nsdiffabledatasourcesnapshot/3375784-reloadsections)
+- [🐻야곰닷넷: Unit Test](https://yagom.net/courses/unit-test-작성하기/)
 - [📗Velog: You don’t (always) need [weak self]](https://velog.io/@haanwave/Article-You-dont-always-need-weak-self)


### PR DESCRIPTION
@July911 
안녕하세요 July!!
리뷰이 Erick🐶, Kyungmin🐼 입니다!
박스오피스II의 두번째 스탭입니다!
이번에도 많은 조언 부탁드립니다🙇

---
## 🤔 고민했던 점
### 1️⃣ 화면 모드 변경
`alert`의 버튼을 눌렀을 때 `CollectionView`의 `layout`과 `cell`을 어떻게 바꿀지 고민했습니다.
`CollectionViewMode`라는 열거형을 만들어 `Controller`가 프로퍼티로 열거형 인스턴스를 들고 있고 `collectionViewMode`를 분기처리하여 `layout`과 `cell`을 결정하도록 설정했습니다.

**CollectionViewMode 코드**
```swift
private enum CollectionViewMode {
    case list
    case grid
}
```

**dataSource 코드**
```swift
UICollectionViewDiffableDataSource<Section, DailyBoxOffice>(collectionView: collectionView) { collectionView, indexPath, dailyBoxOffice in
    switch self.collectionViewMode {
    case .list:
        // ...

        return listCell
    case .grid:
        // ...

        return gridCell
    }
}
```

### 2️⃣ 모드 변경 애니메이션
처음에는 모드 변경을 할 때 `collectionView.reloadData()`로 모든 셀을 다시 로드하였습니다. 하지만 이럴 경우 애니메이션 효과 없이 화면이 한번에 바뀌어 사용자 경험을 저하시킬 수 있기에 `setCollectionViewLayout`과 `reloadSections`을 사용하여 `layout`이 바뀌는 순간과 `section`이 리로드 되는 순간에 애니메이션 효과를 주었습니다.

**layout이 업데이트 될 때 애니메이션**
```swift
switch collectionViewMode {
case .list:
    collectionView.setCollectionViewLayout(listLayout(), animated: true)
case .grid:
    collectionView.setCollectionViewLayout(gridLayout(), animated: true)
}
```

**reloadSections와 apply를 사용하여 section이 업데이트 될 때 애니메이션**
```swift
var snapshot = NSDiffableDataSourceSnapshot<Section, DailyBoxOffice>()
snapshot.appendSections([.main])
snapshot.appendItems(boxOfficeManager.dailyBoxOffices, toSection: .main)
snapshot.reloadSections([.main])

dailyBoxOfficeDataSource.apply(snapshot, animatingDifferences: true)
```

### 3️⃣ dynamic하게 cell의 높이를 변경하기
처음 `label`들의 `text`에만 `adjustsFontForContentSizeCategory`속성을 `true`로 변경해줬을때는 `collectionView`의 `cell`높이가 `dynamic`하게 변경되지 않았습니다.
`centerY`로 설정돼있던 `label`들의 제약을 `topAnchor`와 `bottomAnchor`를 `contentView`의 `topAnchor`와 `bottomAnchor`를 잇고, `.estimated`를 활용해 `dynamic`하게 `cell`의 높이가 변경 되게 해줬습니다.
```swift
let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
                                      heightDimension: .estimated(80))
let item = NSCollectionLayoutItem(layoutSize: itemSize)
let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), 
                                       heightDimension: .estimated(80))
```

## 🙇‍♂️ 조언을 얻고싶은 점
### 1️⃣ 영화 상세화면 dynamic type 적용
요구사항에서는 `dynamic type`을 적용했을때 감독, 제작년도, 개봉일 등의 `titleLabel`이 크기가 커져서 모두 같은 크기를 갖는 것처럼 보였습니다. `titleLabel`의 `Compression priority`를 `.required`로 설정하는 방법이 제일 바람직하다고 판단하여 적용했지만, 세로 줄이 요구사항과는 다르게 맞지 않았습니다.

이를 해결하기 위해 `titleLabe`l과 오른쪽 정보를 닮는 `label`을 각각 다른 세로 스택뷰에 따로 담아서 해결하려 했으나 오른쪽 정보를 닮는 `label`크기가 유동적이기때문에 이 방법으로도 해결하지 못했습니다.

미리 `titleLabel`의 크기를 고정시켜놓는 방법 이외에 이 문제를 어떻게 해결할 수 있을까요?

#### 📃 요구사항 화면
<Img src = "https://hackmd.io/_uploads/r1rWYounh.png" width="350"/>

#### 🔨 현재 구현된 화면
<Img src = "https://hackmd.io/_uploads/SJppvj_2h.png" width="350"/>


---
### 📚 참고 링크
- [🍎Apple: estimated(_:)](https://developer.apple.com/documentation/uikit/nscollectionlayoutdimension/3199057-estimated)
- [🍎Apple: setCollectionViewLayout(_:animated:)](https://developer.apple.com/documentation/uikit/uicollectionview/1618086-setcollectionviewlayout)
- [🍎Apple: reloadSections(_:)](https://developer.apple.com/documentation/uikit/nsdiffabledatasourcesnapshot/3375784-reloadsections)