### PR TITLE
박스오피스II [STEP 2] yetti, maxhyunm

### DIFF
--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -14,7 +14,7 @@
 		3B8F5FD42A73556200D1A7F6 /* BoxOfficeNetworkingTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B8F5FD32A73556200D1A7F6 /* BoxOfficeNetworkingTest.swift */; };
 		3BF7147F2A6E75C6006F274D /* BoxOfficeDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF7147E2A6E75C6006F274D /* BoxOfficeDecodingTests.swift */; };
 		3BF714862A6E78E3006F274D /* DecodingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF714852A6E78E3006F274D /* DecodingManager.swift */; };
-		3BF7D9AE2A79E69800996A5E /* BoxOfficeRankingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF7D9AD2A79E69800996A5E /* BoxOfficeRankingCell.swift */; };
+		3BF7D9AE2A79E69800996A5E /* BoxOfficeRankingListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF7D9AD2A79E69800996A5E /* BoxOfficeRankingListCell.swift */; };
 		3BF7D9B12A7C7D0600996A5E /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF7D9B02A7C7D0600996A5E /* String+.swift */; };
 		3BF7D9B62A81C28400996A5E /* DaumImageEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF7D9B52A81C28400996A5E /* DaumImageEntity.swift */; };
 		3BF7D9B82A81D69300996A5E /* MovieDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF7D9B72A81D69300996A5E /* MovieDetailViewController.swift */; };
@@ -25,6 +25,7 @@
 		63DF20F82970E1A1005DF7D1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 63DF20F72970E1A1005DF7D1 /* Assets.xcassets */; };
 		63DF20FB2970E1A1005DF7D1 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 63DF20F92970E1A1005DF7D1 /* LaunchScreen.storyboard */; };
 		BA1A55AE2A81DF3D0012C89D /* MovieDetailStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1A55AD2A81DF3D0012C89D /* MovieDetailStackView.swift */; };
+		BA1A55B82A8C99320012C89D /* BoxOfficeRankingIconCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1A55B72A8C99320012C89D /* BoxOfficeRankingIconCell.swift */; };
 		BAAC6F2E2A6E6B7700AD34ED /* box_office_sample.json in Resources */ = {isa = PBXBuildFile; fileRef = BAAC6F2D2A6E6B7700AD34ED /* box_office_sample.json */; };
 		BAAC6F302A6E6C4B00AD34ED /* BoxOfficeEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAAC6F2F2A6E6C4B00AD34ED /* BoxOfficeEntity.swift */; };
 		BAAC6F362A710D8100AD34ED /* MovieDetailEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAAC6F352A710D8100AD34ED /* MovieDetailEntity.swift */; };
@@ -53,7 +54,7 @@
 		3BF7147C2A6E75C6006F274D /* BoxOfficeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BoxOfficeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3BF7147E2A6E75C6006F274D /* BoxOfficeDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxOfficeDecodingTests.swift; sourceTree = "<group>"; };
 		3BF714852A6E78E3006F274D /* DecodingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodingManager.swift; sourceTree = "<group>"; };
-		3BF7D9AD2A79E69800996A5E /* BoxOfficeRankingCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxOfficeRankingCell.swift; sourceTree = "<group>"; };
+		3BF7D9AD2A79E69800996A5E /* BoxOfficeRankingListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxOfficeRankingListCell.swift; sourceTree = "<group>"; };
 		3BF7D9B02A7C7D0600996A5E /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
 		3BF7D9B52A81C28400996A5E /* DaumImageEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaumImageEntity.swift; sourceTree = "<group>"; };
 		3BF7D9B72A81D69300996A5E /* MovieDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieDetailViewController.swift; sourceTree = "<group>"; };
@@ -66,6 +67,7 @@
 		63DF20FA2970E1A1005DF7D1 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		63DF20FC2970E1A1005DF7D1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		BA1A55AD2A81DF3D0012C89D /* MovieDetailStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieDetailStackView.swift; sourceTree = "<group>"; };
+		BA1A55B72A8C99320012C89D /* BoxOfficeRankingIconCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxOfficeRankingIconCell.swift; sourceTree = "<group>"; };
 		BAAC6F2D2A6E6B7700AD34ED /* box_office_sample.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = box_office_sample.json; sourceTree = "<group>"; };
 		BAAC6F2F2A6E6C4B00AD34ED /* BoxOfficeEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxOfficeEntity.swift; sourceTree = "<group>"; };
 		BAAC6F352A710D8100AD34ED /* MovieDetailEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieDetailEntity.swift; sourceTree = "<group>"; };
@@ -133,7 +135,8 @@
 			isa = PBXGroup;
 			children = (
 				63DF20F92970E1A1005DF7D1 /* LaunchScreen.storyboard */,
-				3BF7D9AD2A79E69800996A5E /* BoxOfficeRankingCell.swift */,
+				3BF7D9AD2A79E69800996A5E /* BoxOfficeRankingListCell.swift */,
+				BA1A55B72A8C99320012C89D /* BoxOfficeRankingIconCell.swift */,
 				BA1A55AD2A81DF3D0012C89D /* MovieDetailStackView.swift */,
 			);
 			path = View;
@@ -303,6 +306,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BAAC6F4A2A734D1B00AD34ED /* URLSessionProtocol.swift in Sources */,
+				BA1A55B82A8C99320012C89D /* BoxOfficeRankingIconCell.swift in Sources */,
 				3BF7D9B82A81D69300996A5E /* MovieDetailViewController.swift in Sources */,
 				3BF7D9BC2A85DFCE00996A5E /* CalendarViewController.swift in Sources */,
 				63DF20F32970E1A0005DF7D1 /* BoxOfficeViewController.swift in Sources */,
@@ -316,7 +320,7 @@
 				3BF714862A6E78E3006F274D /* DecodingManager.swift in Sources */,
 				3B8F5F9E2A72186D00D1A7F6 /* NetworkConfiguration.swift in Sources */,
 				3B8F5F9C2A71032C00D1A7F6 /* Error.swift in Sources */,
-				3BF7D9AE2A79E69800996A5E /* BoxOfficeRankingCell.swift in Sources */,
+				3BF7D9AE2A79E69800996A5E /* BoxOfficeRankingListCell.swift in Sources */,
 				3BF7D9B12A7C7D0600996A5E /* String+.swift in Sources */,
 				63DF20F12970E1A0005DF7D1 /* SceneDelegate.swift in Sources */,
 			);

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -12,6 +12,7 @@ final class BoxOfficeViewController: UIViewController, URLSessionDelegate {
     private var refreshControl = UIRefreshControl()
     private var dataSource: UICollectionViewDiffableDataSource<NetworkConfiguration, BoxOfficeEntity.BoxOfficeResult.DailyBoxOffice>?
     private var date: Date = Calendar.current.date(byAdding: .day, value: -1, to: Date()) ?? Date()
+    private var isListMode = true
     
     private let collectionView: UICollectionView = {
         let configuration = UICollectionLayoutListConfiguration(appearance: .plain)
@@ -58,11 +59,16 @@ extension BoxOfficeViewController {
     private func setUpUI() {
         let safeArea = view.safeAreaLayoutGuide
         let dateSelectionButton = UIBarButtonItem(title: "날짜선택", style: .plain, target: self, action: #selector(showCalendar))
+        let modeChangeButton = UIBarButtonItem(title: "화면 모드 변경", style: .plain, target: self, action: #selector(hitChangeModeButton))
+        let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: self, action: nil)
+        
         
         view.backgroundColor = .systemBackground
         view.addSubview(collectionView)
         view.addSubview(indicatorView)
         
+        self.navigationController?.isToolbarHidden = false
+        self.toolbarItems = [flexibleSpace, modeChangeButton, flexibleSpace]
         self.title = getDateString(format: Namespace.dateWithHyphen)
         self.navigationItem.rightBarButtonItem = dateSelectionButton
         
@@ -83,6 +89,19 @@ extension BoxOfficeViewController {
         viewController.modalPresentationStyle = UIModalPresentationStyle.automatic
         
         self.present(viewController, animated: true)
+    }
+    
+    @objc func hitChangeModeButton() {
+        let mode: String = isListMode == true ? "아이콘" : "리스트"
+        let alert = UIAlertController(title: "화면 모드 변경", message: nil, preferredStyle: .actionSheet)
+        let modeChangeAction = UIAlertAction(title: mode, style: .default) { _ in
+            self.isListMode.toggle()
+        }
+        let cancelAction = UIAlertAction(title: "취소", style: .cancel)
+        
+        alert.addAction(modeChangeAction)
+        alert.addAction(cancelAction)
+        present(alert, animated: true)
     }
 }
 

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -152,7 +152,7 @@ extension BoxOfficeViewController {
         if isListMode {
             dataSource = UICollectionViewDiffableDataSource<NetworkConfiguration, BoxOfficeEntity.BoxOfficeResult.DailyBoxOffice>(collectionView: self.collectionView) { (collectionView, indexPath, data) -> UICollectionViewCell? in
                 guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: BoxOfficeRankingListCell.cellIdentifier, for: indexPath) as? BoxOfficeRankingListCell else {
-                    return UICollectionViewCell()
+                    return BoxOfficeRankingListCell()
                 }
                 
                 cell.setUpLabelText(data)
@@ -162,7 +162,7 @@ extension BoxOfficeViewController {
         } else {
             dataSource = UICollectionViewDiffableDataSource<NetworkConfiguration, BoxOfficeEntity.BoxOfficeResult.DailyBoxOffice>(collectionView: self.collectionView) { (collectionView, indexPath, data) -> UICollectionViewCell? in
                 guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: BoxOfficeRankingIconCell.cellIdentifier, for: indexPath) as? BoxOfficeRankingIconCell else {
-                    return UICollectionViewCell()
+                    return BoxOfficeRankingIconCell()
                 }
 
                 cell.setUpLabelText(data)
@@ -170,7 +170,6 @@ extension BoxOfficeViewController {
                 return cell
             }
         }
-            
     }
     
     private func setUpDataSnapshot(_ data: [BoxOfficeEntity.BoxOfficeResult.DailyBoxOffice]) {
@@ -244,6 +243,7 @@ extension BoxOfficeViewController: BoxOfficeDelegate {
     func setUpDate(_ date: Date) {
         self.date = date
         self.title = getDateString(format: Namespace.dateWithHyphen)
+
         passFetchedData()
     }
 }

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -243,7 +243,9 @@ extension BoxOfficeViewController: BoxOfficeDelegate {
     func setUpDate(_ date: Date) {
         self.date = date
         self.title = getDateString(format: Namespace.dateWithHyphen)
-
+        
+        setUpCollectionViewLayout()
+        setUpDataSource()
         passFetchedData()
     }
 }

--- a/BoxOffice/Controller/BoxOfficeViewController.swift
+++ b/BoxOffice/Controller/BoxOfficeViewController.swift
@@ -19,7 +19,8 @@ final class BoxOfficeViewController: UIViewController, URLSessionDelegate {
         let layout = UICollectionViewCompositionalLayout.list(using: configuration)
         let view = UICollectionView(frame: .zero, collectionViewLayout: layout)
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.register(BoxOfficeRankingCell.self, forCellWithReuseIdentifier: BoxOfficeRankingCell.cellIdentifier)
+        view.register(BoxOfficeRankingListCell.self, forCellWithReuseIdentifier: BoxOfficeRankingListCell.cellIdentifier)
+        view.register(BoxOfficeRankingIconCell.self, forCellWithReuseIdentifier: BoxOfficeRankingIconCell.cellIdentifier)
 
         return view
     }()
@@ -124,12 +125,12 @@ extension BoxOfficeViewController {
     
     private func setUpDataSource() {
         dataSource = UICollectionViewDiffableDataSource<NetworkConfiguration, BoxOfficeEntity.BoxOfficeResult.DailyBoxOffice>(collectionView: self.collectionView) { (collectionView, indexPath, data) -> UICollectionViewCell? in
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: BoxOfficeRankingCell.cellIdentifier, for: indexPath) as? BoxOfficeRankingCell else {
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: BoxOfficeRankingListCell.cellIdentifier, for: indexPath) as? BoxOfficeRankingListCell else {
                 return UICollectionViewCell()
             }
-            
+
             cell.setUpLabelText(data)
-            
+
             return cell
         }
     }

--- a/BoxOffice/Model/Error.swift
+++ b/BoxOffice/Model/Error.swift
@@ -10,6 +10,7 @@ enum NetworkingError: Error {
     case notHttpUrlResponse
     case invalidResponse(statusCode: Int)
     case invalidURL
+    case invalidAPIKey
     
     var description: String {
         switch self {
@@ -21,6 +22,8 @@ enum NetworkingError: Error {
             return "서버 응답 오류입니다. Status Code: \(statusCode)"
         case .invalidURL:
             return "유효하지 않은 URL입니다."
+        case .invalidAPIKey:
+            return "유효하지 않은 API Key입니다."
         }
     }
 }

--- a/BoxOffice/Model/NetworkingManager.swift
+++ b/BoxOffice/Model/NetworkingManager.swift
@@ -15,7 +15,11 @@ struct NetworkingManager {
     }
     
     func load(_ networkType: NetworkConfiguration, completion: @escaping (Result<Data, NetworkingError>) -> Void) {
-        var urlComponents = URLComponents(string: networkType.url)
+        guard let urlString = networkType.url, let header = networkType.header else {
+            completion(.failure(NetworkingError.invalidAPIKey))
+            return
+        }
+        var urlComponents = URLComponents(string: urlString)
         
         networkType.query.forEach {
             urlComponents?.queryItems = [URLQueryItem(name: $0.name, value: $0.value)]
@@ -23,12 +27,12 @@ struct NetworkingManager {
         
         guard let url = urlComponents?.url else {
             completion(.failure(NetworkingError.invalidURL))
-            return 
+            return
         }
         
         var request = URLRequest(url: url)
-        
-        networkType.header.forEach {
+
+        header.forEach {
             request.setValue($0.value, forHTTPHeaderField: $0.forHTTPHeaderField)
         }
 

--- a/BoxOffice/Resource/NetworkConfiguration.swift
+++ b/BoxOffice/Resource/NetworkConfiguration.swift
@@ -12,11 +12,19 @@ enum NetworkConfiguration: Hashable {
     case movieDetail(_ movieCode: String)
     case daumImage(_ movieName: String)
     
-    var url: String {
+    var url: String? {
         switch self {
         case .boxOffice(let targetDate):
+            if NetworkConfiguration.apiKey == "" {
+                return nil
+            }
+            
             return String(format: "http://kobis.or.kr/kobisopenapi/webservice/rest/boxoffice/searchDailyBoxOfficeList.json?key=%@&targetDt=%@", NetworkConfiguration.apiKey, targetDate)
         case .movieDetail(let movieCode):
+            if NetworkConfiguration.apiKey == "" {
+                return nil
+            }
+            
             return String(format: "http://www.kobis.or.kr/kobisopenapi/webservice/rest/movie/searchMovieInfo.json?key=%@&movieCd=%@", NetworkConfiguration.apiKey, movieCode)
         case .daumImage:
             return "https://dapi.kakao.com/v2/search/image"
@@ -32,9 +40,13 @@ enum NetworkConfiguration: Hashable {
         }
     }
     
-    var header: [(value: String, forHTTPHeaderField: String)] {
+    var header: [(value: String, forHTTPHeaderField: String)]? {
         switch self {
         case .daumImage:
+            if NetworkConfiguration.daumApiKey == "" {
+                return nil
+            }
+            
             return [(value: "KakaoAK \(NetworkConfiguration.daumApiKey)", forHTTPHeaderField: "Authorization")]
         default:
             return []

--- a/BoxOffice/View/BoxOfficeRankingIconCell.swift
+++ b/BoxOffice/View/BoxOfficeRankingIconCell.swift
@@ -1,14 +1,14 @@
 //
-//  BoxOfficeRankingCell.swift
+//  BoxOfficeRankingIconCell.swift
 //  BoxOffice
 //
-//  Created by Yetti, Maxhyunm on 2023/08/02.
+//  Created by Min Hyun on 2023/08/16.
 //
 
 import UIKit
 
-final class BoxOfficeRankingCell: UICollectionViewListCell {
-    static let cellIdentifier = "BoxOfficeCell"
+class BoxOfficeRankingIconCell: UICollectionViewCell {
+    static let cellIdentifier = "BoxOfficeIconCell"
     
     private let rankLabel: UILabel = {
         let label = UILabel()
@@ -47,6 +47,8 @@ final class BoxOfficeRankingCell: UICollectionViewListCell {
         let stackView = UIStackView()
         stackView.axis = .vertical
         stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.alignment = .center
+        stackView.distribution = .equalSpacing
         
         return stackView
     }()
@@ -61,29 +63,20 @@ final class BoxOfficeRankingCell: UICollectionViewListCell {
     }
     
     private func setUpUI() {
-        self.accessories = [.outlineDisclosure(options: .init(tintColor: .systemGray))]
+        self.layer.borderWidth = 2.0
+        self.layer.borderColor = .init(gray: 0.5, alpha: 1.0)
         
-        stackView.addArrangedSubview(movieNameLabel)
-        stackView.addArrangedSubview(audienceLabel)
-        contentView.addSubview(rankLabel)
-        contentView.addSubview(rankIntensityLabel)
         contentView.addSubview(stackView)
+        stackView.addArrangedSubview(rankLabel)
+        stackView.addArrangedSubview(movieNameLabel)
+        stackView.addArrangedSubview(rankIntensityLabel)
+        stackView.addArrangedSubview(audienceLabel)
         
         NSLayoutConstraint.activate([
-            rankLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 10),
-            rankLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-            rankLabel.widthAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.3),
-            
-            rankIntensityLabel.widthAnchor.constraint(equalTo: rankLabel.widthAnchor),
-            rankIntensityLabel.topAnchor.constraint(equalTo: rankLabel.bottomAnchor),
-            rankIntensityLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-            rankIntensityLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -10),
-            
-            stackView.leadingAnchor.constraint(equalTo: rankLabel.trailingAnchor),
-            stackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
+            stackView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
             stackView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-            
-            self.separatorLayoutGuide.leadingAnchor.constraint(equalTo: rankLabel.leadingAnchor)
+            stackView.widthAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.9),
+            stackView.heightAnchor.constraint(equalTo: contentView.heightAnchor, multiplier: 0.9)
         ])
     }
     
@@ -118,5 +111,9 @@ final class BoxOfficeRankingCell: UICollectionViewListCell {
         attributedString.addAttribute(.foregroundColor, value: UIColor.systemBlue, range: (fixedIntensity as NSString).range(of: "▼"))
         
         return attributedString
+    }
+    
+    override func prepareForReuse() {
+        rankIntensityLabel.textColor = .black
     }
 }

--- a/BoxOffice/View/BoxOfficeRankingIconCell.swift
+++ b/BoxOffice/View/BoxOfficeRankingIconCell.swift
@@ -15,6 +15,7 @@ class BoxOfficeRankingIconCell: UICollectionViewCell {
         label.textAlignment = .center
         label.font = .preferredFont(forTextStyle: .largeTitle)
         label.translatesAutoresizingMaskIntoConstraints = false
+        label.adjustsFontForContentSizeCategory = true
         
         return label
     }()
@@ -24,6 +25,7 @@ class BoxOfficeRankingIconCell: UICollectionViewCell {
         label.textAlignment = .center
         label.font = .preferredFont(forTextStyle: .callout)
         label.translatesAutoresizingMaskIntoConstraints = false
+        label.adjustsFontForContentSizeCategory = true
         
         return label
     }()
@@ -32,13 +34,18 @@ class BoxOfficeRankingIconCell: UICollectionViewCell {
         let label = UILabel()
         label.font = .preferredFont(forTextStyle: .title3)
         label.translatesAutoresizingMaskIntoConstraints = false
+        label.adjustsFontForContentSizeCategory = true
+        label.numberOfLines = 0
         
         return label
     }()
     
     private let audienceLabel: UILabel = {
         let label = UILabel()
+        label.font = .preferredFont(forTextStyle: .callout)
         label.translatesAutoresizingMaskIntoConstraints = false
+        label.adjustsFontForContentSizeCategory = true
+        label.adjustsFontSizeToFitWidth = true
         
         return label
     }()

--- a/BoxOffice/View/BoxOfficeRankingListCell.swift
+++ b/BoxOffice/View/BoxOfficeRankingListCell.swift
@@ -1,0 +1,126 @@
+//
+//  BoxOfficeRankingCell.swift
+//  BoxOffice
+//
+//  Created by Yetti, Maxhyunm on 2023/08/02.
+//
+
+import UIKit
+
+final class BoxOfficeRankingListCell: UICollectionViewListCell {
+    static let cellIdentifier = "BoxOfficeListCell"
+    
+    private let rankLabel: UILabel = {
+        let label = UILabel()
+        label.textAlignment = .center
+        label.font = .preferredFont(forTextStyle: .largeTitle)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        
+        return label
+    }()
+    
+    private let rankIntensityLabel: UILabel = {
+        let label = UILabel()
+        label.textAlignment = .center
+        label.font = .preferredFont(forTextStyle: .callout)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        
+        return label
+    }()
+    
+    private let movieNameLabel: UILabel = {
+        let label = UILabel()
+        label.font = .preferredFont(forTextStyle: .title3)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        
+        return label
+    }()
+    
+    private let audienceLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        
+        return label
+    }()
+    
+    private let stackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        
+        return stackView
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setUpUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setUpUI() {
+        self.accessories = [.outlineDisclosure(options: .init(tintColor: .systemGray))]
+        
+        stackView.addArrangedSubview(movieNameLabel)
+        stackView.addArrangedSubview(audienceLabel)
+        contentView.addSubview(rankLabel)
+        contentView.addSubview(rankIntensityLabel)
+        contentView.addSubview(stackView)
+        
+        NSLayoutConstraint.activate([
+            rankLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 10),
+            rankLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            rankLabel.widthAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.3),
+            
+            rankIntensityLabel.widthAnchor.constraint(equalTo: rankLabel.widthAnchor),
+            rankIntensityLabel.topAnchor.constraint(equalTo: rankLabel.bottomAnchor),
+            rankIntensityLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            rankIntensityLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -10),
+            
+            stackView.leadingAnchor.constraint(equalTo: rankLabel.trailingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
+            stackView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            
+            self.separatorLayoutGuide.leadingAnchor.constraint(equalTo: rankLabel.leadingAnchor)
+        ])
+    }
+    
+    func setUpLabelText(_ data: BoxOfficeEntity.BoxOfficeResult.DailyBoxOffice) {
+        rankLabel.text = data.rank
+        rankIntensityLabel.attributedText = setUpRankIntensity(data.rankIntensity, isNew: data.rankOldAndNew == "NEW")
+        movieNameLabel.text = data.movieName
+        audienceLabel.text = "오늘 \(data.audienceCount.formatToDecimalNumber()) / 총 \(data.audienceAccumulate.formatToDecimalNumber())"
+    }
+    
+    private func setUpRankIntensity(_ rankIntensity: String, isNew: Bool) -> NSMutableAttributedString {
+        var fixedIntensity = ""
+        let intRankIntensity = Int(rankIntensity) ?? 0
+        
+        guard !isNew else {
+            rankIntensityLabel.textColor = .systemRed
+            return  NSMutableAttributedString(string: "신작")
+        }
+
+        if intRankIntensity == 0 {
+            fixedIntensity = "-"
+        } else if intRankIntensity > 0 {
+            fixedIntensity = "▲\(rankIntensity)"
+        } else {
+            fixedIntensity = "▼\(intRankIntensity * -1)"
+        }
+        
+        let attributedString = NSMutableAttributedString(string: fixedIntensity)
+        
+        attributedString.addAttribute(.foregroundColor, value: UIColor.systemRed, range: (fixedIntensity as NSString).range(of: "-"))
+        attributedString.addAttribute(.foregroundColor, value: UIColor.systemRed, range: (fixedIntensity as NSString).range(of: "▲"))
+        attributedString.addAttribute(.foregroundColor, value: UIColor.systemBlue, range: (fixedIntensity as NSString).range(of: "▼"))
+        
+        return attributedString
+    }
+    
+    override func prepareForReuse() {
+        rankIntensityLabel.textColor = .black
+    }
+}

--- a/BoxOffice/View/BoxOfficeRankingListCell.swift
+++ b/BoxOffice/View/BoxOfficeRankingListCell.swift
@@ -15,6 +15,7 @@ final class BoxOfficeRankingListCell: UICollectionViewListCell {
         label.textAlignment = .center
         label.font = .preferredFont(forTextStyle: .largeTitle)
         label.translatesAutoresizingMaskIntoConstraints = false
+        label.adjustsFontForContentSizeCategory = true
         
         return label
     }()
@@ -24,6 +25,7 @@ final class BoxOfficeRankingListCell: UICollectionViewListCell {
         label.textAlignment = .center
         label.font = .preferredFont(forTextStyle: .callout)
         label.translatesAutoresizingMaskIntoConstraints = false
+        label.adjustsFontForContentSizeCategory = true
         
         return label
     }()
@@ -32,18 +34,31 @@ final class BoxOfficeRankingListCell: UICollectionViewListCell {
         let label = UILabel()
         label.font = .preferredFont(forTextStyle: .title3)
         label.translatesAutoresizingMaskIntoConstraints = false
+        label.adjustsFontForContentSizeCategory = true
+        label.numberOfLines = 0
         
         return label
     }()
     
     private let audienceLabel: UILabel = {
         let label = UILabel()
+        label.font = .preferredFont(forTextStyle: .body)
         label.translatesAutoresizingMaskIntoConstraints = false
+        label.adjustsFontForContentSizeCategory = true
+        label.adjustsFontSizeToFitWidth = true
         
         return label
     }()
     
-    private let stackView: UIStackView = {
+    private let rankingStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        
+        return stackView
+    }()
+    
+    private let informationStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .vertical
         stackView.translatesAutoresizingMaskIntoConstraints = false
@@ -63,26 +78,25 @@ final class BoxOfficeRankingListCell: UICollectionViewListCell {
     private func setUpUI() {
         self.accessories = [.outlineDisclosure(options: .init(tintColor: .systemGray))]
         
-        stackView.addArrangedSubview(movieNameLabel)
-        stackView.addArrangedSubview(audienceLabel)
-        contentView.addSubview(rankLabel)
-        contentView.addSubview(rankIntensityLabel)
-        contentView.addSubview(stackView)
+        rankingStackView.addArrangedSubview(rankLabel)
+        rankingStackView.addArrangedSubview(rankIntensityLabel)
+        
+        informationStackView.addArrangedSubview(movieNameLabel)
+        informationStackView.addArrangedSubview(audienceLabel)
+
+        contentView.addSubview(rankingStackView)
+        contentView.addSubview(informationStackView)
         
         NSLayoutConstraint.activate([
-            rankLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 10),
-            rankLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-            rankLabel.widthAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.3),
+            rankingStackView.widthAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.3),
+            rankingStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            rankingStackView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
             
-            rankIntensityLabel.widthAnchor.constraint(equalTo: rankLabel.widthAnchor),
-            rankIntensityLabel.topAnchor.constraint(equalTo: rankLabel.bottomAnchor),
-            rankIntensityLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-            rankIntensityLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -10),
+            informationStackView.leadingAnchor.constraint(equalTo: rankLabel.trailingAnchor),
+            informationStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
+            informationStackView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
             
-            stackView.leadingAnchor.constraint(equalTo: rankLabel.trailingAnchor),
-            stackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
-            stackView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-            
+            self.heightAnchor.constraint(equalTo: informationStackView.heightAnchor, constant: 30),
             self.separatorLayoutGuide.leadingAnchor.constraint(equalTo: rankLabel.leadingAnchor)
         ])
     }

--- a/BoxOffice/View/MovieDetailStackView.swift
+++ b/BoxOffice/View/MovieDetailStackView.swift
@@ -12,14 +12,18 @@ final class MovieDetailStackView: UIStackView {
         let label = UILabel()
         label.font = .preferredFont(forTextStyle: .headline)
         label.textAlignment = .center
+        label.adjustsFontForContentSizeCategory = true
+        label.numberOfLines = 0
         
         return label
     }()
     
     let valueLabel: UILabel = {
         let label = UILabel()
+        label.font = .preferredFont(forTextStyle: .body)
         label.lineBreakMode = .byWordWrapping
         label.numberOfLines = 0
+        label.adjustsFontForContentSizeCategory = true
         
         return label
     }()

--- a/README.md
+++ b/README.md
@@ -1,29 +1,30 @@
 # 박스오피스🎬
 ## 소개
-> 영화진흥위원회의 API를 통해 박스오피스, 영화 상세정보를 불러오는 앱입니다.
+> 영화진흥위원회와 Daum 검색 API를 통해 날짜별 박스오피스, 영화 상세정보를 불러오는 앱입니다.
 
-**프로젝트 기간 : 23/07/24~**
+**프로젝트 기간 : 23/07/24~23/08/18**
 </br>
 
 ## 목차
-1. [팀원소개](#1.)
-2. [타임라인](#2.)
-3. [시각화구조](#3.)
-4. [핵심경험](#4.)
-5. [트러블슈팅](#5.)
-6. [참고자료](#6.)
-7. [팀 회고](#7.)
+1. [팀원 소개](#1.)
+2. [타임 라인](#2.)
+3. [시각화 구조](#3.)
+4. [실행 화면](#4. )
+5. [핵심 경험](#5.)
+6. [트러블 슈팅](#6.)
+7. [참고 자료](#7.)
+8. [팀 회고](#8.)
 
 </br>
 
 <a id="1."></a></br>
-## 팀원소개
+## 팀원 소개
 |<Img src =  "https://hackmd.io/_uploads/rJj1EtKt2.png" width="200" height="200">|<Img src="https://hackmd.io/_uploads/rk62zRiun.png" width="200">|
 |:-:|:-:|
 |[**Yetti**](https://github.com/iOS-Yetti)|[**maxhyunm**](https://github.com/maxhyunm)|
 
 <a id="2."></a></br>
-## 타임라인
+## 타임 라인
 |날짜|내용|
 |:--:|--|
 |2023.07.24.| json 파일 파싱을 위한 BoxOfficeEntity 타입 생성, 디코딩 유닛테스트 진행 |
@@ -33,7 +34,16 @@
 |2023.07.31.| 프로젝트 진행을 위한 개인 공부시간 |
 |2023.08.01.| 프로젝트 진행을 위한 개인 공부시간 |
 |2023.08.02.| CollectionView세팅, BoxOfficeRankingCell 생성 및 셀 구성 세팅,  DiffableDataSource 세팅 및 연결, 랭킹 증감분 AttributedString 처리, collectionView에 refreshControl 추가 |
-|2023.08.04.| 리뷰에 따른 리팩토링 진행  |
+|2023.08.07.| 리뷰에 따른 리팩토링 진행  |
+|2023.08.08.|DaumImageEntity 파일 추가 및 DAUM_API_KEY 추가, MovieDetailViewController 파일 추가 및 view 전환 메서드 추가, MoviewDetailViewController에 MoviewDetail 네트워크 연결 |
+|2023.08.09.|프로젝트 진행을 위한 개인 공부시간|
+|2023.08.10.|스택뷰의 text설정메서드 기능 분리 및 Namespace 생성, MovieDetailView 로딩화면 수정 |
+|2023.08.11.|README 작성|
+|2023.08.14.|url 호출 실패시 completion으로 에러처리 추가, MovieDetailViewController에서 isDataLoading, isImageLoading 호출 위치 변경|
+|2023.08.15.|프로젝트 진행을 위한 개인 공부시간|
+|2023.08.16.|화면 모드 변경 버튼 추가 BoxOfficeRankingIconCell 타입 생성, 화면 모드 변경시 CollectionView의 레이아웃 설정을 바꾸는 기능 구현, 텍스트에 다이나믹 타입 적용 및 auto layout 수정|
+|2023.08.17.|APIKey 검증과정 및 에러처리 추가, 날짜 변경시 컬렉션뷰 레이아웃 틀어지는 오류 수정|
+|2023.08.18.|README 작성|
 
 <a id="3."></a></br>
 ## 시각화 구조
@@ -44,22 +54,27 @@
     │   │   └── String+.swift
     │   ├── Model
     │   │   ├── BoxOfficeEntity.swift
+    │   │   ├── MovieDetailEntity.swift
+    │   │   ├── DaumImageEntity.swift
     │   │   ├── DecodingManager.swift
     │   │   ├── Error.swift
-    │   │   ├── MovieDetailEntity.swift
     │   │   ├── NetworkingManager.swift
     │   │   └── URLSessionProtocol.swift
     │   ├──View
-    │   │   └── BoxOfficeRankingCell.swift
+    │   │   ├── BoxOfficeRankingListCell.swift
+    │   │   ├── BoxOfficeRankingIconCell.swift
+    │   │   └── MovieDetailStackView.swift
     │   ├── Controller
-    │   │   └── BoxOfficeViewController.swift
+    │   │   ├── BoxOfficeViewController.swift
+    │   │   ├── CalendarViewController.swift
+    │   │   └── MovieDetailViewController.swift
     │   ├── Resource
     │   │   ├── AppDelegate.swift
     │   │   ├── SceneDelegate.swift
-    │   │   ├── NetworkNamespace.swift
+    │   │   ├── NetworkConfiguration.swift
     │   │   ├── Assets.xcassets
     │   │   └── box_office_sample.json
-    │   └──  Info.plist
+    │   └──Info.plist
     ├── BoxOffice.xcodeproj
     ├── BoxOfficeTests
     │   ├── BoxOffice.xctestplan
@@ -69,29 +84,256 @@
     └── README.md
 
 ### UML
-<img src="https://hackmd.io/_uploads/B1tZIkFo3.png"><br>
+#### 박스오피스 화면
+<img src="https://hackmd.io/_uploads/S1FsUShn3.png"><br>
 
+#### 영화 상세정보 화면
+<img src="https://hackmd.io/_uploads/SkGRUHhhh.png">
+<br>
 
 <a id="4."></a></br>
-## 핵심경험
-#### 🌟 CodingKeys와 Nested Type Enum을 활용한 중첩 json 파싱
-`Nested Type`을 활용하여 여러 단계로 중첩된 형태의 json을 파싱할 수 있도록 하였고, `CodingKeys`를 활용해 이해하기 어려운 파라미터명을 변경하였습니다.
-#### 🌟 Generic을 활용한 범용 메서드 구현
-다양한 타입의 Entity를 반환해야 하는 `DecodingManager`의 메서드를 `Generic`으로 구현하였습니다.
-#### 🌟 xcconfig, info.plist를 활용한 api key 설정
-환경 파일을 활용해 원격 저장소에 공유되지 않아야 하는 key 정보를 관리하였습니다.
-#### 🌟 UIActivityIndicatorView를 활용한 로딩 구현
-데이터 fetch 상태에 따라 `UIActivityIndicatorView`의 상태값을 변경하여 로딩 마크가 활성화/비활성화 되도록 구현하였습니다.
-#### 🌟 UIRefreshControl를 활용한 새로고침 구현
-`Collection View`에 `UIRefreshColtrol` 객체를 추가하여, 아래로 당겼을 때 새로고침을 진행할 수 있도록 하였습니다.
-#### 🌟 Modern Collection View 구현
-`Modern Collection View`를 통해 박스오피스 랭킹 리스트를 구현하기 위하여 `Diffable Data Source`와 `Collection View List Cell`를 활용하였습니다.
-#### 🌟 Attributed String 활용
-하나의 레이블 안에서 여러 가지 색상을 표시하기 위하여 `Attributed String`을 활용하였습니다.
+## 실행 화면
+
+| 영화 상세정보 | 날짜 변경 | 화면 모드 변경 |
+|:--------:|:--------:|:--------:|
+|<img src="https://file.notion.so/f/s/381a37e3-8fac-46d9-988f-bc65a6b2c618/boxoffice.gif?id=07a404ad-ba68-4422-9c17-aae2e1ab04dd&table=block&spaceId=26c8d86e-7094-42a2-9751-594e7aa0a176&expirationTimestamp=1692410400000&signature=aITy02Giq1_hYjSPyupBQbBn8cwPbdCFrOtaF-0ISXI" width="250">|<img src="https://file.notion.so/f/s/6444c61f-e00c-4d42-8314-85a7259cb144/boxoffice_datechange.gif?id=a4fc2b9d-9dcf-48d6-b247-dd1df05572ff&table=block&spaceId=26c8d86e-7094-42a2-9751-594e7aa0a176&expirationTimestamp=1692410400000&signature=sMktJU4AZmvRlbZ7Ln9aHYcotN7N3ydImJ2K_LU4ypI" width="250">|<img src="https://file.notion.so/f/s/df1a49e1-c359-43d4-a782-2e759bad427d/boxoffice_modechange.gif?id=0f186811-05ed-4a04-85db-0a430761d7ae&table=block&spaceId=26c8d86e-7094-42a2-9751-594e7aa0a176&expirationTimestamp=1692410400000&signature=AhIyobnGXMb-LCQHIB0gSXFthoOh3o5QBtmhlQz2Ln0" width="250">|
+
+
+
 
 <a id="5."></a></br>
-## 트러블슈팅
-### 1️⃣ dataTask 메서드로 받아온 데이터 처리
+## 핵심 경험
+#### 🌟 xcconfig, info.plist를 활용한 api key 설정
+환경 파일을 활용해 원격 저장소에 공유되지 않아야 하는 key 정보를 관리하였습니다.
+
+#### 🌟 CodingKeys와 Nested Type Enum을 활용한 중첩 json 파싱
+`Nested Type`을 활용하여 여러 단계로 중첩된 형태의 json을 파싱할 수 있도록 하였고, `CodingKeys`를 활용해 이해하기 어려운 파라미터명을 변경하였습니다.
+<details>
+<summary>상세코드</summary>
+<div markdown="1">
+
+```swift
+extension BoxOfficeEntity {
+    struct BoxOfficeResult: Decodable {
+        let boxOfficeType, showRange: String
+        let dailyBoxOfficeList: [DailyBoxOffice]
+
+        enum CodingKeys: String, CodingKey {
+            case boxOfficeType = "boxofficeType"
+            case showRange, dailyBoxOfficeList
+        }
+    }
+}
+```
+</div>
+</details>
+
+#### 🌟 Generic을 활용한 범용 메서드 구현
+다양한 타입의 Entity를 반환해야 하는 `DecodingManager`의 메서드를 `Generic`으로 구현하였습니다.
+<details>
+<summary>상세코드</summary>
+<div markdown="1">
+
+```swift
+func decode<T: Decodable>(_ data: Data?) throws -> T {
+    guard let data = data,
+          let decodedData = try? decoder.decode(T.self, from: data) else {
+        throw DecodingError.decodingFailure
+    }
+    return decodedData
+}
+```
+    
+</div>
+</details>
+
+#### 🌟 Modern Collection View 구현
+`Modern Collection View`를 통해 박스오피스 랭킹 리스트를 구현하기 위하여 `Diffable Data Source`와 `Collection View List Cell`를 활용하였습니다.
+<details>
+<summary>상세코드</summary>
+<div markdown="1">
+    
+```swift
+private let collectionView: UICollectionView = {
+    let configuration = UICollectionLayoutListConfiguration(appearance: .plain)
+    let layout = UICollectionViewCompositionalLayout.list(using: configuration)
+...
+}
+    
+private var dataSource: UICollectionViewDiffableDataSource<NetworkNamespace, BoxOfficeEntity.BoxOfficeResult.DailyBoxOffice>?
+...
+    
+```
+    
+</div>
+</details>
+    
+#### 🌟 UICalendarView 활용
+`UICalendarView`를 활용해 `Calendar`를 구현하고 과거 날짜의 데이터를 불러올 수 있도록 활용하였습니다.
+<details>
+<summary>상세코드</summary>
+<div markdown="1">
+    
+```swift
+private let calendarView: UICalendarView = {
+        var calendarView = UICalendarView()
+        calendarView.translatesAutoresizingMaskIntoConstraints = false
+        calendarView.backgroundColor = .systemBackground
+        
+        let endDate = Calendar.current.date(byAdding: .day, value: -1, to: Date()) ?? Date()
+        let calendarViewDateRange = DateInterval(start: Date(timeIntervalSince1970: 0), end: endDate)
+        calendarView.availableDateRange = calendarViewDateRange
+        
+        return calendarView
+    }()
+```
+    
+</div>
+</details>
+    
+#### 🌟 UIActivityIndicatorView를 활용한 로딩 구현
+데이터 fetch 상태에 따라 `UIActivityIndicatorView`의 상태값을 변경하여 로딩 마크가 활성화/비활성화 되도록 구현하였습니다.
+<details>
+<summary>상세코드</summary>
+<div markdown="1">
+    
+```swift
+private let indicatorView: UIActivityIndicatorView = {
+    let indicatorView = UIActivityIndicatorView()
+    indicatorView.style = .large
+    indicatorView.translatesAutoresizingMaskIntoConstraints = false
+
+    return indicatorView
+}()
+
+private var isLoading: Bool = true {
+    willSet(newValue) {
+        if newValue == true {
+            indicatorView.isHidden = false
+            indicatorView.startAnimating()
+        } else {
+            indicatorView.isHidden = true
+            indicatorView.stopAnimating()
+        }
+    }
+}
+```
+    
+</div>
+</details>
+
+#### 🌟 UIRefreshControl를 활용한 새로고침 구현
+`Collection View`에 `UIRefreshColtrol` 객체를 추가하여, 아래로 당겼을 때 새로고침을 진행할 수 있도록 하였습니다.
+<details>
+<summary>상세코드</summary>
+<div markdown="1">
+    
+```swift
+collectionView.refreshControl = refreshControl
+    refreshControl.addTarget(self, action: #selector(refresh), for: .valueChanged)
+```
+    
+</div>
+</details>
+    
+#### 🌟 UIToolBar 활용
+`UIToolBar`와 `flexibleSpace`를 활용하여 화면 하단 버튼을 구현하였습니다.
+    
+<details>
+<summary>상세코드</summary>
+<div markdown="1">
+    
+```swift
+let modeChangeButton = UIBarButtonItem(title: "화면 모드 변경", style: .plain, target: self, action: #selector(hitChangeModeButton))
+let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: self, action: nil)
+...
+self.toolbarItems = [flexibleSpace, modeChangeButton, flexibleSpace]
+```
+    
+</div>
+</details>
+
+#### 🌟 UIAlertController 활용
+화면 모드 변경시 `UIAlertController`의 `actionSheet`스타일로 아이콘 모드와 리스트 모드 화면을 선택적으로 적용할 수 있도록 구현하였습니다.
+<details>
+<summary>상세코드</summary>
+<div markdown="1">
+    
+```swift
+@objc func hitChangeModeButton() {
+    let mode: String = isListMode == true ? "아이콘" : "리스트"
+    let alert = UIAlertController(title: "화면 모드 변경", message: nil, preferredStyle: .actionSheet)
+    let modeChangeAction = UIAlertAction(title: mode, style: .default) { _ in
+        self.isListMode.toggle()
+    }
+    let cancelAction = UIAlertAction(title: "취소", style: .cancel)
+        
+    alert.addAction(modeChangeAction)
+    alert.addAction(cancelAction)
+    present(alert, animated: true)
+}
+```
+    
+</div>
+</details>
+    
+
+#### 🌟 Attributed String 활용
+하나의 레이블 안에서 여러 가지 색상을 표시하기 위하여 `Attributed String`을 활용하였습니다.
+<details>
+<summary>상세코드</summary>
+<div markdown="1">
+    
+```swift
+attributedString.addAttribute(.foregroundColor, value: UIColor.systemRed, range: (fixedIntensity as NSString).range(of: "▲"))
+```
+    
+</div>
+</details>
+
+#### 🌟 DynamicType 적용
+`preferredFont`를 활용하여 폰트에 `DynamicType`을 적용하였고, `adjustsFontSizeToFitWidth` 설정을 통해 가로 너비에 맞춰 텍스트 크기를 자동 조절할 수 있도록 구현하였습니다.
+<details>
+<summary>상세코드</summary>
+<div markdown="1">
+    
+```swift
+private let audienceLabel: UILabel = {
+    let label = UILabel()
+    label.font = .preferredFont(forTextStyle: .body)
+    label.translatesAutoresizingMaskIntoConstraints = false
+    label.adjustsFontForContentSizeCategory = true
+    label.adjustsFontSizeToFitWidth = true
+
+    return label
+}()
+```
+    
+</div>
+</details>
+
+<a id="6."></a></br>
+## 트러블 슈팅
+### 1️⃣ 네트워크 연결시 URL 전달 방식
+**🚨 문제점**</br>
+기존에는 `dataTask` 메서드에 `URL` 타입을 전달하여 네트워크 연결을 진행하도록 구현했었습니다. 하지만 이번에 `Daum API`가 추가되면서 `Authorization` 헤더를 추가해야 했기 때문에 해당 정보를 어떻게 전달할지 고민하였습니다.
+
+**💡 해결 방법**</br>
+`URLRequest`를 활용하면 `setValue`를 통해 헤더 정보를 추가할 수 있음을 확인하였습니다. 이에 따라 기존 테스트더블 및 테스트코드 모두 `URLRequest`에 맞게 수정을 진행하였습니다.
+
+```swift
+var request = URLRequest(url: url)
+request.setValue("KakaoAK \(NetworkNamespace.daumApiKey)", forHTTPHeaderField: "Authorization")
+```
+
+또한 `Daum API`에 전달할 쿼리 내용에는 띄어쓰기가 추가되어 있어, `URL`에 붙여서 보내기보다는 `URLComponents`를 사용해 필요한 쿼리 아이템을 추가하는 게 좋겠다는 생각이 들었습니다.
+해당 내용은 아래와 같이 구현하였습니다.
+```swift
+var urlComponents = URLComponents(string: NetworkNamespace.daumImage.url)
+urlComponents?.queryItems = [URLQueryItem(name: "query", value: "\(movieName) 영화 포스터")]
+```
+
+### 2️⃣ dataTask 메서드로 받아온 데이터 처리
 **🚨 문제점**</br>
 `NetworkingManager`의 `load()` 메서드를 호출한 위치에서 `dataTask`를 통해 받아 온 데이터를 활용할 수 있는 방법에 대해 고민이 있었습니다.
 처음에는 두 타입을 델리게이트로 연결하여 전달하는 등의 방법을 생각했습니다. 하지만 데이터 처리를 위해 네트워킹을 사용하는 모든 타입을 델리게이트로 연결하는 것은 권장되는 방식도 아니고, 효율적이지 못한 것 같았습니다.
@@ -112,7 +354,7 @@ func load(_ urlString: String, completion: @escaping (Result<Data, BoxOfficeErro
         ...
 ```
 
-### 2️⃣ ATS를 통한 네트워크 설정
+### 3️⃣ ATS를 통한 네트워크 설정
 **🚨 문제점**</br>
 API를 받아와야 하는 도메인이 `https`가 아닌 `http`를 활용하고 있어 네트워크 연결시에 오류가 발생하였습니다.</br>
 <img src="https://hackmd.io/_uploads/BkwWly-jn.png"></br>
@@ -121,7 +363,7 @@ API를 받아와야 하는 도메인이 `https`가 아닌 `http`를 활용하고
 해당 도메인 및 하위 도메인 정보를 ATS에 `Exception Domains`로 추가하여 정상적으로 네트워킹이 가능하도록 구현하였습니다.</br>
 <img src="https://hackmd.io/_uploads/Hkj4Tsgjh.png"></br>
 
-### 3️⃣ 로딩과 새로고침 종료 위치 설정
+### 4️⃣ 로딩과 새로고침 종료 위치 설정
 **🚨 문제점**</br>
 네트워킹을 통해 받아 온 데이터를 처리하는 과정에서 성공한 경우에만 로딩을 끝내고 빠져나갈 수 있도록 처리하였더니, 에러가 났을 때는 아래와 같이 계속 로딩이 돌아가고 있는 것처럼 보이는 것을 확인했습니다.</br>
 <img src="https://hackmd.io/_uploads/HkMVV0Yon.png" width="200"></br>
@@ -151,33 +393,17 @@ DispatchQueue.main.async {
 }
 ```
 
-### 4️⃣ Cell Accessory 설정
+### 5️⃣ 셀 재활용으로 인한 문제 해결
 **🚨 문제점**</br>
-아래와 같이 코드를 작성하여 각 셀 우측에 악세서리를 추가하였습니다. 하지만 이렇게 하니 `>` 아이콘이 파란색으로 표시되는 것을 확인하였습니다.
-```swift
-cell.accessories = [.outlineDisclosure()]
-```
-<img src="https://hackmd.io/_uploads/BJyxnyYoh.png"></br>
-
+Collection View에서 셀을 재사용하면서, 검은 색으로 들어가야 하는 순위 텍스트가 빨간색으로 잘못 들어가는 문제가 있었습니다.
+<img src="https://hackmd.io/_uploads/HkS1_Shhh.png" width="300"></br>
 **💡 해결 방법**</br>
-`tintColor` 설정을 추가하여 회색으로 표시될 수 있도록 변경하였습니다.
+`PrepareForReuse()`를 통해 아래와 같이 폰트 색상을 초기화해 주었습니다.
 ```swift
-cell.accessories = [.outlineDisclosure(options: .init(tintColor: .systemGray))]
+override func prepareForReuse() {
+    rankIntensityLabel.textColor = .black
+}
 ```
-<img src="https://hackmd.io/_uploads/r19MhyYj3.png"></br>
-
-### 5️⃣ Cell Separator 설정
-**🚨 문제점**</br>
-`UICollectionLayoutListConfiguration`의 기본 설정으로 `Collection View`를 구성하니 각 셀 사이의 구분자인 `separator`가 화면 끝까지 이어지지 않는 문제가 있었습니다.</br>
-<img src="https://hackmd.io/_uploads/B1ysLAFj2.png"></br>
-
-**💡 해결 방법**</br>
-레이아웃 설정에서 아래의 내용을 추가하여 해결하였습니다.
-```swift
-self.separatorLayoutGuide.leadingAnchor.constraint(equalTo: rankLabel.leadingAnchor)
-```
-<img src="https://hackmd.io/_uploads/SySyvCYo2.png"></br>
-
 ### 6️⃣ Test Double 생성
 **🚨 문제점**</br>
 인터넷 연결이 없는 상태에서 네트워크 통신을 테스트하기 위해 `Test Double`을 생성하였습니다. 이 과정에서 테스트용 `Stub Session`과 실제 `Session` 사이에 호환이 가능하도록 하기 위해 `URLSessionProtocol`을 구현하였는데, `URLSession`에서 이를 상속하려 하니 아래와 같은 경고가 발생하였습니다.</br>
@@ -190,17 +416,57 @@ typealias CompletionHandler = @Sendable (Data?, URLResponse?, Error?) -> Void
 ```
 
 
-<a id="6."></a></br>
-## 참고자료
-- [URLSession 공식문서🍎](https://developer.apple.com/documentation/foundation/urlsession)
-- [Fetching Website Data into Memory 공식문서🍎](https://developer.apple.com/documentation/foundation/url_loading_system/fetching_website_data_into_memory)
-- [UICollectionView 공식문서🍎](https://developer.apple.com/documentation/uikit/uicollectionview)
-- [UICollectionViewListCell 공식문서🍎](https://developer.apple.com/documentation/uikit/uicollectionviewlistcell)
-- [UICollectionViewDiffableDataSource 공식문서🍎](https://developer.apple.com/documentation/uikit/uicollectionviewdiffabledatasource)
+### 7️⃣ 다양한 네트워크에 대한 Test 환경 구성 
+**🚨 문제점**</br>
+세 가지 다른 API를 호출하는 프로그램이다 보니, 각 API 내용에 따라 매번 새로운 테스트 환경을 만들어주어야 해서 번거로웠습니다.
+
+**💡 해결 방법**</br>
+아래와 같이 테스트 타입을 파라미터로 전달받아 각 타입에 맞는 테스트환경을 구성할 수 있도록 구현하였습니다. 
+```swift
+func setUpSUT(isSuccess: Bool, apiType: NetworkNamespace) {
+    ...
+        switch apiType {
+    case .boxOffice:
+        urlString = String(format: NetworkNamespace.boxOffice.url, NetworkNamespace.apiKey, "20230801")
+        asset = "box_office_sample"
+    case .movieDetail:
+        urlString = String(format: NetworkNamespace.movieDetail.url, NetworkNamespace.apiKey, "20230801")
+        asset = "movie_detail_sample"
+    case .daumImage:
+        urlString = String(format: NetworkNamespace.daumImage.url)
+        asset = "daum_image_sample"
+    }
+    ...
+
+    if isSuccess {
+        ...
+        let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)
+        ...
+    } else {
+        let response = HTTPURLResponse(url: url, statusCode: 400, httpVersion: nil, headerFields: nil)
+        ...
+    }
+}
+```
+
+<a id="7."></a></br>
+## 참고 자료
+- [URLSession 공식문서 🍎](https://developer.apple.com/documentation/foundation/urlsession)
+- [Fetching Website Data into Memory 공식문서 🍎](https://developer.apple.com/documentation/foundation/url_loading_system/fetching_website_data_into_memory)
+- [UICollectionView 공식문서 🍎](https://developer.apple.com/documentation/uikit/uicollectionview)
+- [UICollectionViewListCell 공식문서 🍎](https://developer.apple.com/documentation/uikit/uicollectionviewlistcell)
+- [UICollectionViewDiffableDataSource 공식문서 🍎](https://developer.apple.com/documentation/uikit/uicollectionviewdiffabledatasource)
+- [URLRequest 공식문서 🍎](https://developer.apple.com/documentation/foundation/urlrequest)
+- [URLComponents 공식문서 🍎](https://developer.apple.com/documentation/foundation/urlcomponents)
+- [AttributedString 공식문서 🍎](https://developer.apple.com/documentation/foundation/attributedstring)
+- [UIRefreshControl 공식문서 🍎](https://developer.apple.com/documentation/uikit/uirefreshcontrol)
+- [UIActivityIndicatorView 공식문서 🍎](https://developer.apple.com/documentation/uikit/uiactivityindicatorview)
+- [UICalendarView 공식문서 🍎](https://developer.apple.com/documentation/uikit/uicalendarview)
+- [UIAlertController 공식문서 🍎](https://developer.apple.com/documentation/uikit/uialertcontroller)
 - [야곰 닷넷 - Unit Test](https://yagom.net/courses/unit-test-%ec%9e%91%ec%84%b1%ed%95%98%ea%b8%b0/)
 </br>
 
-<a id="7."></a></br>
+<a id="8."></a></br>
 ## 팀 회고
 [일일 스크럼](https://github.com/iOS-Yetti/ios-box-office/wiki)
 


### PR DESCRIPTION
안녕하세요 델마!(@delmaSong)
STEP1 수정과 STEP2를 함께 작업해서 올려드립니다!
이번에도 리뷰 잘 부탁드립니다🙇‍♀️
## 고민했던 점
### `화면모드 변경 버튼 구현`
1. 버튼
`UIButton`을 이용해서 구현해보았는데 `UIButton`을 사용해 구현하게 되면 직접 구현해줘야하는 부분이 많아 코드가 길어졌고 `backgroundColor` 역시 요구사항에서처럼 뽑아낼 수 없었습니다.
2. UITabbarController
`NavigationController`처럼 하단의 `Tabbar`를 관리하는 `UITabbarController`를 활용하는 방법도 고민해 보았습니다.
다만 이렇게 구현할 경우 NavigationController와 TabbarController가 혼재하는 복잡한 방식으로 구현하게 되고, 불필요하게 컨트롤러 설정을 위한 코드가 추가되기 때문에 바람직한 방법이 아닌 것 같았습니다.

이 내용은 뷰의 `toolbarItems` 프로퍼티에 아래와 같이 Array를 추가함으로써 간단하게 구현할 수 있었습니다.
```swift
let modeChangeButton = UIBarButtonItem(title: "화면 모드 변경", style: .plain, target: self, action: #selector(hitChangeModeButton))
let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: self, action: nil)
...
self.toolbarItems = [flexibleSpace, modeChangeButton, flexibleSpace]
```
`flexibleSpace`는 툴바에 들어가는 아이템들의 `spacing`을 일정하게 조절할 수 있도록 사용됩니다. 여기서는 화면 모드 변경 아이템을 중앙에 배치하기 위해 좌우로 `flexibleSpace`를 추가해 주었습니다.

### `Grid 형식 아이콘 크기 설정`
아이콘 방식으로 화면을 구현하게 되면 한 줄에 두 개의 박스가 들어가도록 레이아웃을 설정해야 합니다. 이때 아이콘의 크기를 어떻게 설정해주며 좋을지 고민이 있었습니다. 저희는 `view` 자체의 너비 즉 `view.frame.width`에서 좌/우 및 중앙 여백을 뺀 값을 2로 나눈 값으로 아이콘의 가로와 세로를 설정하였습니다.

### `셀 재활용으로 인한 문제 해결`
`Collection View`에서 셀을 재사용하면서, 검은 색으로 들어가야 하는 순위 텍스트가 빨간색으로 잘못 들어가는 부분을 확인했습니다.
<img src="https://hackmd.io/_uploads/SyfOUxq23.png">

해당 부분은 `PrepareForReuse()`를 통해 아래와 같이 폰트 색상을 초기화해 주었습니다.
```swift
override func prepareForReuse() {
    rankIntensityLabel.textColor = .black
}
```

## 조언을 얻고 싶은 점
### `셀높이 자동 지정 문제`
날짜선택을 통해 다른 데이터를 불러오고 나면 일부 셀의 높이가 초기화되지 못하고 줄어드는 문제를 확인하였습니다.
<img src="https://hackmd.io/_uploads/SJfBwe53h.png">
레이아웃을 초기화시키면 해결될까 싶어서 `invalidateLayout()`을 넣어보기도 하고, `layoutIfNeeded()`를 호출해보기도 했는데 해결이 되지 않았습니다.
그래서 아예 셀 관련 레이아웃을 새로 설정할 수 있게 `setUpCollectionViewLayout()`과 `setUpDataSource()`를 다시 호출하니 문제가 해결되었습니다.

현재 정상적으로 앱이 작동하고 있긴 하지만, 이게 제대로된 해결방법인지 의구심이 듭니다 😭
혹시 델마께서는 이런 상황에서 사용할 만한 좋은 해결방법을 알고계실까 싶어서 조언을 얻고 싶습니다!