### PR TITLE
박스오피스II [STEP 2] Diana, gama, Danny

### DIFF
--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		066F8AF12BD7DC4500AFA4E9 /* KakaoSearchDataDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 066F8AF02BD7DC4500AFA4E9 /* KakaoSearchDataDTO.swift */; };
 		066F8AF52BD7EC9400AFA4E9 /* MovieInformationDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 066F8AF42BD7EC9400AFA4E9 /* MovieInformationDTO.swift */; };
 		0691FB852BBBCB8400382C7A /* JSONDecoder+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0691FB842BBBCB8400382C7A /* JSONDecoder+.swift */; };
+		06F4C18A2BDB471A00F5C0AD /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06F4C1892BDB471A00F5C0AD /* String+.swift */; };
 		2E9AF6442BBBC7D70070DCCA /* BoxOffice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E9AF6432BBBC7D70070DCCA /* BoxOffice.swift */; };
 		2E9AF6602BBED0190070DCCA /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E9AF65F2BBED0190070DCCA /* NetworkService.swift */; };
 		2E9AF6852BBFE0290070DCCA /* MovieInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E9AF6842BBFE0290070DCCA /* MovieInformation.swift */; };
@@ -52,6 +53,7 @@
 		066F8AF02BD7DC4500AFA4E9 /* KakaoSearchDataDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoSearchDataDTO.swift; sourceTree = "<group>"; };
 		066F8AF42BD7EC9400AFA4E9 /* MovieInformationDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieInformationDTO.swift; sourceTree = "<group>"; };
 		0691FB842BBBCB8400382C7A /* JSONDecoder+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "JSONDecoder+.swift"; path = "BoxOffice/Extension/JSONDecoder+.swift"; sourceTree = SOURCE_ROOT; };
+		06F4C1892BDB471A00F5C0AD /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
 		2E9AF6432BBBC7D70070DCCA /* BoxOffice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BoxOffice.swift; path = BoxOffice/Models/BoxOffice.swift; sourceTree = SOURCE_ROOT; };
 		2E9AF65F2BBED0190070DCCA /* NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
 		2E9AF6832BBFB48D0070DCCA /* Secret.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secret.xcconfig; sourceTree = "<group>"; };
@@ -163,6 +165,7 @@
 				8BF0F7592BCE20E000371B15 /* UILabel+.swift */,
 				8BF0F75B2BCE218F00371B15 /* NumberFormatter+.swift */,
 				8BFD944D2BCFF083004ADB0E /* Date+.swift */,
+				06F4C1892BDB471A00F5C0AD /* String+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -332,6 +335,7 @@
 				2E9AF6442BBBC7D70070DCCA /* BoxOffice.swift in Sources */,
 				2E9AF6872BBFEB830070DCCA /* Bundle+.swift in Sources */,
 				066F8AF52BD7EC9400AFA4E9 /* MovieInformationDTO.swift in Sources */,
+				06F4C18A2BDB471A00F5C0AD /* String+.swift in Sources */,
 				066F8AED2BD6832E00AFA4E9 /* MovieDetailViewController.swift in Sources */,
 				8BFD944E2BCFF083004ADB0E /* Date+.swift in Sources */,
 			);

--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		062A1A322BD1448700934851 /* BoxOfficeDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 062A1A312BD1448700934851 /* BoxOfficeDTO.swift */; };
 		066F8AED2BD6832E00AFA4E9 /* MovieDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 066F8AEC2BD6832E00AFA4E9 /* MovieDetailViewController.swift */; };
 		066F8AEF2BD6A56400AFA4E9 /* KakaoSearchData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 066F8AEE2BD6A56400AFA4E9 /* KakaoSearchData.swift */; };
+		066F8AF12BD7DC4500AFA4E9 /* KakaoSearchDataDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 066F8AF02BD7DC4500AFA4E9 /* KakaoSearchDataDTO.swift */; };
 		0691FB852BBBCB8400382C7A /* JSONDecoder+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0691FB842BBBCB8400382C7A /* JSONDecoder+.swift */; };
 		2E9AF6442BBBC7D70070DCCA /* BoxOffice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E9AF6432BBBC7D70070DCCA /* BoxOffice.swift */; };
 		2E9AF6602BBED0190070DCCA /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E9AF65F2BBED0190070DCCA /* NetworkService.swift */; };
@@ -47,6 +48,7 @@
 		062A1A312BD1448700934851 /* BoxOfficeDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxOfficeDTO.swift; sourceTree = "<group>"; };
 		066F8AEC2BD6832E00AFA4E9 /* MovieDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieDetailViewController.swift; sourceTree = "<group>"; };
 		066F8AEE2BD6A56400AFA4E9 /* KakaoSearchData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoSearchData.swift; sourceTree = "<group>"; };
+		066F8AF02BD7DC4500AFA4E9 /* KakaoSearchDataDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoSearchDataDTO.swift; sourceTree = "<group>"; };
 		0691FB842BBBCB8400382C7A /* JSONDecoder+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "JSONDecoder+.swift"; path = "BoxOffice/Extension/JSONDecoder+.swift"; sourceTree = SOURCE_ROOT; };
 		2E9AF6432BBBC7D70070DCCA /* BoxOffice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BoxOffice.swift; path = BoxOffice/Models/BoxOffice.swift; sourceTree = SOURCE_ROOT; };
 		2E9AF65F2BBED0190070DCCA /* NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
@@ -98,8 +100,9 @@
 				2E9AF6432BBBC7D70070DCCA /* BoxOffice.swift */,
 				2E9AF6842BBFE0290070DCCA /* MovieInformation.swift */,
 				062A1A312BD1448700934851 /* BoxOfficeDTO.swift */,
-				066F8AEE2BD6A56400AFA4E9 /* KakaoSearchData.swift */,
 				8B8AB80F2BD77AFF006EA94A /* FontConstants.swift */,
+				066F8AEE2BD6A56400AFA4E9 /* KakaoSearchData.swift */,
+				066F8AF02BD7DC4500AFA4E9 /* KakaoSearchDataDTO.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -308,6 +311,7 @@
 			files = (
 				8BF0F75E2BCE566E00371B15 /* CalendarViewController.swift in Sources */,
 				63DF20F32970E1A0005DF7D1 /* ViewController.swift in Sources */,
+				066F8AF12BD7DC4500AFA4E9 /* KakaoSearchDataDTO.swift in Sources */,
 				8BAD2F8C2BBFEAA900504D37 /* URLs.swift in Sources */,
 				062A1A322BD1448700934851 /* BoxOfficeDTO.swift in Sources */,
 				0691FB852BBBCB8400382C7A /* JSONDecoder+.swift in Sources */,

--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		062A1A322BD1448700934851 /* BoxOfficeDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 062A1A312BD1448700934851 /* BoxOfficeDTO.swift */; };
+		066F8AEF2BD6A56400AFA4E9 /* KakaoSearchData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 066F8AEE2BD6A56400AFA4E9 /* KakaoSearchData.swift */; };
 		0691FB852BBBCB8400382C7A /* JSONDecoder+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0691FB842BBBCB8400382C7A /* JSONDecoder+.swift */; };
 		2E9AF6442BBBC7D70070DCCA /* BoxOffice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E9AF6432BBBC7D70070DCCA /* BoxOffice.swift */; };
 		2E9AF6602BBED0190070DCCA /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E9AF65F2BBED0190070DCCA /* NetworkService.swift */; };
@@ -42,6 +43,7 @@
 
 /* Begin PBXFileReference section */
 		062A1A312BD1448700934851 /* BoxOfficeDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxOfficeDTO.swift; sourceTree = "<group>"; };
+		066F8AEE2BD6A56400AFA4E9 /* KakaoSearchData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoSearchData.swift; sourceTree = "<group>"; };
 		0691FB842BBBCB8400382C7A /* JSONDecoder+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "JSONDecoder+.swift"; path = "BoxOffice/Extension/JSONDecoder+.swift"; sourceTree = SOURCE_ROOT; };
 		2E9AF6432BBBC7D70070DCCA /* BoxOffice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BoxOffice.swift; path = BoxOffice/Models/BoxOffice.swift; sourceTree = SOURCE_ROOT; };
 		2E9AF65F2BBED0190070DCCA /* NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
@@ -92,6 +94,7 @@
 				2E9AF6432BBBC7D70070DCCA /* BoxOffice.swift */,
 				2E9AF6842BBFE0290070DCCA /* MovieInformation.swift */,
 				062A1A312BD1448700934851 /* BoxOfficeDTO.swift */,
+				066F8AEE2BD6A56400AFA4E9 /* KakaoSearchData.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -308,6 +311,7 @@
 				63DF20EF2970E1A0005DF7D1 /* AppDelegate.swift in Sources */,
 				8BAD2F852BBFDA1600504D37 /* DateFormatter+.swift in Sources */,
 				63DF20F12970E1A0005DF7D1 /* SceneDelegate.swift in Sources */,
+				066F8AEF2BD6A56400AFA4E9 /* KakaoSearchData.swift in Sources */,
 				2E9AF6602BBED0190070DCCA /* NetworkService.swift in Sources */,
 				8BCFAC6A2BC433B200580129 /* CustomError.swift in Sources */,
 				2E9AF6852BBFE0290070DCCA /* MovieInformation.swift in Sources */,

--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		066F8AED2BD6832E00AFA4E9 /* MovieDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 066F8AEC2BD6832E00AFA4E9 /* MovieDetailViewController.swift */; };
 		066F8AEF2BD6A56400AFA4E9 /* KakaoSearchData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 066F8AEE2BD6A56400AFA4E9 /* KakaoSearchData.swift */; };
 		066F8AF12BD7DC4500AFA4E9 /* KakaoSearchDataDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 066F8AF02BD7DC4500AFA4E9 /* KakaoSearchDataDTO.swift */; };
+		066F8AF52BD7EC9400AFA4E9 /* MovieInformationDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 066F8AF42BD7EC9400AFA4E9 /* MovieInformationDTO.swift */; };
 		0691FB852BBBCB8400382C7A /* JSONDecoder+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0691FB842BBBCB8400382C7A /* JSONDecoder+.swift */; };
 		2E9AF6442BBBC7D70070DCCA /* BoxOffice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E9AF6432BBBC7D70070DCCA /* BoxOffice.swift */; };
 		2E9AF6602BBED0190070DCCA /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E9AF65F2BBED0190070DCCA /* NetworkService.swift */; };
@@ -49,6 +50,7 @@
 		066F8AEC2BD6832E00AFA4E9 /* MovieDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieDetailViewController.swift; sourceTree = "<group>"; };
 		066F8AEE2BD6A56400AFA4E9 /* KakaoSearchData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoSearchData.swift; sourceTree = "<group>"; };
 		066F8AF02BD7DC4500AFA4E9 /* KakaoSearchDataDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoSearchDataDTO.swift; sourceTree = "<group>"; };
+		066F8AF42BD7EC9400AFA4E9 /* MovieInformationDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieInformationDTO.swift; sourceTree = "<group>"; };
 		0691FB842BBBCB8400382C7A /* JSONDecoder+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "JSONDecoder+.swift"; path = "BoxOffice/Extension/JSONDecoder+.swift"; sourceTree = SOURCE_ROOT; };
 		2E9AF6432BBBC7D70070DCCA /* BoxOffice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BoxOffice.swift; path = BoxOffice/Models/BoxOffice.swift; sourceTree = SOURCE_ROOT; };
 		2E9AF65F2BBED0190070DCCA /* NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
@@ -98,11 +100,12 @@
 			isa = PBXGroup;
 			children = (
 				2E9AF6432BBBC7D70070DCCA /* BoxOffice.swift */,
-				2E9AF6842BBFE0290070DCCA /* MovieInformation.swift */,
 				062A1A312BD1448700934851 /* BoxOfficeDTO.swift */,
-				8B8AB80F2BD77AFF006EA94A /* FontConstants.swift */,
+				2E9AF6842BBFE0290070DCCA /* MovieInformation.swift */,
+				066F8AF42BD7EC9400AFA4E9 /* MovieInformationDTO.swift */,
 				066F8AEE2BD6A56400AFA4E9 /* KakaoSearchData.swift */,
 				066F8AF02BD7DC4500AFA4E9 /* KakaoSearchDataDTO.swift */,
+				8B8AB80F2BD77AFF006EA94A /* FontConstants.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -328,6 +331,7 @@
 				8B8AB8102BD77AFF006EA94A /* FontConstants.swift in Sources */,
 				2E9AF6442BBBC7D70070DCCA /* BoxOffice.swift in Sources */,
 				2E9AF6872BBFEB830070DCCA /* Bundle+.swift in Sources */,
+				066F8AF52BD7EC9400AFA4E9 /* MovieInformationDTO.swift in Sources */,
 				066F8AED2BD6832E00AFA4E9 /* MovieDetailViewController.swift in Sources */,
 				8BFD944E2BCFF083004ADB0E /* Date+.swift in Sources */,
 			);

--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		062A1A322BD1448700934851 /* BoxOfficeDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 062A1A312BD1448700934851 /* BoxOfficeDTO.swift */; };
 		0691FB852BBBCB8400382C7A /* JSONDecoder+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0691FB842BBBCB8400382C7A /* JSONDecoder+.swift */; };
 		2E9AF6442BBBC7D70070DCCA /* BoxOffice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E9AF6432BBBC7D70070DCCA /* BoxOffice.swift */; };
 		2E9AF6602BBED0190070DCCA /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E9AF65F2BBED0190070DCCA /* NetworkService.swift */; };
@@ -40,6 +41,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		062A1A312BD1448700934851 /* BoxOfficeDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxOfficeDTO.swift; sourceTree = "<group>"; };
 		0691FB842BBBCB8400382C7A /* JSONDecoder+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "JSONDecoder+.swift"; path = "BoxOffice/Extension/JSONDecoder+.swift"; sourceTree = SOURCE_ROOT; };
 		2E9AF6432BBBC7D70070DCCA /* BoxOffice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BoxOffice.swift; path = BoxOffice/Models/BoxOffice.swift; sourceTree = SOURCE_ROOT; };
 		2E9AF65F2BBED0190070DCCA /* NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
@@ -89,6 +91,7 @@
 			children = (
 				2E9AF6432BBBC7D70070DCCA /* BoxOffice.swift */,
 				2E9AF6842BBFE0290070DCCA /* MovieInformation.swift */,
+				062A1A312BD1448700934851 /* BoxOfficeDTO.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -297,6 +300,7 @@
 				8BF0F75E2BCE566E00371B15 /* CalendarViewController.swift in Sources */,
 				63DF20F32970E1A0005DF7D1 /* ViewController.swift in Sources */,
 				8BAD2F8C2BBFEAA900504D37 /* URLs.swift in Sources */,
+				062A1A322BD1448700934851 /* BoxOfficeDTO.swift in Sources */,
 				0691FB852BBBCB8400382C7A /* JSONDecoder+.swift in Sources */,
 				8BF0F75C2BCE218F00371B15 /* NumberFormatter+.swift in Sources */,
 				8BF0F75A2BCE20E000371B15 /* UILabel+.swift in Sources */,

--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		062A1A322BD1448700934851 /* BoxOfficeDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 062A1A312BD1448700934851 /* BoxOfficeDTO.swift */; };
+		066F8AED2BD6832E00AFA4E9 /* MovieDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 066F8AEC2BD6832E00AFA4E9 /* MovieDetailViewController.swift */; };
 		066F8AEF2BD6A56400AFA4E9 /* KakaoSearchData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 066F8AEE2BD6A56400AFA4E9 /* KakaoSearchData.swift */; };
 		0691FB852BBBCB8400382C7A /* JSONDecoder+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0691FB842BBBCB8400382C7A /* JSONDecoder+.swift */; };
 		2E9AF6442BBBC7D70070DCCA /* BoxOffice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E9AF6432BBBC7D70070DCCA /* BoxOffice.swift */; };
@@ -43,6 +44,7 @@
 
 /* Begin PBXFileReference section */
 		062A1A312BD1448700934851 /* BoxOfficeDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxOfficeDTO.swift; sourceTree = "<group>"; };
+		066F8AEC2BD6832E00AFA4E9 /* MovieDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieDetailViewController.swift; sourceTree = "<group>"; };
 		066F8AEE2BD6A56400AFA4E9 /* KakaoSearchData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoSearchData.swift; sourceTree = "<group>"; };
 		0691FB842BBBCB8400382C7A /* JSONDecoder+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "JSONDecoder+.swift"; path = "BoxOffice/Extension/JSONDecoder+.swift"; sourceTree = SOURCE_ROOT; };
 		2E9AF6432BBBC7D70070DCCA /* BoxOffice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BoxOffice.swift; path = BoxOffice/Models/BoxOffice.swift; sourceTree = SOURCE_ROOT; };
@@ -162,6 +164,7 @@
 				63DF20F22970E1A0005DF7D1 /* ViewController.swift */,
 				8BF0F7572BCD686400371B15 /* BoxOfficeCell.swift */,
 				8BF0F75D2BCE566D00371B15 /* CalendarViewController.swift */,
+				066F8AEC2BD6832E00AFA4E9 /* MovieDetailViewController.swift */,
 			);
 			path = ViewControllers;
 			sourceTree = "<group>";
@@ -317,6 +320,7 @@
 				2E9AF6852BBFE0290070DCCA /* MovieInformation.swift in Sources */,
 				2E9AF6442BBBC7D70070DCCA /* BoxOffice.swift in Sources */,
 				2E9AF6872BBFEB830070DCCA /* Bundle+.swift in Sources */,
+				066F8AED2BD6832E00AFA4E9 /* MovieDetailViewController.swift in Sources */,
 				8BFD944E2BCFF083004ADB0E /* Date+.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/BoxOffice.xcodeproj/project.pbxproj
+++ b/BoxOffice.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		63DF20F32970E1A0005DF7D1 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63DF20F22970E1A0005DF7D1 /* ViewController.swift */; };
 		63DF20F82970E1A1005DF7D1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 63DF20F72970E1A1005DF7D1 /* Assets.xcassets */; };
 		63DF20FB2970E1A1005DF7D1 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 63DF20F92970E1A1005DF7D1 /* LaunchScreen.storyboard */; };
+		8B8AB8102BD77AFF006EA94A /* FontConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B8AB80F2BD77AFF006EA94A /* FontConstants.swift */; };
 		8BAD2F852BBFDA1600504D37 /* DateFormatter+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BAD2F842BBFDA1600504D37 /* DateFormatter+.swift */; };
 		8BAD2F8C2BBFEAA900504D37 /* URLs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BAD2F8B2BBFEAA900504D37 /* URLs.swift */; };
 		8BCFAC6A2BC433B200580129 /* CustomError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BCFAC692BC433B200580129 /* CustomError.swift */; };
@@ -60,6 +61,7 @@
 		63DF20F72970E1A1005DF7D1 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		63DF20FA2970E1A1005DF7D1 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		63DF20FC2970E1A1005DF7D1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		8B8AB80F2BD77AFF006EA94A /* FontConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontConstants.swift; sourceTree = "<group>"; };
 		8BAD2F842BBFDA1600504D37 /* DateFormatter+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+.swift"; sourceTree = "<group>"; };
 		8BAD2F8B2BBFEAA900504D37 /* URLs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLs.swift; sourceTree = "<group>"; };
 		8BCFAC692BC433B200580129 /* CustomError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomError.swift; sourceTree = "<group>"; };
@@ -97,6 +99,7 @@
 				2E9AF6842BBFE0290070DCCA /* MovieInformation.swift */,
 				062A1A312BD1448700934851 /* BoxOfficeDTO.swift */,
 				066F8AEE2BD6A56400AFA4E9 /* KakaoSearchData.swift */,
+				8B8AB80F2BD77AFF006EA94A /* FontConstants.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -318,6 +321,7 @@
 				2E9AF6602BBED0190070DCCA /* NetworkService.swift in Sources */,
 				8BCFAC6A2BC433B200580129 /* CustomError.swift in Sources */,
 				2E9AF6852BBFE0290070DCCA /* MovieInformation.swift in Sources */,
+				8B8AB8102BD77AFF006EA94A /* FontConstants.swift in Sources */,
 				2E9AF6442BBBC7D70070DCCA /* BoxOffice.swift in Sources */,
 				2E9AF6872BBFEB830070DCCA /* Bundle+.swift in Sources */,
 				066F8AED2BD6832E00AFA4E9 /* MovieDetailViewController.swift in Sources */,

--- a/BoxOffice/Extension/Bundle+.swift
+++ b/BoxOffice/Extension/Bundle+.swift
@@ -16,4 +16,13 @@ extension Bundle {
             return key
         }
     }
+    
+    var kakaoApiKey: String? {
+        let key = infoDictionary?["KAKAO_API_KEY"] as? String
+        if key == "" {
+            fatalError("KAKAO_API_KEY 값을 입력해주세요.")
+        } else {
+            return key
+        }
+    }
 }

--- a/BoxOffice/Extension/Bundle+.swift
+++ b/BoxOffice/Extension/Bundle+.swift
@@ -10,7 +10,7 @@ import Foundation
 extension Bundle {
     var apiKey: String? {
         let key = infoDictionary?["API_KEY"] as? String
-        if infoDictionary?["API_KEY"] as? String == "" {
+        if key == "" {
             fatalError("API_KEY 값을 입력해주세요.")
         } else {
             return key

--- a/BoxOffice/Extension/String+.swift
+++ b/BoxOffice/Extension/String+.swift
@@ -1,0 +1,29 @@
+//
+//  String+.swift
+//  BoxOffice
+//
+//  Created by H on 4/26/24.
+//
+
+import Foundation
+
+extension String {
+    func formatDate() -> String {
+        guard self.count == 8 else { return self }
+        
+        let yearStartIndex = self.index(self.startIndex, offsetBy: 0)
+        let yearEndIndex = self.index(self.startIndex, offsetBy: 3)
+        
+        let monthStartIndex = self.index(self.startIndex, offsetBy: 4)
+        let monthEndIndex = self.index(self.startIndex, offsetBy: 5)
+        
+        let dayStartIndex = self.index(self.startIndex, offsetBy: 6)
+        let dayEndIndex = self.index(self.startIndex, offsetBy: 7)
+        
+        let yearString = String(self[yearStartIndex...yearEndIndex])
+        let monthString = String(self[monthStartIndex...monthEndIndex])
+        let dayString = String(self[dayStartIndex...dayEndIndex])
+        
+        return yearString + "-" + monthString + "-" + dayString
+    }
+}

--- a/BoxOffice/Info.plist
+++ b/BoxOffice/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>API_KEY</key>
 	<string>$(API_KEY)</string>
+	<key>KAKAO_API_KEY</key>
+	<string>$(KAKAO_API_KEY)</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/BoxOffice/Models/BoxOffice.swift
+++ b/BoxOffice/Models/BoxOffice.swift
@@ -25,7 +25,7 @@ struct BoxOfficeResults: Codable {
     }
 }
 
-struct BoxOfficeInformation: Codable, Hashable {
+struct BoxOfficeInformation: Codable {
     let squenceNumber: String?
     let rank: String?
     let rankIntensity: String?
@@ -64,5 +64,11 @@ struct BoxOfficeInformation: Codable, Hashable {
         case audienceAccumulation = "audiAcc"
         case screenCount = "scrnCnt"
         case showCount = "showCnt"
+    }
+}
+
+extension BoxOfficeInformation {
+    func toDTO() -> BoxOfficeInformationDTO {
+        return BoxOfficeInformationDTO.init(rank: self.rank ?? "", rankIntensity: self.rankIntensity ?? "", rankOldAndNew: self.rankOldAndNew ?? "", movieRepresentCode: self.movieRepresentCode ?? "", movieName: self.movieName ?? "", audienceCount: self.audienceCount ?? "", audienceAccumulation: self.audienceAccumulation ?? "")
     }
 }

--- a/BoxOffice/Models/BoxOffice.swift
+++ b/BoxOffice/Models/BoxOffice.swift
@@ -6,7 +6,7 @@
 //
 
 struct BoxOffice: Codable {
-    let boxOfficeResults: BoxOfficeResults
+    let boxOfficeResults: BoxOfficeResults?
     
     enum CodingKeys: String, CodingKey {
         case boxOfficeResults = "boxOfficeResult"
@@ -69,6 +69,12 @@ struct BoxOfficeInformation: Codable {
 
 extension BoxOfficeInformation {
     func toDTO() -> BoxOfficeInformationDTO {
-        return BoxOfficeInformationDTO.init(rank: self.rank ?? "", rankIntensity: self.rankIntensity ?? "", rankOldAndNew: self.rankOldAndNew ?? "", movieRepresentCode: self.movieRepresentCode ?? "", movieName: self.movieName ?? "", audienceCount: self.audienceCount ?? "", audienceAccumulation: self.audienceAccumulation ?? "")
+        return BoxOfficeInformationDTO.init(rank: self.rank ?? "",
+                                            rankIntensity: self.rankIntensity ?? "",
+                                            rankOldAndNew: self.rankOldAndNew ?? "",
+                                            movieRepresentCode: self.movieRepresentCode ?? "",
+                                            movieName: self.movieName ?? "",
+                                            audienceCount: self.audienceCount ?? "",
+                                            audienceAccumulation: self.audienceAccumulation ?? "")
     }
 }

--- a/BoxOffice/Models/BoxOfficeDTO.swift
+++ b/BoxOffice/Models/BoxOfficeDTO.swift
@@ -1,0 +1,35 @@
+//
+//  BoxOfficeDTO.swift
+//  BoxOffice
+//
+//  Created by Danny, Diana, gama on 4/18/24.
+//
+
+import UIKit
+
+struct BoxOfficeInformationDTO: Hashable {
+    let rank: String
+    let rankIntensity: String
+    let rankOldAndNew: String
+    let movieRepresentCode: String
+    let movieName: String
+    let audienceCount: String
+    let audienceAccumulation: String
+    
+    func checkIfNew() -> Bool {
+        return rankOldAndNew == "NEW" ? true : false
+    }
+    
+    func rankIntensityFormate() -> NSAttributedString {
+        let number = Int(rankIntensity) ?? 0
+        
+        if number > 0 {
+            return UILabel().asColor(color: .red, fullText: "▲\(abs(number))", targetString: "▲")
+        } else if number < 0 {
+            return UILabel().asColor(color: .systemBlue,
+                                     fullText: "▼\(abs(number))", targetString: "▼")
+        } else {
+            return UILabel().asColor(color: .black, fullText: "-", targetString: "")
+        }
+    }
+}

--- a/BoxOffice/Models/FontConstants.swift
+++ b/BoxOffice/Models/FontConstants.swift
@@ -1,0 +1,19 @@
+//
+//  Constants.swift
+//  BoxOffice
+//
+//  Created by Yejin Hong on 4/23/24.
+//
+import UIKit
+
+struct FontConstants {
+    static let TITLE1: UIFont = .preferredFont(forTextStyle: .title1)
+    static let TITLE2: UIFont = .preferredFont(forTextStyle: .title2)
+    static let TITLE3: UIFont = .preferredFont(forTextStyle: .title3)
+    static let TITLE3_BOLD: UIFont = .init(descriptor: UIFontDescriptor.preferredFontDescriptor(withTextStyle: .title3).withSymbolicTraits(.traitBold)!,
+                                           size: 0.0)
+    
+    static let BODY: UIFont = .preferredFont(forTextStyle: .body)
+    static let BODY_BOLD: UIFont = .init(descriptor:UIFontDescriptor.preferredFontDescriptor(withTextStyle: .body).withSymbolicTraits(.traitBold)!,
+                                         size: 0.0)
+}

--- a/BoxOffice/Models/KakaoSearchData.swift
+++ b/BoxOffice/Models/KakaoSearchData.swift
@@ -8,19 +8,19 @@
 import Foundation
 
 struct KakaoSearchData: Codable {
-    let documents: [Document]
-    let meta: Meta
+    let documents: [Document]?
+    let meta: Meta?
 }
 
 struct Document: Codable {
-    let collection: String
-    let datetime: String
-    let displaySiteName: String
-    let docURL: String
-    let height: Int
-    let imageURL: String
-    let thumbnailURL: String
-    let width: Int
+    let collection: String?
+    let datetime: String?
+    let displaySiteName: String?
+    let docURL: String?
+    let height: Int?
+    let imageURL: String?
+    let thumbnailURL: String?
+    let width: Int?
 
     enum CodingKeys: String, CodingKey {
         case collection
@@ -35,13 +35,19 @@ struct Document: Codable {
 }
 
 struct Meta: Codable {
-    let isEnd: Bool
-    let pageableCount: Int
-    let totalCount: Int
+    let isEnd: Bool?
+    let pageableCount: Int?
+    let totalCount: Int?
 
     enum CodingKeys: String, CodingKey {
         case isEnd = "is_end"
         case pageableCount = "pageable_count"
         case totalCount = "total_count"
+    }
+}
+
+extension Document {
+    func toDTO() -> KakaoSearchDataDocumentDTO {
+        return KakaoSearchDataDocumentDTO(imageURL: imageURL ?? "")
     }
 }

--- a/BoxOffice/Models/KakaoSearchData.swift
+++ b/BoxOffice/Models/KakaoSearchData.swift
@@ -1,0 +1,47 @@
+//
+//  KakaoSearchData.swift
+//  BoxOffice
+//
+//  Created by Danny, Diana, gama on 4/22/24.
+//
+
+import Foundation
+
+struct KakaoSearchData: Codable {
+    let documents: [Document]
+    let meta: Meta
+}
+
+struct Document: Codable {
+    let collection: String
+    let datetime: String
+    let displaySiteName: String
+    let docURL: String
+    let height: Int
+    let imageURL: String
+    let thumbnailURL: String
+    let width: Int
+
+    enum CodingKeys: String, CodingKey {
+        case collection
+        case datetime
+        case displaySiteName = "display_sitename"
+        case docURL = "doc_url"
+        case height
+        case imageURL = "image_url"
+        case thumbnailURL = "thumbnail_url"
+        case width
+    }
+}
+
+struct Meta: Codable {
+    let isEnd: Bool
+    let pageableCount: Int
+    let totalCount: Int
+
+    enum CodingKeys: String, CodingKey {
+        case isEnd = "is_end"
+        case pageableCount = "pageable_count"
+        case totalCount = "total_count"
+    }
+}

--- a/BoxOffice/Models/KakaoSearchDataDTO.swift
+++ b/BoxOffice/Models/KakaoSearchDataDTO.swift
@@ -1,0 +1,12 @@
+//
+//  KakaoSearchDataDTO.swift
+//  BoxOffice
+//
+//  Created by Danny, Diana, gama on 4/23/24.
+//
+
+import Foundation
+
+struct KakaoSearchDataDocumentDTO: Codable {
+    let imageURL: String
+}

--- a/BoxOffice/Models/MovieInformation.swift
+++ b/BoxOffice/Models/MovieInformation.swift
@@ -64,7 +64,7 @@ struct MovieInformationDetail: Codable {
 }
 
 struct Nation: Codable {
-    let nationName: String
+    let nationName: String?
     
     enum CodingKeys: String, CodingKey {
         case nationName = "nationNm"
@@ -72,7 +72,7 @@ struct Nation: Codable {
 }
 
 struct Genre: Codable {
-    let genreName: String
+    let genreName: String?
     
     enum CodingKeys: String, CodingKey {
         case genreName = "genreNm"
@@ -80,8 +80,8 @@ struct Genre: Codable {
 }
 
 struct Director: Codable {
-    let peopleName: String
-    let peopleEnglishName: String
+    let peopleName: String?
+    let peopleEnglishName: String?
     
     enum CodingKeys: String, CodingKey {
         case peopleName = "peopleNm"
@@ -90,10 +90,10 @@ struct Director: Codable {
 }
 
 struct Actor: Codable {
-    let peopleName: String
-    let peopleEnglishName: String
-    let cast: String
-    let englishCast: String
+    let peopleName: String?
+    let peopleEnglishName: String?
+    let cast: String?
+    let englishCast: String?
     
     enum CodingKeys: String, CodingKey {
         case peopleName = "peopleNm"
@@ -104,8 +104,8 @@ struct Actor: Codable {
 }
 
 struct ShowType: Codable {
-    let showTypeGroupName: String
-    let showTypeName: String
+    let showTypeGroupName: String?
+    let showTypeName: String?
     
     enum CodingKeys: String, CodingKey {
         case showTypeGroupName = "showTypeGroupNm"
@@ -114,10 +114,10 @@ struct ShowType: Codable {
 }
 
 struct Company: Codable {
-    let companyCode: String
-    let companyName: String
-    let companyEnglishName: String
-    let companyPartName: String
+    let companyCode: String?
+    let companyName: String?
+    let companyEnglishName: String?
+    let companyPartName: String?
 
     enum CodingKeys: String, CodingKey {
         case companyCode = "companyCd"
@@ -128,8 +128,8 @@ struct Company: Codable {
 }
 
 struct Audit: Codable {
-    let auditNumber: String
-    let watchGradeName: String
+    let auditNumber: String?
+    let watchGradeName: String?
     
     enum CodingKeys: String, CodingKey {
         case auditNumber = "auditNo"
@@ -138,13 +138,57 @@ struct Audit: Codable {
 }
 
 struct Staff: Codable {
-    let peopleName: String
-    let peopleEnglishName: String
-    let staffRoleName: String
+    let peopleName: String?
+    let peopleEnglishName: String?
+    let staffRoleName: String?
     
     enum CodingKeys: String, CodingKey {
         case peopleName = "peopleNm"
         case peopleEnglishName = "peopleNmEn"
         case staffRoleName = "staffRoleNm"
+    }
+}
+
+extension MovieInformationDetail {
+    func toDTO() -> MovieInformationDetailDTO {
+        return MovieInformationDetailDTO(movieName: movieName ?? "",
+                                         productYear: productYear ?? "",
+                                         showTime: showTime ?? "",
+                                         openDate: openDate ?? "",
+                                         nations: nations?.map { $0.toDTO() } ?? [NationDTO(nationName: "")],
+                                         genres: genres?.map { $0.toDTO() } ?? [GenreDTO(genreName: "")],
+                                         directors: directors?.map { $0.toDTO() } ?? [DirectorDTO(peopleName: "")],
+                                         actors: actors?.map { $0.toDTO() } ?? [ActorDTO(peopleName: "")],
+                                         audits: audits?.map { $0.toDTO() } ?? [AuditDTO(watchGradeName: "")])
+    }
+}
+
+extension Nation {
+    func toDTO() -> NationDTO {
+        return NationDTO(nationName: nationName ?? "")
+    }
+}
+
+extension Genre {
+    func toDTO() -> GenreDTO {
+        return GenreDTO(genreName: genreName ?? "")
+    }
+}
+
+extension Director {
+    func toDTO() -> DirectorDTO {
+        return DirectorDTO(peopleName: peopleName ?? "")
+    }
+}
+
+extension Actor {
+    func toDTO() -> ActorDTO {
+        return ActorDTO(peopleName: peopleName ?? "")
+    }
+}
+
+extension Audit {
+    func toDTO() -> AuditDTO {
+        return AuditDTO(watchGradeName: watchGradeName ?? "")
     }
 }

--- a/BoxOffice/Models/MovieInformationDTO.swift
+++ b/BoxOffice/Models/MovieInformationDTO.swift
@@ -1,0 +1,40 @@
+//
+//  MovieInformationDTO.swift
+//  BoxOffice
+//
+//  Created by Danny, Diana, gama on 4/23/24.
+//
+
+import Foundation
+
+struct MovieInformationDetailDTO {
+    let movieName: String
+    let productYear: String
+    let showTime: String
+    let openDate: String
+    let nations: [NationDTO]
+    let genres: [GenreDTO]
+    let directors: [DirectorDTO]
+    let actors: [ActorDTO]
+    let audits: [AuditDTO]
+}
+
+struct NationDTO {
+    let nationName: String
+}
+
+struct GenreDTO {
+    let genreName: String
+}
+
+struct DirectorDTO {
+    let peopleName: String
+}
+
+struct ActorDTO {
+    let peopleName: String
+}
+
+struct AuditDTO {
+    let watchGradeName: String
+}

--- a/BoxOffice/Network/CustomError.swift
+++ b/BoxOffice/Network/CustomError.swift
@@ -18,4 +18,6 @@ enum CustomError: Error {
     case httpResponseError
     case statusCodeError(Int)
     case emptyData
+    
+    case invalidURL
 }

--- a/BoxOffice/Network/NetworkService.swift
+++ b/BoxOffice/Network/NetworkService.swift
@@ -27,8 +27,11 @@ struct KakaoSearchOption {
     }
 }
 
-class NetworkService {
-    func loadKakaoSearchAPI<T: Decodable>(searchType: KakaoSearchType, dataType: T.Type, searchOption: KakaoSearchOption, completion: @escaping (_ result: Result<T, CustomError>) -> ()) {
+final class NetworkService {
+    static let shared = NetworkService()
+    
+    private init() { }
+    
     func getURL(searchType: KakaoSearchType, searchOption: KakaoSearchOption) -> URL? {
         guard var urlComponents = URLComponents(string: searchType.urlString) else {
             return nil

--- a/BoxOffice/Network/NetworkService.swift
+++ b/BoxOffice/Network/NetworkService.swift
@@ -29,8 +29,9 @@ struct KakaoSearchOption {
 
 class NetworkService {
     func loadKakaoSearchAPI<T: Decodable>(searchType: KakaoSearchType, dataType: T.Type, searchOption: KakaoSearchOption, completion: @escaping (_ result: Result<T, CustomError>) -> ()) {
+    func getURL(searchType: KakaoSearchType, searchOption: KakaoSearchOption) -> URL? {
         guard var urlComponents = URLComponents(string: searchType.urlString) else {
-            return
+            return nil
         }
         
         urlComponents.queryItems = [
@@ -40,9 +41,17 @@ class NetworkService {
             URLQueryItem(name: "size", value: String(searchOption.page ?? 1)),
         ]
         
-        urlComponents.percentEncodedQuery = urlComponents.percentEncodedQuery?.replacingOccurrences(of: "+", with: "%2B")
-
         guard let url = urlComponents.url else {
+            return nil
+        }
+        
+        return url
+    }
+    
+    func loadKakaoSearchAPI<T: Decodable>(searchType: KakaoSearchType, dataType: T.Type, searchOption: KakaoSearchOption, completion: @escaping (_ result: Result<T, CustomError>) -> ()) {
+        
+        guard let url = getURL(searchType: searchType, searchOption: searchOption) else {
+            completion(.failure(.invalidURL))
             return
         }
         

--- a/BoxOffice/Network/NetworkService.swift
+++ b/BoxOffice/Network/NetworkService.swift
@@ -11,7 +11,10 @@ enum KakaoSearchType {
     case image
     
     var urlString: String {
-        return "\(URLs.KAKAO_IMAGE_SEARCH)"
+        switch self{
+        case .image:
+            return "\(URLs.KAKAO_IMAGE_SEARCH)"
+        }
     }
 }
 

--- a/BoxOffice/Network/URLs.swift
+++ b/BoxOffice/Network/URLs.swift
@@ -15,4 +15,6 @@ struct URLs {
     
     static let DAILY_BOX_OFFICE = "boxoffice/searchDailyBoxOfficeList.json?key=\(apiKey)&targetDt="
     static let MOVIE_DETAIL = "movie/searchMovieInfo.json?key=\(apiKey)&movieCd="
+    
+    static let KAKAO_IMAGE_SEARCH = "https://dapi.kakao.com/v2/search/image"
 }

--- a/BoxOffice/Network/URLs.swift
+++ b/BoxOffice/Network/URLs.swift
@@ -9,6 +9,7 @@ import Foundation
 
 struct URLs {
     static let apiKey = Bundle.main.apiKey ?? ""
+    static let kakaoApiKey = Bundle.main.kakaoApiKey ?? ""
     
     static let PREFIX = "https://kobis.or.kr/kobisopenapi/webservice/rest/"
     

--- a/BoxOffice/ViewControllers/BoxOfficeCell.swift
+++ b/BoxOffice/ViewControllers/BoxOfficeCell.swift
@@ -44,6 +44,17 @@ class BoxOfficeCell: UICollectionViewListCell {
         return stackView
     }()
     
+    private let gridStackView: UIStackView = {
+        let stackView = UIStackView()
+        
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        stackView.alignment = .center
+        stackView.distribution = .equalCentering
+        
+        return stackView
+    }()
+    
     private let rightStackView: UIStackView = {
         let stackView = UIStackView()
         
@@ -115,6 +126,8 @@ class BoxOfficeCell: UICollectionViewListCell {
                 self.rightStackView.addArrangedSubview($0)
             }
             
+            contentView.layer.borderWidth = 0
+            
             NSLayoutConstraint.activate([
                 contentView.heightAnchor.constraint(equalToConstant: 80),
 
@@ -128,6 +141,24 @@ class BoxOfficeCell: UICollectionViewListCell {
             ])
         case .icon:
             print("추가해주세요")
+            [gridStackView].forEach {
+                self.contentView.addSubview($0)
+            }
+            
+            [rankNumberLabel, movieTitleLabel, rankChangeLabel, audienceLabel].forEach {
+                self.gridStackView.addArrangedSubview($0)
+            }
+            
+            contentView.layer.borderWidth = 1
+            
+            NSLayoutConstraint.activate([
+                contentView.heightAnchor.constraint(equalToConstant: 80),
+                
+                gridStackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 10),
+                gridStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -10),
+                gridStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+                gridStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
+            ])
         }
     }
 }

--- a/BoxOffice/ViewControllers/BoxOfficeCell.swift
+++ b/BoxOffice/ViewControllers/BoxOfficeCell.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 class BoxOfficeCell: UICollectionViewListCell {
-    static let reuseIdentifier = "boxOfficeCell"
+    static let IDENTIFIER = "boxOfficeCell"
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -127,41 +127,18 @@ class BoxOfficeCell: UICollectionViewListCell {
 }
 
 extension BoxOfficeCell {
-    func updateComponents(data: BoxOfficeInformation) {
-        guard let movieRank = data.rank,
-              let movieName = data.movieName,
-              let audienceCount = data.audienceCount,
-              let audienceAccumulation = data.audienceAccumulation,
-              let rankIntensity = data.rankIntensity else { return }
+    func updateComponents(data: BoxOfficeInformationDTO) {
+        rankNumberLabel.text = data.rank
+        movieTitleLabel.text = data.movieName
+        audienceLabel.text = "오늘 \(NumberFormatter.formatNumber(data.audienceCount)) / 총 \(NumberFormatter.formatNumber(data.audienceAccumulation))"
         
-        rankNumberLabel.text = movieRank
-        movieTitleLabel.text = movieName
-        audienceLabel.text = "오늘 \(NumberFormatter.formatNumber(audienceCount)) / 총 \(NumberFormatter.formatNumber(audienceAccumulation))"
-        
-        if self.checkIfNew(data: data) {
+        if data.checkIfNew() {
             rankChangeLabel.text = "신작"
             rankChangeLabel.textColor = .red
         } else {
-            rankChangeLabel.attributedText = rankIntensityFormate(rankIntensity)
+            rankChangeLabel.attributedText = data.rankIntensityFormate()
         }
         
         accessories = [.disclosureIndicator(displayed: .always)]
-    }
-    
-    private func checkIfNew(data: BoxOfficeInformation) -> Bool {
-        return data.rankOldAndNew == "NEW" ? true : false
-    }
-    
-    private func rankIntensityFormate(_ rankIntensity: String) -> NSAttributedString {
-        let number = Int(rankIntensity) ?? 0
-        
-        if number > 0 {
-            return UILabel().asColor(color: .red, fullText: "▲\(abs(number))", targetString: "▲")
-        } else if number < 0 {
-            return UILabel().asColor(color: .systemBlue,
-                                     fullText: "▼\(abs(number))", targetString: "▼")
-        } else {
-            return UILabel().asColor(color: .black, fullText: "-", targetString: "")
-        }
     }
 }

--- a/BoxOffice/ViewControllers/BoxOfficeCell.swift
+++ b/BoxOffice/ViewControllers/BoxOfficeCell.swift
@@ -9,6 +9,7 @@ import UIKit
 
 class BoxOfficeCell: UICollectionViewListCell {
     static let IDENTIFIER = "boxOfficeCell"
+    var cellMode: CellMode = .list
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -99,30 +100,35 @@ class BoxOfficeCell: UICollectionViewListCell {
       separatorLayoutGuide.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 0).isActive = true
     }
     
-    private func configure() {
-        [leftStackView, rightStackView].forEach {
-            self.contentView.addSubview($0)
-        }
-        
-        [rankNumberLabel, rankChangeLabel].forEach {
-            self.leftStackView.addArrangedSubview($0)
-        }
-        
-        [movieTitleLabel, audienceLabel].forEach {
-            self.rightStackView.addArrangedSubview($0)
-        }
-        
-        NSLayoutConstraint.activate([
-            contentView.heightAnchor.constraint(equalToConstant: 80),
+    func configure() {
+        switch cellMode {
+        case .list:
+            [leftStackView, rightStackView].forEach {
+                self.contentView.addSubview($0)
+            }
+            
+            [rankNumberLabel, rankChangeLabel].forEach {
+                self.leftStackView.addArrangedSubview($0)
+            }
+            
+            [movieTitleLabel, audienceLabel].forEach {
+                self.rightStackView.addArrangedSubview($0)
+            }
+            
+            NSLayoutConstraint.activate([
+                contentView.heightAnchor.constraint(equalToConstant: 80),
 
-            leftStackView.widthAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.2),
-            leftStackView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-            leftStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+                leftStackView.widthAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.2),
+                leftStackView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+                leftStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
 
-            rightStackView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-            rightStackView.leadingAnchor.constraint(equalTo: leftStackView.trailingAnchor),
-            rightStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
-        ])
+                rightStackView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+                rightStackView.leadingAnchor.constraint(equalTo: leftStackView.trailingAnchor),
+                rightStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
+            ])
+        case .icon:
+            print("추가해주세요")
+        }
     }
 }
 
@@ -139,6 +145,10 @@ extension BoxOfficeCell {
             rankChangeLabel.attributedText = data.rankIntensityFormate()
         }
         
-        accessories = [.disclosureIndicator(displayed: .always)]
+        if cellMode == .list {
+            accessories = [.disclosureIndicator(displayed: .always)]
+        } else {
+            accessories.removeAll()
+        }
     }
 }

--- a/BoxOffice/ViewControllers/BoxOfficeCell.swift
+++ b/BoxOffice/ViewControllers/BoxOfficeCell.swift
@@ -122,6 +122,11 @@ class BoxOfficeCell: UICollectionViewListCell {
                 $0.numberOfLines = 0
             }
             
+            rankNumberLabel.textAlignment = .center
+            rankChangeLabel.textAlignment = .center
+            movieTitleLabel.textAlignment = .left
+            audienceLabel.textAlignment = .left
+            
             [leftStackView, rightStackView].forEach {
                 self.contentView.addSubview($0)
             }

--- a/BoxOffice/ViewControllers/BoxOfficeCell.swift
+++ b/BoxOffice/ViewControllers/BoxOfficeCell.swift
@@ -88,7 +88,6 @@ class BoxOfficeCell: UICollectionViewListCell {
         let label = UILabel()
         
         label.font = TITLE_3_BOLD_FONT
-        label.lineBreakMode = .byWordWrapping
         label.numberOfLines = 0
         
         label.adjustsFontForContentSizeCategory = true
@@ -109,17 +108,6 @@ class BoxOfficeCell: UICollectionViewListCell {
         return label
     }()
     
-    private let gridStackView: UIStackView = {
-        let stackView = UIStackView()
-        
-        stackView.axis = .vertical
-        stackView.alignment = .center
-        stackView.distribution = .equalCentering
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        
-        return stackView
-    }()
-    
     override func updateConstraints() {
       super.updateConstraints()
 
@@ -129,6 +117,11 @@ class BoxOfficeCell: UICollectionViewListCell {
     func configure() {
         switch cellMode {
         case .list:
+            [rankNumberLabel, movieTitleLabel, rankChangeLabel, audienceLabel].forEach {
+                $0.removeFromSuperview()
+                $0.numberOfLines = 0
+            }
+            
             [leftStackView, rightStackView].forEach {
                 self.contentView.addSubview($0)
             }
@@ -178,22 +171,29 @@ class BoxOfficeCell: UICollectionViewListCell {
                 $0.removeFromSuperview()
             }
             
-            [gridStackView].forEach {
-                self.contentView.addSubview($0)
-            }
-            
             [rankNumberLabel, movieTitleLabel, rankChangeLabel, audienceLabel].forEach {
-                self.gridStackView.addArrangedSubview($0)
+                $0.numberOfLines = 0
+                $0.textAlignment = .center
+                self.contentView.addSubview($0)
             }
             
             contentView.layer.borderWidth = 1
             
             NSLayoutConstraint.activate([
-                gridStackView.topAnchor.constraint(equalTo: contentView.topAnchor),
-                gridStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
-                gridStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-                gridStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+                rankNumberLabel.widthAnchor.constraint(equalTo: contentView.widthAnchor),
+                movieTitleLabel.widthAnchor.constraint(equalTo: contentView.widthAnchor),
+                rankChangeLabel.widthAnchor.constraint(equalTo: contentView.widthAnchor),
+                audienceLabel.widthAnchor.constraint(equalTo: contentView.widthAnchor),
                 
+                rankNumberLabel.heightAnchor.constraint(equalTo: contentView.heightAnchor, multiplier: 0.25),
+                movieTitleLabel.heightAnchor.constraint(equalTo: contentView.heightAnchor, multiplier: 0.25),
+                rankChangeLabel.heightAnchor.constraint(equalTo: contentView.heightAnchor, multiplier: 0.25),
+                audienceLabel.heightAnchor.constraint(equalTo: contentView.heightAnchor, multiplier: 0.25),
+                
+                rankNumberLabel.topAnchor.constraint(equalTo: contentView.topAnchor),
+                movieTitleLabel.topAnchor.constraint(equalTo: rankNumberLabel.bottomAnchor),
+                rankChangeLabel.topAnchor.constraint(equalTo: movieTitleLabel.bottomAnchor),
+                audienceLabel.topAnchor.constraint(equalTo: rankChangeLabel.bottomAnchor)
             ])
         }
     }

--- a/BoxOffice/ViewControllers/BoxOfficeCell.swift
+++ b/BoxOffice/ViewControllers/BoxOfficeCell.swift
@@ -9,11 +9,12 @@ import UIKit
 
 class BoxOfficeCell: UICollectionViewListCell {
     static let IDENTIFIER = "boxOfficeCell"
-    var cellMode: CellMode = .list
     
-    final let TITLE_1_FONT: UIFont = .preferredFont(forTextStyle: .title1)
-    final let TITLE_3_FONT: UIFont = .preferredFont(forTextStyle: .title3)
-    final let BODYFONT: UIFont = .preferredFont(forTextStyle: .body)
+    final let TITLE_1_FONT: UIFont = FontConstants.TITLE1
+    final let TITLE_3_BOLD_FONT: UIFont = FontConstants.TITLE3_BOLD
+    final let BODY_FONT: UIFont = FontConstants.BODY
+    
+    var cellMode: CellMode = .list
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -83,7 +84,7 @@ class BoxOfficeCell: UICollectionViewListCell {
     lazy var rankChangeLabel: UILabel = {
         let label = UILabel()
         
-        label.font = BODYFONT
+        label.font = BODY_FONT
         
         label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -94,7 +95,7 @@ class BoxOfficeCell: UICollectionViewListCell {
     lazy var movieTitleLabel: UILabel = {
         let label = UILabel()
         
-        label.font = TITLE_3_FONT
+        label.font = TITLE_3_BOLD_FONT
         label.lineBreakMode = .byWordWrapping
         label.numberOfLines = 0
         
@@ -107,7 +108,7 @@ class BoxOfficeCell: UICollectionViewListCell {
     lazy var audienceLabel: UILabel = {
         let label = UILabel()
         
-        label.font = BODYFONT
+        label.font = BODY_FONT
         label.numberOfLines = 0
         
         label.adjustsFontForContentSizeCategory = true

--- a/BoxOffice/ViewControllers/BoxOfficeCell.swift
+++ b/BoxOffice/ViewControllers/BoxOfficeCell.swift
@@ -11,6 +11,10 @@ class BoxOfficeCell: UICollectionViewListCell {
     static let IDENTIFIER = "boxOfficeCell"
     var cellMode: CellMode = .list
     
+    final let TITLE_1_FONT: UIFont = .preferredFont(forTextStyle: .title1)
+    final let TITLE_3_FONT: UIFont = .preferredFont(forTextStyle: .title3)
+    final let BODYFONT: UIFont = .preferredFont(forTextStyle: .body)
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         
@@ -36,21 +40,10 @@ class BoxOfficeCell: UICollectionViewListCell {
     private let leftStackView: UIStackView = {
         let stackView = UIStackView()
         
-        stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .vertical
         stackView.alignment = .center
         stackView.distribution = .fill
-        
-        return stackView
-    }()
-    
-    private let gridStackView: UIStackView = {
-        let stackView = UIStackView()
-        
         stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .vertical
-        stackView.alignment = .center
-        stackView.distribution = .equalCentering
         
         return stackView
     }()
@@ -58,49 +51,67 @@ class BoxOfficeCell: UICollectionViewListCell {
     private let rightStackView: UIStackView = {
         let stackView = UIStackView()
         
-        stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .vertical
         stackView.spacing = 2
+        stackView.translatesAutoresizingMaskIntoConstraints = false
         
         return stackView
     }()
     
-    let rankNumberLabel: UILabel = {
+    private let gridStackView: UIStackView = {
+        let stackView = UIStackView()
+        
+        stackView.axis = .vertical
+        stackView.alignment = .center
+        stackView.distribution = .equalCentering
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        
+        return stackView
+    }()
+    
+    lazy var rankNumberLabel: UILabel = {
         let label = UILabel()
         
+        label.font = TITLE_1_FONT
+        
+        label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = UIFont.systemFont(ofSize: 30)
-        label.textColor = UIColor.black
         
         return label
     }()
     
-    let rankChangeLabel: UILabel = {
+    lazy var rankChangeLabel: UILabel = {
         let label = UILabel()
         
+        label.font = BODYFONT
+        
+        label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = UIFont.systemFont(ofSize: 16)
         
         return label
     }()
     
-    let movieTitleLabel: UILabel = {
+    lazy var movieTitleLabel: UILabel = {
         let label = UILabel()
         
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = UIFont.boldSystemFont(ofSize: 20)
+        label.font = TITLE_3_FONT
         label.lineBreakMode = .byWordWrapping
         label.numberOfLines = 0
         
+        label.adjustsFontForContentSizeCategory = true
+        label.translatesAutoresizingMaskIntoConstraints = false
+        
         return label
     }()
     
-    let audienceLabel: UILabel = {
+    lazy var audienceLabel: UILabel = {
         let label = UILabel()
         
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = UIFont.systemFont(ofSize: 16)
+        label.font = BODYFONT
         label.numberOfLines = 0
+        
+        label.adjustsFontForContentSizeCategory = true
+        label.translatesAutoresizingMaskIntoConstraints = false
         
         return label
     }()

--- a/BoxOffice/ViewControllers/BoxOfficeCell.swift
+++ b/BoxOffice/ViewControllers/BoxOfficeCell.swift
@@ -42,29 +42,7 @@ class BoxOfficeCell: UICollectionViewListCell {
         let stackView = UIStackView()
         
         stackView.axis = .vertical
-        stackView.alignment = .center
-        stackView.distribution = .fill
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        
-        return stackView
-    }()
-    
-    private let rightStackView: UIStackView = {
-        let stackView = UIStackView()
-        
-        stackView.axis = .vertical
-        stackView.spacing = 2
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        
-        return stackView
-    }()
-    
-    private let gridStackView: UIStackView = {
-        let stackView = UIStackView()
-        
-        stackView.axis = .vertical
-        stackView.alignment = .center
-        stackView.distribution = .equalCentering
+        stackView.distribution = .fillProportionally
         stackView.translatesAutoresizingMaskIntoConstraints = false
         
         return stackView
@@ -74,6 +52,7 @@ class BoxOfficeCell: UICollectionViewListCell {
         let label = UILabel()
         
         label.font = TITLE_1_FONT
+        label.textAlignment = .center
         
         label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -85,11 +64,24 @@ class BoxOfficeCell: UICollectionViewListCell {
         let label = UILabel()
         
         label.font = BODY_FONT
+        label.textAlignment = .center
         
         label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
         
         return label
+    }()
+    
+    
+    private let rightStackView: UIStackView = {
+        let stackView = UIStackView()
+        
+        stackView.axis = .vertical
+        stackView.spacing = 2
+        stackView.distribution = .fillProportionally
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        
+        return stackView
     }()
     
     lazy var movieTitleLabel: UILabel = {
@@ -117,6 +109,17 @@ class BoxOfficeCell: UICollectionViewListCell {
         return label
     }()
     
+    private let gridStackView: UIStackView = {
+        let stackView = UIStackView()
+        
+        stackView.axis = .vertical
+        stackView.alignment = .center
+        stackView.distribution = .equalCentering
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        
+        return stackView
+    }()
+    
     override func updateConstraints() {
       super.updateConstraints()
 
@@ -131,28 +134,50 @@ class BoxOfficeCell: UICollectionViewListCell {
             }
             
             [rankNumberLabel, rankChangeLabel].forEach {
-                self.leftStackView.addArrangedSubview($0)
+                self.leftStackView.addSubview($0)
             }
             
             [movieTitleLabel, audienceLabel].forEach {
-                self.rightStackView.addArrangedSubview($0)
+                self.rightStackView.addSubview($0)
             }
             
             contentView.layer.borderWidth = 0
             
             NSLayoutConstraint.activate([
-                contentView.heightAnchor.constraint(equalToConstant: 80),
-
-                leftStackView.widthAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.2),
-                leftStackView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+                leftStackView.widthAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.3),
                 leftStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-
-                rightStackView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+                leftStackView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+                
+                rankNumberLabel.topAnchor.constraint(equalTo: leftStackView.topAnchor),
+                rankNumberLabel.leadingAnchor.constraint(equalTo: leftStackView.leadingAnchor),
+                rankNumberLabel.bottomAnchor.constraint(equalTo: rankChangeLabel.topAnchor),
+                rankNumberLabel.trailingAnchor.constraint(equalTo: leftStackView.trailingAnchor),
+                
+                rankChangeLabel.topAnchor.constraint(equalTo: rankNumberLabel.bottomAnchor),
+                rankChangeLabel.leadingAnchor.constraint(equalTo: leftStackView.leadingAnchor),
+                rankChangeLabel.trailingAnchor.constraint(equalTo: leftStackView.trailingAnchor),
+                rankChangeLabel.bottomAnchor.constraint(equalTo: leftStackView.bottomAnchor),
+                
+                rightStackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 16),
                 rightStackView.leadingAnchor.constraint(equalTo: leftStackView.trailingAnchor),
-                rightStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
+                rightStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -16),
+                rightStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+                
+                movieTitleLabel.topAnchor.constraint(equalTo: rightStackView.topAnchor),
+                movieTitleLabel.leadingAnchor.constraint(equalTo: rightStackView.leadingAnchor),
+                movieTitleLabel.bottomAnchor.constraint(equalTo: audienceLabel.topAnchor),
+                movieTitleLabel.trailingAnchor.constraint(equalTo: rightStackView.trailingAnchor),
+                
+                audienceLabel.topAnchor.constraint(equalTo: movieTitleLabel.bottomAnchor),
+                audienceLabel.leadingAnchor.constraint(equalTo: rightStackView.leadingAnchor),
+                audienceLabel.bottomAnchor.constraint(equalTo: rightStackView.bottomAnchor),
+                audienceLabel.trailingAnchor.constraint(equalTo: rightStackView.trailingAnchor)
             ])
         case .icon:
-            print("추가해주세요")
+            [leftStackView, rightStackView].forEach {
+                $0.removeFromSuperview()
+            }
+            
             [gridStackView].forEach {
                 self.contentView.addSubview($0)
             }
@@ -164,12 +189,11 @@ class BoxOfficeCell: UICollectionViewListCell {
             contentView.layer.borderWidth = 1
             
             NSLayoutConstraint.activate([
-                contentView.heightAnchor.constraint(equalToConstant: 80),
-                
-                gridStackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 10),
-                gridStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -10),
+                gridStackView.topAnchor.constraint(equalTo: contentView.topAnchor),
+                gridStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
                 gridStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-                gridStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
+                gridStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+                
             ])
         }
     }

--- a/BoxOffice/ViewControllers/MovieDetailViewController.swift
+++ b/BoxOffice/ViewControllers/MovieDetailViewController.swift
@@ -1,3 +1,4 @@
+
 //
 //  MovieDetailViewController.swift
 //  BoxOffice
@@ -66,7 +67,6 @@ class MovieDetailViewController: UIViewController {
         label.font = BODY_BOLD_FONT
         label.text = "감독"
         label.textAlignment = .center
-        label.numberOfLines = 0
         
         return label
     }()
@@ -102,7 +102,6 @@ class MovieDetailViewController: UIViewController {
         label.font = BODY_BOLD_FONT
         label.text = "제작연도"
         label.textAlignment = .center
-        label.numberOfLines = 0
         
         return label
     }()
@@ -138,7 +137,6 @@ class MovieDetailViewController: UIViewController {
         label.font = BODY_BOLD_FONT
         label.text = "개봉일"
         label.textAlignment = .center
-        label.numberOfLines = 0
         
         return label
     }()
@@ -174,7 +172,6 @@ class MovieDetailViewController: UIViewController {
         label.font = BODY_BOLD_FONT
         label.text = "상영시간"
         label.textAlignment = .center
-        label.numberOfLines = 0
         
         return label
     }()
@@ -210,7 +207,6 @@ class MovieDetailViewController: UIViewController {
         label.font = BODY_BOLD_FONT
         label.text = "관람 등급"
         label.textAlignment = .center
-        label.numberOfLines = 0
         
         return label
     }()
@@ -246,7 +242,6 @@ class MovieDetailViewController: UIViewController {
         label.font = BODY_BOLD_FONT
         label.text = "제작국가"
         label.textAlignment = .center
-        label.numberOfLines = 0
         
         return label
     }()
@@ -282,7 +277,6 @@ class MovieDetailViewController: UIViewController {
         label.font = BODY_BOLD_FONT
         label.text = "장르"
         label.textAlignment = .center
-        label.numberOfLines = 0
         
         return label
     }()
@@ -318,7 +312,6 @@ class MovieDetailViewController: UIViewController {
         label.font = BODY_BOLD_FONT
         label.text = "배우"
         label.textAlignment = .center
-        label.numberOfLines = 0
         
         return label
     }()
@@ -337,10 +330,9 @@ class MovieDetailViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        setConstraints()
         configureUI()
         imageLoad()
-        setTitleLabelConstraints()
+        setConstraints()
     }
     
     init(movieInformationDTO: MovieInformationDetailDTO) {
@@ -351,22 +343,6 @@ class MovieDetailViewController: UIViewController {
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-    
-    func setTitleLabelConstraints() {
-        let longestLabelSize = movieWatchGradeNameTitleLabel.intrinsicContentSize.width
-        
-        NSLayoutConstraint.activate([
-                movieDirectorTitleLabel.widthAnchor.constraint(equalToConstant: longestLabelSize),
-                movieProductYearTitleLabel.widthAnchor.constraint(equalToConstant: longestLabelSize),
-                movieOpenDateTitleLabel.widthAnchor.constraint(equalToConstant: longestLabelSize),
-                movieShowTimeTitleLabel.widthAnchor.constraint(equalToConstant: longestLabelSize),
-                movieWatchGradeNameTitleLabel.widthAnchor.constraint(equalToConstant: longestLabelSize),
-                movieNationNameTitleLabel.widthAnchor.constraint(equalToConstant: longestLabelSize),
-                movieGenreTitleLabel.widthAnchor.constraint(equalToConstant: longestLabelSize),
-                movieActorTitleLabel.widthAnchor.constraint(equalToConstant: longestLabelSize),
-            ]
-        )
     }
     
     func imageLoad() {
@@ -401,35 +377,34 @@ class MovieDetailViewController: UIViewController {
     
     func setConstraints() {
         view.addSubview(detailScrollView)
+        
         detailScrollView.addSubview(detailContentView)
         
-        [moviePosterImageView, movieDirectorStackView, movieProductYearStackView, movieOpenDateStackView, movieShowTimeStackView, movieWatchGradeNameStackView, movieNationNameStackView, movieGenreStackView, movieActorStackView].forEach {
-            detailContentView.addSubview($0)
-        }
+        detailScrollView.addSubview(moviePosterImageView)
         
-        movieDirectorStackView.addArrangedSubview(movieDirectorTitleLabel)
-        movieDirectorStackView.addArrangedSubview(movieDirectorValueLabel)
+        detailContentView.addSubview(movieDirectorTitleLabel)
+        detailContentView.addSubview(movieDirectorValueLabel)
         
-        movieProductYearStackView.addArrangedSubview(movieProductYearTitleLabel)
-        movieProductYearStackView.addArrangedSubview(movieProductYearValueLabel)
+        detailContentView.addSubview(movieProductYearTitleLabel)
+        detailContentView.addSubview(movieProductYearValueLabel)
         
-        movieOpenDateStackView.addArrangedSubview(movieOpenDateTitleLabel)
-        movieOpenDateStackView.addArrangedSubview(movieOpenDateValueLabel)
+        detailContentView.addSubview(movieOpenDateTitleLabel)
+        detailContentView.addSubview(movieOpenDateValueLabel)
         
-        movieShowTimeStackView.addArrangedSubview(movieShowTimeTitleLabel)
-        movieShowTimeStackView.addArrangedSubview(movieShowTimeValueLabel)
+        detailContentView.addSubview(movieShowTimeTitleLabel)
+        detailContentView.addSubview(movieShowTimeValueLabel)
         
-        movieWatchGradeNameStackView.addArrangedSubview(movieWatchGradeNameTitleLabel)
-        movieWatchGradeNameStackView.addArrangedSubview(movieWatchGradeNameValueLabel)
+        detailContentView.addSubview(movieWatchGradeNameTitleLabel)
+        detailContentView.addSubview(movieWatchGradeNameValueLabel)
         
-        movieNationNameStackView.addArrangedSubview(movieNationNameTitleLabel)
-        movieNationNameStackView.addArrangedSubview(movieNationNameValueLabel)
+        detailContentView.addSubview(movieNationNameTitleLabel)
+        detailContentView.addSubview(movieNationNameValueLabel)
         
-        movieGenreStackView.addArrangedSubview(movieGenreTitleLabel)
-        movieGenreStackView.addArrangedSubview(movieGenreValueLabel)
+        detailContentView.addSubview(movieGenreTitleLabel)
+        detailContentView.addSubview(movieGenreValueLabel)
         
-        movieActorStackView.addArrangedSubview(movieActorTitleLabel)
-        movieActorStackView.addArrangedSubview(movieActorValueLabel)
+        detailContentView.addSubview(movieActorTitleLabel)
+        detailContentView.addSubview(movieActorValueLabel)
         
         let safeArea = view.safeAreaLayoutGuide
         
@@ -450,56 +425,82 @@ class MovieDetailViewController: UIViewController {
             moviePosterImageView.leadingAnchor.constraint(equalTo: detailContentView.leadingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
             moviePosterImageView.trailingAnchor.constraint(equalTo: detailContentView.trailingAnchor, constant: MovieDetailViewController.trailingPaddingConstant),
             
-            movieDirectorStackView.topAnchor.constraint(equalTo: moviePosterImageView.bottomAnchor, constant: MovieDetailViewController.topPaddingConstant),
-            movieDirectorStackView.leadingAnchor.constraint(equalTo: detailContentView.leadingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
-            movieDirectorStackView.trailingAnchor.constraint(equalTo: detailContentView.trailingAnchor, constant: MovieDetailViewController.trailingPaddingConstant),
+            movieDirectorTitleLabel.topAnchor.constraint(equalTo: moviePosterImageView.bottomAnchor, constant: MovieDetailViewController.topPaddingConstant),
+            movieDirectorTitleLabel.leadingAnchor.constraint(equalTo: detailContentView.leadingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
+            
+            movieProductYearTitleLabel.topAnchor.constraint(equalTo: movieDirectorTitleLabel.bottomAnchor, constant: MovieDetailViewController.topPaddingConstant),
+            movieProductYearTitleLabel.leadingAnchor.constraint(equalTo: detailContentView.leadingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
+            
+            movieOpenDateTitleLabel.topAnchor.constraint(equalTo: movieProductYearTitleLabel.bottomAnchor, constant: MovieDetailViewController.topPaddingConstant),
+            movieOpenDateTitleLabel.leadingAnchor.constraint(equalTo: detailContentView.leadingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
+            
+            movieShowTimeTitleLabel.topAnchor.constraint(equalTo: movieOpenDateTitleLabel.bottomAnchor, constant: MovieDetailViewController.topPaddingConstant),
+            movieShowTimeTitleLabel.leadingAnchor.constraint(equalTo: detailContentView.leadingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
+            
+            movieWatchGradeNameTitleLabel.topAnchor.constraint(equalTo: movieShowTimeTitleLabel.bottomAnchor, constant: MovieDetailViewController.topPaddingConstant),
+            movieWatchGradeNameTitleLabel.leadingAnchor.constraint(equalTo: detailContentView.leadingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
+            
+            movieNationNameTitleLabel.topAnchor.constraint(equalTo: movieWatchGradeNameTitleLabel.bottomAnchor, constant: MovieDetailViewController.topPaddingConstant),
+            movieNationNameTitleLabel.leadingAnchor.constraint(equalTo: detailContentView.leadingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
+            
+            movieGenreTitleLabel.topAnchor.constraint(equalTo: movieNationNameTitleLabel.bottomAnchor, constant: MovieDetailViewController.topPaddingConstant),
+            movieGenreTitleLabel.leadingAnchor.constraint(equalTo: detailContentView.leadingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
+            
+            movieActorTitleLabel.topAnchor.constraint(equalTo: movieGenreTitleLabel.bottomAnchor, constant: MovieDetailViewController.topPaddingConstant),
+            movieActorTitleLabel.leadingAnchor.constraint(equalTo: detailContentView.leadingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
+            movieActorTitleLabel.bottomAnchor.constraint(equalTo: detailContentView.bottomAnchor, constant: MovieDetailViewController.bottomPaddingConstant),
             
             
-//            preferredContentSize
-            //            movieDirectorTitleLabel.widthAnchor.constraint(equalTo: movieDirectorStackView.widthAnchor, multiplier: MovieDetailViewController.titleMultiplierConstant),
             
-            movieProductYearStackView.topAnchor.constraint(equalTo: movieDirectorStackView.bottomAnchor, constant: MovieDetailViewController.gapPaddingConstant),
-            movieProductYearStackView.leadingAnchor.constraint(equalTo: detailContentView.leadingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
-            movieProductYearStackView.trailingAnchor.constraint(equalTo: detailContentView.trailingAnchor, constant: MovieDetailViewController.trailingPaddingConstant),
+            movieDirectorTitleLabel.trailingAnchor.constraint(equalTo: movieWatchGradeNameTitleLabel.trailingAnchor),
+            movieProductYearTitleLabel.trailingAnchor.constraint(equalTo: movieWatchGradeNameTitleLabel.trailingAnchor),
+            movieOpenDateTitleLabel.trailingAnchor.constraint(equalTo: movieWatchGradeNameTitleLabel.trailingAnchor),
+            movieShowTimeTitleLabel.trailingAnchor.constraint(equalTo: movieWatchGradeNameTitleLabel.trailingAnchor),
+            movieNationNameTitleLabel.trailingAnchor.constraint(equalTo: movieWatchGradeNameTitleLabel.trailingAnchor),
+            movieGenreTitleLabel.trailingAnchor.constraint(equalTo: movieWatchGradeNameTitleLabel.trailingAnchor),
+            movieActorTitleLabel.trailingAnchor.constraint(equalTo: movieWatchGradeNameTitleLabel.trailingAnchor),
             
-//            movieProductYearTitleLabel.widthAnchor.constraint(equalTo: movieProductYearStackView.widthAnchor, multiplier: MovieDetailViewController.titleMultiplierConstant),
             
-            movieOpenDateStackView.topAnchor.constraint(equalTo: movieProductYearStackView.bottomAnchor, constant: MovieDetailViewController.gapPaddingConstant),
-            movieOpenDateStackView.leadingAnchor.constraint(equalTo: detailContentView.leadingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
-            movieOpenDateStackView.trailingAnchor.constraint(equalTo: detailContentView.trailingAnchor, constant: MovieDetailViewController.trailingPaddingConstant),
             
-//            movieOpenDateTitleLabel.widthAnchor.constraint(equalTo: movieOpenDateStackView.widthAnchor, multiplier: MovieDetailViewController.titleMultiplierConstant),
+            movieDirectorValueLabel.topAnchor.constraint(equalTo: movieDirectorTitleLabel.topAnchor),
+            movieDirectorValueLabel.leadingAnchor.constraint(equalTo: movieDirectorTitleLabel.trailingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
+            movieDirectorValueLabel.bottomAnchor.constraint(equalTo: movieDirectorTitleLabel.bottomAnchor),
+            movieDirectorValueLabel.trailingAnchor.constraint(equalTo: detailContentView.trailingAnchor, constant: MovieDetailViewController.trailingPaddingConstant),
             
-            movieShowTimeStackView.topAnchor.constraint(equalTo: movieOpenDateStackView.bottomAnchor, constant: MovieDetailViewController.gapPaddingConstant),
-            movieShowTimeStackView.leadingAnchor.constraint(equalTo: detailContentView.leadingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
-            movieShowTimeStackView.trailingAnchor.constraint(equalTo: detailContentView.trailingAnchor, constant: MovieDetailViewController.trailingPaddingConstant),
+            movieProductYearValueLabel.topAnchor.constraint(equalTo: movieProductYearTitleLabel.topAnchor),
+            movieProductYearValueLabel.leadingAnchor.constraint(equalTo: movieProductYearTitleLabel.trailingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
+            movieProductYearValueLabel.bottomAnchor.constraint(equalTo: movieProductYearTitleLabel.bottomAnchor),
+            movieProductYearValueLabel.trailingAnchor.constraint(equalTo: detailContentView.trailingAnchor, constant: MovieDetailViewController.trailingPaddingConstant),
             
-//            movieShowTimeTitleLabel.widthAnchor.constraint(equalTo: movieShowTimeStackView.widthAnchor, multiplier: MovieDetailViewController.titleMultiplierConstant),
+            movieOpenDateValueLabel.topAnchor.constraint(equalTo: movieOpenDateTitleLabel.topAnchor),
+            movieOpenDateValueLabel.leadingAnchor.constraint(equalTo: movieOpenDateTitleLabel.trailingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
+            movieOpenDateValueLabel.bottomAnchor.constraint(equalTo: movieOpenDateTitleLabel.bottomAnchor),
+            movieOpenDateValueLabel.trailingAnchor.constraint(equalTo: detailContentView.trailingAnchor, constant: MovieDetailViewController.trailingPaddingConstant),
             
-            movieWatchGradeNameStackView.topAnchor.constraint(equalTo: movieShowTimeStackView.bottomAnchor, constant: MovieDetailViewController.gapPaddingConstant),
-            movieWatchGradeNameStackView.leadingAnchor.constraint(equalTo: detailContentView.leadingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
-            movieWatchGradeNameStackView.trailingAnchor.constraint(equalTo: detailContentView.trailingAnchor, constant: MovieDetailViewController.trailingPaddingConstant),
+            movieShowTimeValueLabel.topAnchor.constraint(equalTo: movieShowTimeTitleLabel.topAnchor),
+            movieShowTimeValueLabel.leadingAnchor.constraint(equalTo: movieShowTimeTitleLabel.trailingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
+            movieShowTimeValueLabel.bottomAnchor.constraint(equalTo: movieShowTimeTitleLabel.bottomAnchor),
+            movieShowTimeValueLabel.trailingAnchor.constraint(equalTo: detailContentView.trailingAnchor, constant: MovieDetailViewController.trailingPaddingConstant),
             
-//            movieWatchGradeNameTitleLabel.widthAnchor.constraint(equalTo: movieWatchGradeNameStackView.widthAnchor, multiplier: MovieDetailViewController.titleMultiplierConstant),
-
-            movieNationNameStackView.topAnchor.constraint(equalTo: movieWatchGradeNameStackView.bottomAnchor, constant: MovieDetailViewController.gapPaddingConstant),
-            movieNationNameStackView.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
-            movieNationNameStackView.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor, constant: MovieDetailViewController.trailingPaddingConstant),
+            movieNationNameValueLabel.topAnchor.constraint(equalTo: movieNationNameTitleLabel.topAnchor),
+            movieNationNameValueLabel.leadingAnchor.constraint(equalTo: movieNationNameTitleLabel.trailingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
+            movieNationNameValueLabel.bottomAnchor.constraint(equalTo: movieNationNameTitleLabel.bottomAnchor),
+            movieNationNameValueLabel.trailingAnchor.constraint(equalTo: detailContentView.trailingAnchor, constant: MovieDetailViewController.trailingPaddingConstant),
             
-//            movieNationNameTitleLabel.widthAnchor.constraint(equalTo: movieNationNameStackView.widthAnchor, multiplier: MovieDetailViewController.titleMultiplierConstant),
+            movieWatchGradeNameValueLabel.topAnchor.constraint(equalTo: movieWatchGradeNameTitleLabel.topAnchor),
+            movieWatchGradeNameValueLabel.leadingAnchor.constraint(equalTo: movieWatchGradeNameTitleLabel.trailingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
+            movieWatchGradeNameValueLabel.bottomAnchor.constraint(equalTo: movieWatchGradeNameTitleLabel.bottomAnchor),
+            movieWatchGradeNameValueLabel.trailingAnchor.constraint(equalTo: detailContentView.trailingAnchor, constant: MovieDetailViewController.trailingPaddingConstant),
             
-            movieGenreStackView.topAnchor.constraint(equalTo: movieNationNameStackView.bottomAnchor, constant: MovieDetailViewController.gapPaddingConstant),
-            movieGenreStackView.leadingAnchor.constraint(equalTo: detailContentView.leadingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
-            movieGenreStackView.trailingAnchor.constraint(equalTo: detailContentView.trailingAnchor, constant: MovieDetailViewController.trailingPaddingConstant),
+            movieGenreValueLabel.topAnchor.constraint(equalTo: movieGenreTitleLabel.topAnchor),
+            movieGenreValueLabel.leadingAnchor.constraint(equalTo: movieGenreTitleLabel.trailingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
+            movieGenreValueLabel.bottomAnchor.constraint(equalTo: movieGenreTitleLabel.bottomAnchor),
+            movieGenreValueLabel.trailingAnchor.constraint(equalTo: detailContentView.trailingAnchor, constant: MovieDetailViewController.trailingPaddingConstant),
             
-//            movieGenreTitleLabel.widthAnchor.constraint(equalTo: movieGenreStackView.widthAnchor, multiplier: MovieDetailViewController.titleMultiplierConstant),
-            
-            movieActorStackView.topAnchor.constraint(equalTo: movieGenreStackView.bottomAnchor, constant: MovieDetailViewController.gapPaddingConstant),
-            movieActorStackView.leadingAnchor.constraint(equalTo: detailContentView.leadingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
-            movieActorStackView.trailingAnchor.constraint(equalTo: detailContentView.trailingAnchor, constant: MovieDetailViewController.trailingPaddingConstant),
-            movieActorStackView.bottomAnchor.constraint(equalTo: detailContentView.bottomAnchor, constant: MovieDetailViewController.bottomPaddingConstant),
-            
-//            movieActorTitleLabel.widthAnchor.constraint(equalTo: movieActorStackView.widthAnchor, multiplier: MovieDetailViewController.titleMultiplierConstant),
+            movieActorValueLabel.topAnchor.constraint(equalTo: movieActorTitleLabel.topAnchor),
+            movieActorValueLabel.leadingAnchor.constraint(equalTo: movieActorTitleLabel.trailingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
+            movieActorValueLabel.bottomAnchor.constraint(equalTo: movieActorTitleLabel.bottomAnchor),
+            movieActorValueLabel.trailingAnchor.constraint(equalTo: detailContentView.trailingAnchor, constant: MovieDetailViewController.trailingPaddingConstant),
         ])
     }
     

--- a/BoxOffice/ViewControllers/MovieDetailViewController.swift
+++ b/BoxOffice/ViewControllers/MovieDetailViewController.swift
@@ -66,6 +66,7 @@ class MovieDetailViewController: UIViewController {
         label.font = BODY_BOLD_FONT
         label.text = "감독"
         label.textAlignment = .center
+        label.numberOfLines = 0
         
         return label
     }()
@@ -101,6 +102,7 @@ class MovieDetailViewController: UIViewController {
         label.font = BODY_BOLD_FONT
         label.text = "제작연도"
         label.textAlignment = .center
+        label.numberOfLines = 0
         
         return label
     }()
@@ -136,6 +138,7 @@ class MovieDetailViewController: UIViewController {
         label.font = BODY_BOLD_FONT
         label.text = "개봉일"
         label.textAlignment = .center
+        label.numberOfLines = 0
         
         return label
     }()
@@ -171,6 +174,7 @@ class MovieDetailViewController: UIViewController {
         label.font = BODY_BOLD_FONT
         label.text = "상영시간"
         label.textAlignment = .center
+        label.numberOfLines = 0
         
         return label
     }()
@@ -206,6 +210,7 @@ class MovieDetailViewController: UIViewController {
         label.font = BODY_BOLD_FONT
         label.text = "관람 등급"
         label.textAlignment = .center
+        label.numberOfLines = 0
         
         return label
     }()
@@ -241,6 +246,7 @@ class MovieDetailViewController: UIViewController {
         label.font = BODY_BOLD_FONT
         label.text = "제작국가"
         label.textAlignment = .center
+        label.numberOfLines = 0
         
         return label
     }()
@@ -276,6 +282,7 @@ class MovieDetailViewController: UIViewController {
         label.font = BODY_BOLD_FONT
         label.text = "장르"
         label.textAlignment = .center
+        label.numberOfLines = 0
         
         return label
     }()
@@ -311,6 +318,7 @@ class MovieDetailViewController: UIViewController {
         label.font = BODY_BOLD_FONT
         label.text = "배우"
         label.textAlignment = .center
+        label.numberOfLines = 0
         
         return label
     }()
@@ -332,6 +340,7 @@ class MovieDetailViewController: UIViewController {
         setConstraints()
         configureUI()
         imageLoad()
+        setTitleLabelConstraints()
     }
     
     init(movieInformationDTO: MovieInformationDetailDTO) {
@@ -342,6 +351,22 @@ class MovieDetailViewController: UIViewController {
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    func setTitleLabelConstraints() {
+        let longestLabelSize = movieWatchGradeNameTitleLabel.intrinsicContentSize.width
+        
+        NSLayoutConstraint.activate([
+                movieDirectorTitleLabel.widthAnchor.constraint(equalToConstant: longestLabelSize),
+                movieProductYearTitleLabel.widthAnchor.constraint(equalToConstant: longestLabelSize),
+                movieOpenDateTitleLabel.widthAnchor.constraint(equalToConstant: longestLabelSize),
+                movieShowTimeTitleLabel.widthAnchor.constraint(equalToConstant: longestLabelSize),
+                movieWatchGradeNameTitleLabel.widthAnchor.constraint(equalToConstant: longestLabelSize),
+                movieNationNameTitleLabel.widthAnchor.constraint(equalToConstant: longestLabelSize),
+                movieGenreTitleLabel.widthAnchor.constraint(equalToConstant: longestLabelSize),
+                movieActorTitleLabel.widthAnchor.constraint(equalToConstant: longestLabelSize),
+            ]
+        )
     }
     
     func imageLoad() {
@@ -429,50 +454,52 @@ class MovieDetailViewController: UIViewController {
             movieDirectorStackView.leadingAnchor.constraint(equalTo: detailContentView.leadingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
             movieDirectorStackView.trailingAnchor.constraint(equalTo: detailContentView.trailingAnchor, constant: MovieDetailViewController.trailingPaddingConstant),
             
-            movieDirectorTitleLabel.widthAnchor.constraint(equalTo: movieDirectorStackView.widthAnchor, multiplier: MovieDetailViewController.titleMultiplierConstant),
+            
+//            preferredContentSize
+            //            movieDirectorTitleLabel.widthAnchor.constraint(equalTo: movieDirectorStackView.widthAnchor, multiplier: MovieDetailViewController.titleMultiplierConstant),
             
             movieProductYearStackView.topAnchor.constraint(equalTo: movieDirectorStackView.bottomAnchor, constant: MovieDetailViewController.gapPaddingConstant),
             movieProductYearStackView.leadingAnchor.constraint(equalTo: detailContentView.leadingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
             movieProductYearStackView.trailingAnchor.constraint(equalTo: detailContentView.trailingAnchor, constant: MovieDetailViewController.trailingPaddingConstant),
             
-            movieProductYearTitleLabel.widthAnchor.constraint(equalTo: movieProductYearStackView.widthAnchor, multiplier: MovieDetailViewController.titleMultiplierConstant),
+//            movieProductYearTitleLabel.widthAnchor.constraint(equalTo: movieProductYearStackView.widthAnchor, multiplier: MovieDetailViewController.titleMultiplierConstant),
             
             movieOpenDateStackView.topAnchor.constraint(equalTo: movieProductYearStackView.bottomAnchor, constant: MovieDetailViewController.gapPaddingConstant),
             movieOpenDateStackView.leadingAnchor.constraint(equalTo: detailContentView.leadingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
             movieOpenDateStackView.trailingAnchor.constraint(equalTo: detailContentView.trailingAnchor, constant: MovieDetailViewController.trailingPaddingConstant),
             
-            movieOpenDateTitleLabel.widthAnchor.constraint(equalTo: movieOpenDateStackView.widthAnchor, multiplier: MovieDetailViewController.titleMultiplierConstant),
+//            movieOpenDateTitleLabel.widthAnchor.constraint(equalTo: movieOpenDateStackView.widthAnchor, multiplier: MovieDetailViewController.titleMultiplierConstant),
             
             movieShowTimeStackView.topAnchor.constraint(equalTo: movieOpenDateStackView.bottomAnchor, constant: MovieDetailViewController.gapPaddingConstant),
             movieShowTimeStackView.leadingAnchor.constraint(equalTo: detailContentView.leadingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
             movieShowTimeStackView.trailingAnchor.constraint(equalTo: detailContentView.trailingAnchor, constant: MovieDetailViewController.trailingPaddingConstant),
             
-            movieShowTimeTitleLabel.widthAnchor.constraint(equalTo: movieShowTimeStackView.widthAnchor, multiplier: MovieDetailViewController.titleMultiplierConstant),
+//            movieShowTimeTitleLabel.widthAnchor.constraint(equalTo: movieShowTimeStackView.widthAnchor, multiplier: MovieDetailViewController.titleMultiplierConstant),
             
             movieWatchGradeNameStackView.topAnchor.constraint(equalTo: movieShowTimeStackView.bottomAnchor, constant: MovieDetailViewController.gapPaddingConstant),
             movieWatchGradeNameStackView.leadingAnchor.constraint(equalTo: detailContentView.leadingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
             movieWatchGradeNameStackView.trailingAnchor.constraint(equalTo: detailContentView.trailingAnchor, constant: MovieDetailViewController.trailingPaddingConstant),
             
-            movieWatchGradeNameTitleLabel.widthAnchor.constraint(equalTo: movieWatchGradeNameStackView.widthAnchor, multiplier: MovieDetailViewController.titleMultiplierConstant),
-            
+//            movieWatchGradeNameTitleLabel.widthAnchor.constraint(equalTo: movieWatchGradeNameStackView.widthAnchor, multiplier: MovieDetailViewController.titleMultiplierConstant),
+
             movieNationNameStackView.topAnchor.constraint(equalTo: movieWatchGradeNameStackView.bottomAnchor, constant: MovieDetailViewController.gapPaddingConstant),
             movieNationNameStackView.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
             movieNationNameStackView.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor, constant: MovieDetailViewController.trailingPaddingConstant),
             
-            movieNationNameTitleLabel.widthAnchor.constraint(equalTo: movieNationNameStackView.widthAnchor, multiplier: MovieDetailViewController.titleMultiplierConstant),
+//            movieNationNameTitleLabel.widthAnchor.constraint(equalTo: movieNationNameStackView.widthAnchor, multiplier: MovieDetailViewController.titleMultiplierConstant),
             
             movieGenreStackView.topAnchor.constraint(equalTo: movieNationNameStackView.bottomAnchor, constant: MovieDetailViewController.gapPaddingConstant),
             movieGenreStackView.leadingAnchor.constraint(equalTo: detailContentView.leadingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
             movieGenreStackView.trailingAnchor.constraint(equalTo: detailContentView.trailingAnchor, constant: MovieDetailViewController.trailingPaddingConstant),
             
-            movieGenreTitleLabel.widthAnchor.constraint(equalTo: movieGenreStackView.widthAnchor, multiplier: MovieDetailViewController.titleMultiplierConstant),
+//            movieGenreTitleLabel.widthAnchor.constraint(equalTo: movieGenreStackView.widthAnchor, multiplier: MovieDetailViewController.titleMultiplierConstant),
             
             movieActorStackView.topAnchor.constraint(equalTo: movieGenreStackView.bottomAnchor, constant: MovieDetailViewController.gapPaddingConstant),
             movieActorStackView.leadingAnchor.constraint(equalTo: detailContentView.leadingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
             movieActorStackView.trailingAnchor.constraint(equalTo: detailContentView.trailingAnchor, constant: MovieDetailViewController.trailingPaddingConstant),
             movieActorStackView.bottomAnchor.constraint(equalTo: detailContentView.bottomAnchor, constant: MovieDetailViewController.bottomPaddingConstant),
             
-            movieActorTitleLabel.widthAnchor.constraint(equalTo: movieActorStackView.widthAnchor, multiplier: MovieDetailViewController.titleMultiplierConstant),
+//            movieActorTitleLabel.widthAnchor.constraint(equalTo: movieActorStackView.widthAnchor, multiplier: MovieDetailViewController.titleMultiplierConstant),
         ])
     }
     

--- a/BoxOffice/ViewControllers/MovieDetailViewController.swift
+++ b/BoxOffice/ViewControllers/MovieDetailViewController.swift
@@ -352,7 +352,7 @@ class MovieDetailViewController: UIViewController {
         
         let movieName = movieInformationData.movieName
         
-        NetworkService().loadKakaoSearchAPI(searchType: KakaoSearchType.image, dataType: KakaoSearchData.self, searchOption: KakaoSearchOption(query: "\(movieName) 영화 포스터", page: 1, size: 1)) { result in
+        NetworkService.shared.loadKakaoSearchAPI(searchType: KakaoSearchType.image, dataType: KakaoSearchData.self, searchOption: KakaoSearchOption(query: "\(movieName) 영화 포스터", page: 1, size: 1)) { result in
             switch result {
             case .success(let data):
                 guard let firstDocument = data.documents?.first else {
@@ -450,8 +450,6 @@ class MovieDetailViewController: UIViewController {
             movieActorTitleLabel.leadingAnchor.constraint(equalTo: detailContentView.leadingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
             movieActorTitleLabel.bottomAnchor.constraint(equalTo: detailContentView.bottomAnchor, constant: MovieDetailViewController.bottomPaddingConstant),
             
-            
-            
             movieDirectorTitleLabel.trailingAnchor.constraint(equalTo: movieWatchGradeNameTitleLabel.trailingAnchor),
             movieProductYearTitleLabel.trailingAnchor.constraint(equalTo: movieWatchGradeNameTitleLabel.trailingAnchor),
             movieOpenDateTitleLabel.trailingAnchor.constraint(equalTo: movieWatchGradeNameTitleLabel.trailingAnchor),
@@ -459,8 +457,6 @@ class MovieDetailViewController: UIViewController {
             movieNationNameTitleLabel.trailingAnchor.constraint(equalTo: movieWatchGradeNameTitleLabel.trailingAnchor),
             movieGenreTitleLabel.trailingAnchor.constraint(equalTo: movieWatchGradeNameTitleLabel.trailingAnchor),
             movieActorTitleLabel.trailingAnchor.constraint(equalTo: movieWatchGradeNameTitleLabel.trailingAnchor),
-            
-            
             
             movieDirectorValueLabel.topAnchor.constraint(equalTo: movieDirectorTitleLabel.topAnchor),
             movieDirectorValueLabel.leadingAnchor.constraint(equalTo: movieDirectorTitleLabel.trailingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),

--- a/BoxOffice/ViewControllers/MovieDetailViewController.swift
+++ b/BoxOffice/ViewControllers/MovieDetailViewController.swift
@@ -52,7 +52,7 @@ class MovieDetailViewController: UIViewController {
     // MARK: - 감독
     let movieDirectorStackView: UIStackView = {
         let stackView = UIStackView()
-        
+
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .horizontal
         stackView.spacing = 10
@@ -382,7 +382,10 @@ class MovieDetailViewController: UIViewController {
                     }
                     
                     DispatchQueue.main.async {
-                        self.moviePosterImageView.image = UIImage(data: data)
+                        guard let image = UIImage(data: data) else { return }
+                        
+                        self.moviePosterImageView.image = image
+                        self.moviePosterImageView.heightAnchor.constraint(equalTo: self.moviePosterImageView.widthAnchor, multiplier: image.size.height / image.size.width).isActive = true
                     }
                 }
             } catch {
@@ -441,7 +444,6 @@ class MovieDetailViewController: UIViewController {
             
             moviePosterImageView.topAnchor.constraint(equalTo: detailContentView.topAnchor, constant: MovieDetailViewController.topPaddingConstant),
             moviePosterImageView.widthAnchor.constraint(equalTo: safeArea.widthAnchor, constant: MovieDetailViewController.trailingPaddingConstant * 2),
-            moviePosterImageView.heightAnchor.constraint(equalTo: safeArea.widthAnchor, constant: MovieDetailViewController.trailingPaddingConstant * 2),
             moviePosterImageView.leadingAnchor.constraint(equalTo: detailContentView.leadingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
             moviePosterImageView.trailingAnchor.constraint(equalTo: detailContentView.trailingAnchor, constant: MovieDetailViewController.trailingPaddingConstant),
             

--- a/BoxOffice/ViewControllers/MovieDetailViewController.swift
+++ b/BoxOffice/ViewControllers/MovieDetailViewController.swift
@@ -49,16 +49,6 @@ class MovieDetailViewController: UIViewController {
     }()
     
     // MARK: - 감독
-    let movieDirectorStackView: UIStackView = {
-        let stackView = UIStackView()
-        
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .horizontal
-        stackView.spacing = 10
-        
-        return stackView
-    }()
-    
     lazy var movieDirectorTitleLabel: UILabel = {
         let label = UILabel()
         
@@ -83,17 +73,6 @@ class MovieDetailViewController: UIViewController {
     }()
     
     // MARK: - 제작연도
-    
-    let movieProductYearStackView: UIStackView = {
-        let stackView = UIStackView()
-        
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .horizontal
-        stackView.spacing = 10
-        
-        return stackView
-    }()
-    
     lazy var movieProductYearTitleLabel: UILabel = {
         let label = UILabel()
         
@@ -118,17 +97,6 @@ class MovieDetailViewController: UIViewController {
     }()
     
     // MARK: - 개봉일
-    
-    let movieOpenDateStackView: UIStackView = {
-        let stackView = UIStackView()
-        
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .horizontal
-        stackView.spacing = 10
-        
-        return stackView
-    }()
-    
     lazy var movieOpenDateTitleLabel: UILabel = {
         let label = UILabel()
         
@@ -153,17 +121,6 @@ class MovieDetailViewController: UIViewController {
     }()
     
     // MARK: - 상영시간
-    
-    let movieShowTimeStackView: UIStackView = {
-        let stackView = UIStackView()
-        
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .horizontal
-        stackView.spacing = 10
-        
-        return stackView
-    }()
-    
     lazy var movieShowTimeTitleLabel: UILabel = {
         let label = UILabel()
         
@@ -188,17 +145,6 @@ class MovieDetailViewController: UIViewController {
     }()
     
     // MARK: - 관람 등급
-    
-    let movieWatchGradeNameStackView: UIStackView = {
-        let stackView = UIStackView()
-        
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .horizontal
-        stackView.spacing = 10
-        
-        return stackView
-    }()
-    
     lazy var movieWatchGradeNameTitleLabel: UILabel = {
         let label = UILabel()
         
@@ -223,17 +169,6 @@ class MovieDetailViewController: UIViewController {
     }()
     
     // MARK: - 제작국가
-    
-    let movieNationNameStackView: UIStackView = {
-        let stackView = UIStackView()
-        
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .horizontal
-        stackView.spacing = 10
-        
-        return stackView
-    }()
-    
     lazy var movieNationNameTitleLabel: UILabel = {
         let label = UILabel()
         
@@ -258,17 +193,6 @@ class MovieDetailViewController: UIViewController {
     }()
     
     // MARK: - 장르
-    
-    let movieGenreStackView: UIStackView = {
-        let stackView = UIStackView()
-        
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .horizontal
-        stackView.spacing = 10
-        
-        return stackView
-    }()
-    
     lazy var movieGenreTitleLabel: UILabel = {
         let label = UILabel()
         
@@ -293,17 +217,6 @@ class MovieDetailViewController: UIViewController {
     }()
     
     // MARK: - 배우
-    
-    let movieActorStackView: UIStackView = {
-        let stackView = UIStackView()
-        
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .horizontal
-        stackView.spacing = 10
-        
-        return stackView
-    }()
-    
     lazy var movieActorTitleLabel: UILabel = {
         let label = UILabel()
         

--- a/BoxOffice/ViewControllers/MovieDetailViewController.swift
+++ b/BoxOffice/ViewControllers/MovieDetailViewController.swift
@@ -15,7 +15,12 @@ class MovieDetailViewController: UIViewController {
     static let trailingPaddingConstant: CGFloat = -20
     static let gapPaddingConstant: CGFloat = 10
     static let titleMultiplierConstant: CGFloat = 0.2
-    static let movieDetailLabelSize: CGFloat = 16
+    
+    final let BODYFONT: UIFont = .preferredFont(forTextStyle: .body)
+    final let TITLEFONT: UIFont = UIFont(descriptor:
+                                    UIFontDescriptor.preferredFontDescriptor(withTextStyle: .body).withSymbolicTraits(.traitBold)!,
+                                   size: 0.0)
+    
     
     var movieInformation: MovieInformation? = nil
     
@@ -57,22 +62,24 @@ class MovieDetailViewController: UIViewController {
         return stackView
     }()
     
-    let movieDirectorTitleLabel: UILabel = {
+    lazy var movieDirectorTitleLabel: UILabel = {
         let label = UILabel()
         
+        label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = .boldSystemFont(ofSize: MovieDetailViewController.movieDetailLabelSize)
+        label.font = TITLEFONT
         label.text = "감독"
         label.textAlignment = .center
         
         return label
     }()
     
-    let movieDirectorValueLabel: UILabel = {
+    lazy var movieDirectorValueLabel: UILabel = {
         let label = UILabel()
         
+        label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = UIFont.systemFont(ofSize: MovieDetailViewController.movieDetailLabelSize)
+        label.font = BODYFONT
         label.numberOfLines = 0
         
         return label
@@ -90,22 +97,24 @@ class MovieDetailViewController: UIViewController {
         return stackView
     }()
     
-    let movieProductYearTitleLabel: UILabel = {
+    lazy var movieProductYearTitleLabel: UILabel = {
         let label = UILabel()
         
+        label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = .boldSystemFont(ofSize: MovieDetailViewController.movieDetailLabelSize)
+        label.font = TITLEFONT
         label.text = "제작연도"
         label.textAlignment = .center
         
         return label
     }()
     
-    let movieProductYearValueLabel: UILabel = {
+    lazy var movieProductYearValueLabel: UILabel = {
         let label = UILabel()
         
+        label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = UIFont.systemFont(ofSize: MovieDetailViewController.movieDetailLabelSize)
+        label.font = BODYFONT
         label.numberOfLines = 0
         
         return label
@@ -123,22 +132,24 @@ class MovieDetailViewController: UIViewController {
         return stackView
     }()
     
-    let movieOpenDateTitleLabel: UILabel = {
+    lazy var movieOpenDateTitleLabel: UILabel = {
         let label = UILabel()
         
+        label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = .boldSystemFont(ofSize: MovieDetailViewController.movieDetailLabelSize)
+        label.font = TITLEFONT
         label.text = "개봉일"
         label.textAlignment = .center
         
         return label
     }()
     
-    let movieOpenDateValueLabel: UILabel = {
+    lazy var movieOpenDateValueLabel: UILabel = {
         let label = UILabel()
         
+        label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = UIFont.systemFont(ofSize: MovieDetailViewController.movieDetailLabelSize)
+        label.font = BODYFONT
         label.numberOfLines = 0
         
         return label
@@ -156,22 +167,24 @@ class MovieDetailViewController: UIViewController {
         return stackView
     }()
     
-    let movieShowTimeTitleLabel: UILabel = {
+    lazy var movieShowTimeTitleLabel: UILabel = {
         let label = UILabel()
         
+        label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = .boldSystemFont(ofSize: MovieDetailViewController.movieDetailLabelSize)
+        label.font = TITLEFONT
         label.text = "상영시간"
         label.textAlignment = .center
         
         return label
     }()
     
-    let movieShowTimeValueLabel: UILabel = {
+    lazy var movieShowTimeValueLabel: UILabel = {
         let label = UILabel()
         
+        label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = UIFont.systemFont(ofSize: MovieDetailViewController.movieDetailLabelSize)
+        label.font = BODYFONT
         label.numberOfLines = 0
         
         return label
@@ -189,22 +202,24 @@ class MovieDetailViewController: UIViewController {
         return stackView
     }()
     
-    let movieWatchGradeNameTitleLabel: UILabel = {
+    lazy var movieWatchGradeNameTitleLabel: UILabel = {
         let label = UILabel()
         
+        label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = .boldSystemFont(ofSize: MovieDetailViewController.movieDetailLabelSize)
+        label.font = TITLEFONT
         label.text = "관람 등급"
         label.textAlignment = .center
         
         return label
     }()
     
-    let movieWatchGradeNameValueLabel: UILabel = {
+    lazy var movieWatchGradeNameValueLabel: UILabel = {
         let label = UILabel()
         
+        label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = UIFont.systemFont(ofSize: MovieDetailViewController.movieDetailLabelSize)
+        label.font = BODYFONT
         label.numberOfLines = 0
         
         return label
@@ -222,22 +237,24 @@ class MovieDetailViewController: UIViewController {
         return stackView
     }()
     
-    let movieNationNameTitleLabel: UILabel = {
+    lazy var movieNationNameTitleLabel: UILabel = {
         let label = UILabel()
         
+        label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = .boldSystemFont(ofSize: MovieDetailViewController.movieDetailLabelSize)
+        label.font = TITLEFONT
         label.text = "제작국가"
         label.textAlignment = .center
         
         return label
     }()
     
-    let movieNationNameValueLabel: UILabel = {
+    lazy var movieNationNameValueLabel: UILabel = {
         let label = UILabel()
         
+        label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = UIFont.systemFont(ofSize: MovieDetailViewController.movieDetailLabelSize)
+        label.font = BODYFONT
         label.numberOfLines = 0
         
         return label
@@ -255,22 +272,24 @@ class MovieDetailViewController: UIViewController {
         return stackView
     }()
     
-    let movieGenreTitleLabel: UILabel = {
+    lazy var movieGenreTitleLabel: UILabel = {
         let label = UILabel()
         
+        label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = .boldSystemFont(ofSize: MovieDetailViewController.movieDetailLabelSize)
+        label.font = TITLEFONT
         label.text = "장르"
         label.textAlignment = .center
         
         return label
     }()
     
-    let movieGenreValueLabel: UILabel = {
+    lazy var movieGenreValueLabel: UILabel = {
         let label = UILabel()
         
+        label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = UIFont.systemFont(ofSize: MovieDetailViewController.movieDetailLabelSize)
+        label.font = BODYFONT
         label.numberOfLines = 0
         
         return label
@@ -288,22 +307,24 @@ class MovieDetailViewController: UIViewController {
         return stackView
     }()
     
-    let movieActorTitleLabel: UILabel = {
+    lazy var movieActorTitleLabel: UILabel = {
         let label = UILabel()
         
+        label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = .boldSystemFont(ofSize: MovieDetailViewController.movieDetailLabelSize)
+        label.font = TITLEFONT
         label.text = "배우"
         label.textAlignment = .center
         
         return label
     }()
     
-    let movieActorValueLabel: UILabel = {
+    lazy var movieActorValueLabel: UILabel = {
         let label = UILabel()
         
+        label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = UIFont.systemFont(ofSize: MovieDetailViewController.movieDetailLabelSize)
+        label.font = BODYFONT
         label.numberOfLines = 0
         
         return label

--- a/BoxOffice/ViewControllers/MovieDetailViewController.swift
+++ b/BoxOffice/ViewControllers/MovieDetailViewController.swift
@@ -16,10 +16,8 @@ class MovieDetailViewController: UIViewController {
     static let gapPaddingConstant: CGFloat = 10
     static let titleMultiplierConstant: CGFloat = 0.2
     
-    final let BODYFONT: UIFont = .preferredFont(forTextStyle: .body)
-    final let TITLEFONT: UIFont = UIFont(descriptor:
-                                    UIFontDescriptor.preferredFontDescriptor(withTextStyle: .body).withSymbolicTraits(.traitBold)!,
-                                   size: 0.0)
+    final let BODY_FONT: UIFont = FontConstants.BODY
+    final let BODY_BOLD_FONT: UIFont = FontConstants.BODY_BOLD
     
     
     var movieInformation: MovieInformation? = nil
@@ -67,7 +65,7 @@ class MovieDetailViewController: UIViewController {
         
         label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = TITLEFONT
+        label.font = BODY_BOLD_FONT
         label.text = "감독"
         label.textAlignment = .center
         
@@ -79,7 +77,7 @@ class MovieDetailViewController: UIViewController {
         
         label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = BODYFONT
+        label.font = BODY_FONT
         label.numberOfLines = 0
         
         return label
@@ -102,7 +100,7 @@ class MovieDetailViewController: UIViewController {
         
         label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = TITLEFONT
+        label.font = BODY_BOLD_FONT
         label.text = "제작연도"
         label.textAlignment = .center
         
@@ -114,7 +112,7 @@ class MovieDetailViewController: UIViewController {
         
         label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = BODYFONT
+        label.font = BODY_FONT
         label.numberOfLines = 0
         
         return label
@@ -137,7 +135,7 @@ class MovieDetailViewController: UIViewController {
         
         label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = TITLEFONT
+        label.font = BODY_BOLD_FONT
         label.text = "개봉일"
         label.textAlignment = .center
         
@@ -149,7 +147,7 @@ class MovieDetailViewController: UIViewController {
         
         label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = BODYFONT
+        label.font = BODY_FONT
         label.numberOfLines = 0
         
         return label
@@ -172,7 +170,7 @@ class MovieDetailViewController: UIViewController {
         
         label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = TITLEFONT
+        label.font = BODY_BOLD_FONT
         label.text = "상영시간"
         label.textAlignment = .center
         
@@ -184,7 +182,7 @@ class MovieDetailViewController: UIViewController {
         
         label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = BODYFONT
+        label.font = BODY_FONT
         label.numberOfLines = 0
         
         return label
@@ -207,7 +205,7 @@ class MovieDetailViewController: UIViewController {
         
         label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = TITLEFONT
+        label.font = BODY_BOLD_FONT
         label.text = "관람 등급"
         label.textAlignment = .center
         
@@ -219,7 +217,7 @@ class MovieDetailViewController: UIViewController {
         
         label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = BODYFONT
+        label.font = BODY_FONT
         label.numberOfLines = 0
         
         return label
@@ -242,7 +240,7 @@ class MovieDetailViewController: UIViewController {
         
         label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = TITLEFONT
+        label.font = BODY_BOLD_FONT
         label.text = "제작국가"
         label.textAlignment = .center
         
@@ -254,7 +252,7 @@ class MovieDetailViewController: UIViewController {
         
         label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = BODYFONT
+        label.font = BODY_FONT
         label.numberOfLines = 0
         
         return label
@@ -277,7 +275,7 @@ class MovieDetailViewController: UIViewController {
         
         label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = TITLEFONT
+        label.font = BODY_BOLD_FONT
         label.text = "장르"
         label.textAlignment = .center
         
@@ -289,7 +287,7 @@ class MovieDetailViewController: UIViewController {
         
         label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = BODYFONT
+        label.font = BODY_FONT
         label.numberOfLines = 0
         
         return label
@@ -312,7 +310,7 @@ class MovieDetailViewController: UIViewController {
         
         label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = TITLEFONT
+        label.font = BODY_BOLD_FONT
         label.text = "배우"
         label.textAlignment = .center
         
@@ -324,7 +322,7 @@ class MovieDetailViewController: UIViewController {
         
         label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = BODYFONT
+        label.font = BODY_FONT
         label.numberOfLines = 0
         
         return label

--- a/BoxOffice/ViewControllers/MovieDetailViewController.swift
+++ b/BoxOffice/ViewControllers/MovieDetailViewController.swift
@@ -509,7 +509,7 @@ class MovieDetailViewController: UIViewController {
         
         movieDirectorValueLabel.text = "\(movieInformationData.directors.map { $0.peopleName }.joined(separator: ", "))"
         movieProductYearValueLabel.text = "\(movieInformationData.productYear)"
-        movieOpenDateValueLabel.text = "\(movieInformationData.openDate)"
+        movieOpenDateValueLabel.text = "\(movieInformationData.openDate.formatDate())"
         movieShowTimeValueLabel.text = "\(movieInformationData.showTime)"
         movieWatchGradeNameValueLabel.text = "\(movieInformationData.audits.map { $0.watchGradeName }.joined(separator: ", "))"
         movieNationNameValueLabel.text = "\(movieInformationData.nations.map { $0.nationName }.joined(separator: ", "))"

--- a/BoxOffice/ViewControllers/MovieDetailViewController.swift
+++ b/BoxOffice/ViewControllers/MovieDetailViewController.swift
@@ -1,0 +1,507 @@
+//
+//  MovieDetailViewController.swift
+//  BoxOffice
+//
+//  Created by Danny, Diana, gama on 4/22/24.
+//
+
+import UIKit
+
+class MovieDetailViewController: UIViewController {
+    
+    static let topPaddingConstant: CGFloat = 20
+    static let bottomPaddingConstant: CGFloat = -20
+    static let leadingPaddingConstant: CGFloat = 20
+    static let trailingPaddingConstant: CGFloat = -20
+    static let gapPaddingConstant: CGFloat = 10
+    static let titleMultiplierConstant: CGFloat = 0.2
+    static let movieDetailLabelSize: CGFloat = 16
+    
+    var movieInformation: MovieInformation? = nil
+    
+    let detailScrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.backgroundColor = .white
+        
+        return scrollView
+    }()
+    
+    let detailContentView: UIView = {
+        let view = UIView()
+        
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = .white
+        
+        return view
+    }()
+    
+    let moviePosterImageView: UIImageView = {
+        let imageView = UIImageView()
+        
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.contentMode = .scaleAspectFit
+        
+        return imageView
+    }()
+    
+    // MARK: - 감독
+    let movieDirectorStackView: UIStackView = {
+        let stackView = UIStackView()
+        
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.spacing = 10
+        
+        return stackView
+    }()
+    
+    let movieDirectorTitleLabel: UILabel = {
+        let label = UILabel()
+        
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = .boldSystemFont(ofSize: MovieDetailViewController.movieDetailLabelSize)
+        label.text = "감독"
+        label.textAlignment = .center
+        
+        return label
+    }()
+    
+    let movieDirectorValueLabel: UILabel = {
+        let label = UILabel()
+        
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = UIFont.systemFont(ofSize: MovieDetailViewController.movieDetailLabelSize)
+        label.numberOfLines = 0
+        
+        return label
+    }()
+    
+    // MARK: - 제작연도
+    
+    let movieProductYearStackView: UIStackView = {
+        let stackView = UIStackView()
+        
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.spacing = 10
+        
+        return stackView
+    }()
+    
+    let movieProductYearTitleLabel: UILabel = {
+        let label = UILabel()
+        
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = .boldSystemFont(ofSize: MovieDetailViewController.movieDetailLabelSize)
+        label.text = "제작연도"
+        label.textAlignment = .center
+        
+        return label
+    }()
+    
+    let movieProductYearValueLabel: UILabel = {
+        let label = UILabel()
+        
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = UIFont.systemFont(ofSize: MovieDetailViewController.movieDetailLabelSize)
+        label.numberOfLines = 0
+        
+        return label
+    }()
+    
+    // MARK: - 개봉일
+    
+    let movieOpenDateStackView: UIStackView = {
+        let stackView = UIStackView()
+        
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.spacing = 10
+        
+        return stackView
+    }()
+    
+    let movieOpenDateTitleLabel: UILabel = {
+        let label = UILabel()
+        
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = .boldSystemFont(ofSize: MovieDetailViewController.movieDetailLabelSize)
+        label.text = "개봉일"
+        label.textAlignment = .center
+        
+        return label
+    }()
+    
+    let movieOpenDateValueLabel: UILabel = {
+        let label = UILabel()
+        
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = UIFont.systemFont(ofSize: MovieDetailViewController.movieDetailLabelSize)
+        label.numberOfLines = 0
+        
+        return label
+    }()
+    
+    // MARK: - 상영시간
+    
+    let movieShowTimeStackView: UIStackView = {
+        let stackView = UIStackView()
+        
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.spacing = 10
+        
+        return stackView
+    }()
+    
+    let movieShowTimeTitleLabel: UILabel = {
+        let label = UILabel()
+        
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = .boldSystemFont(ofSize: MovieDetailViewController.movieDetailLabelSize)
+        label.text = "상영시간"
+        label.textAlignment = .center
+        
+        return label
+    }()
+    
+    let movieShowTimeValueLabel: UILabel = {
+        let label = UILabel()
+        
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = UIFont.systemFont(ofSize: MovieDetailViewController.movieDetailLabelSize)
+        label.numberOfLines = 0
+        
+        return label
+    }()
+    
+    // MARK: - 관람 등급
+    
+    let movieWatchGradeNameStackView: UIStackView = {
+        let stackView = UIStackView()
+        
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.spacing = 10
+        
+        return stackView
+    }()
+    
+    let movieWatchGradeNameTitleLabel: UILabel = {
+        let label = UILabel()
+        
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = .boldSystemFont(ofSize: MovieDetailViewController.movieDetailLabelSize)
+        label.text = "관람 등급"
+        label.textAlignment = .center
+        
+        return label
+    }()
+    
+    let movieWatchGradeNameValueLabel: UILabel = {
+        let label = UILabel()
+        
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = UIFont.systemFont(ofSize: MovieDetailViewController.movieDetailLabelSize)
+        label.numberOfLines = 0
+        
+        return label
+    }()
+    
+    // MARK: - 제작국가
+    
+    let movieNationNameStackView: UIStackView = {
+        let stackView = UIStackView()
+        
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.spacing = 10
+        
+        return stackView
+    }()
+    
+    let movieNationNameTitleLabel: UILabel = {
+        let label = UILabel()
+        
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = .boldSystemFont(ofSize: MovieDetailViewController.movieDetailLabelSize)
+        label.text = "제작국가"
+        label.textAlignment = .center
+        
+        return label
+    }()
+    
+    let movieNationNameValueLabel: UILabel = {
+        let label = UILabel()
+        
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = UIFont.systemFont(ofSize: MovieDetailViewController.movieDetailLabelSize)
+        label.numberOfLines = 0
+        
+        return label
+    }()
+    
+    // MARK: - 장르
+    
+    let movieGenreStackView: UIStackView = {
+        let stackView = UIStackView()
+        
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.spacing = 10
+        
+        return stackView
+    }()
+    
+    let movieGenreTitleLabel: UILabel = {
+        let label = UILabel()
+        
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = .boldSystemFont(ofSize: MovieDetailViewController.movieDetailLabelSize)
+        label.text = "장르"
+        label.textAlignment = .center
+        
+        return label
+    }()
+    
+    let movieGenreValueLabel: UILabel = {
+        let label = UILabel()
+        
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = UIFont.systemFont(ofSize: MovieDetailViewController.movieDetailLabelSize)
+        label.numberOfLines = 0
+        
+        return label
+    }()
+    
+    // MARK: - 배우
+    
+    let movieActorStackView: UIStackView = {
+        let stackView = UIStackView()
+        
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.spacing = 10
+        
+        return stackView
+    }()
+    
+    let movieActorTitleLabel: UILabel = {
+        let label = UILabel()
+        
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = .boldSystemFont(ofSize: MovieDetailViewController.movieDetailLabelSize)
+        label.text = "배우"
+        label.textAlignment = .center
+        
+        return label
+    }()
+    
+    let movieActorValueLabel: UILabel = {
+        let label = UILabel()
+        
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = UIFont.systemFont(ofSize: MovieDetailViewController.movieDetailLabelSize)
+        label.numberOfLines = 0
+        
+        return label
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setConstraints()
+        configureUI()
+        imageLoad()
+    }
+    
+    init(movieInformation: MovieInformation) {
+        self.movieInformation = movieInformation
+        
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func imageLoad() {
+        guard let movieName = movieInformation?.movieInformationResult.movieInformation.movieName else {
+            return
+        }
+        
+        guard let url = URL(string: "https://dapi.kakao.com/v2/search/image?query=\(movieName) 영화 포스터&page=1&size=1") else {
+            return
+        }
+        
+        var urlRequest = URLRequest(url: url)
+        
+        urlRequest.httpMethod = "GET" // 요청에 사용할 HTTP 메서드 설정
+        
+        urlRequest.setValue("KakaoAK \(URLs.kakaoApiKey)", forHTTPHeaderField: "Authorization") // HTTP 헤더 설정
+        
+        let task = URLSession.shared.dataTask(with: urlRequest) { data, response, error in
+            if let error = error {
+                print("URLSession Error")
+                return
+            }
+            
+            guard let data = data, let response = response as? HTTPURLResponse else {
+                print("Empty Data")
+                return
+            }
+            
+            do {
+                let jsonData = try JSONDecoder().decode(KakaoSearchData.self, from: data)
+                
+                DispatchQueue.global().async {
+                    guard let document = jsonData.documents.first, let url = URL(string: document.imageURL), let data = try? Data(contentsOf: url) else {
+                        print("Empty Document")
+                        return
+                    }
+                    
+                    DispatchQueue.main.async {
+                        self.moviePosterImageView.image = UIImage(data: data)
+                    }
+                }
+            } catch {
+                print("Error parsing JSON response")
+            }
+        }
+        
+        task.resume()
+    }
+    
+    func setConstraints() {
+        view.addSubview(detailScrollView)
+        detailScrollView.addSubview(detailContentView)
+        
+        [moviePosterImageView, movieDirectorStackView, movieProductYearStackView, movieOpenDateStackView, movieShowTimeStackView, movieWatchGradeNameStackView, movieNationNameStackView, movieGenreStackView, movieActorStackView].forEach {
+            detailContentView.addSubview($0)
+        }
+        
+        movieDirectorStackView.addArrangedSubview(movieDirectorTitleLabel)
+        movieDirectorStackView.addArrangedSubview(movieDirectorValueLabel)
+        
+        movieProductYearStackView.addArrangedSubview(movieProductYearTitleLabel)
+        movieProductYearStackView.addArrangedSubview(movieProductYearValueLabel)
+        
+        movieOpenDateStackView.addArrangedSubview(movieOpenDateTitleLabel)
+        movieOpenDateStackView.addArrangedSubview(movieOpenDateValueLabel)
+        
+        movieShowTimeStackView.addArrangedSubview(movieShowTimeTitleLabel)
+        movieShowTimeStackView.addArrangedSubview(movieShowTimeValueLabel)
+        
+        movieWatchGradeNameStackView.addArrangedSubview(movieWatchGradeNameTitleLabel)
+        movieWatchGradeNameStackView.addArrangedSubview(movieWatchGradeNameValueLabel)
+        
+        movieNationNameStackView.addArrangedSubview(movieNationNameTitleLabel)
+        movieNationNameStackView.addArrangedSubview(movieNationNameValueLabel)
+        
+        movieGenreStackView.addArrangedSubview(movieGenreTitleLabel)
+        movieGenreStackView.addArrangedSubview(movieGenreValueLabel)
+        
+        movieActorStackView.addArrangedSubview(movieActorTitleLabel)
+        movieActorStackView.addArrangedSubview(movieActorValueLabel)
+        
+        let safeArea = view.safeAreaLayoutGuide
+        
+        NSLayoutConstraint.activate([
+            detailScrollView.topAnchor.constraint(equalTo: safeArea.topAnchor),
+            detailScrollView.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor),
+            detailScrollView.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor),
+            detailScrollView.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor),
+            
+            detailContentView.widthAnchor.constraint(equalTo: detailScrollView.widthAnchor),
+            detailContentView.topAnchor.constraint(equalTo: detailScrollView.contentLayoutGuide.topAnchor),
+            detailContentView.bottomAnchor.constraint(equalTo: detailScrollView.contentLayoutGuide.bottomAnchor),
+            detailContentView.leadingAnchor.constraint(equalTo: detailScrollView.contentLayoutGuide.leadingAnchor),
+            detailContentView.trailingAnchor.constraint(equalTo: detailScrollView.contentLayoutGuide.trailingAnchor),
+            
+            moviePosterImageView.topAnchor.constraint(equalTo: detailContentView.topAnchor, constant: MovieDetailViewController.topPaddingConstant),
+            moviePosterImageView.widthAnchor.constraint(equalTo: safeArea.widthAnchor, constant: MovieDetailViewController.trailingPaddingConstant * 2),
+            moviePosterImageView.heightAnchor.constraint(equalTo: safeArea.widthAnchor, constant: MovieDetailViewController.trailingPaddingConstant * 2),
+            moviePosterImageView.leadingAnchor.constraint(equalTo: detailContentView.leadingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
+            moviePosterImageView.trailingAnchor.constraint(equalTo: detailContentView.trailingAnchor, constant: MovieDetailViewController.trailingPaddingConstant),
+            
+            movieDirectorStackView.topAnchor.constraint(equalTo: moviePosterImageView.bottomAnchor, constant: MovieDetailViewController.topPaddingConstant),
+            movieDirectorStackView.leadingAnchor.constraint(equalTo: detailContentView.leadingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
+            movieDirectorStackView.trailingAnchor.constraint(equalTo: detailContentView.trailingAnchor, constant: MovieDetailViewController.trailingPaddingConstant),
+            
+            movieDirectorTitleLabel.widthAnchor.constraint(equalTo: movieDirectorStackView.widthAnchor, multiplier: MovieDetailViewController.titleMultiplierConstant),
+            
+            movieProductYearStackView.topAnchor.constraint(equalTo: movieDirectorStackView.bottomAnchor, constant: MovieDetailViewController.gapPaddingConstant),
+            movieProductYearStackView.leadingAnchor.constraint(equalTo: detailContentView.leadingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
+            movieProductYearStackView.trailingAnchor.constraint(equalTo: detailContentView.trailingAnchor, constant: MovieDetailViewController.trailingPaddingConstant),
+            
+            movieProductYearTitleLabel.widthAnchor.constraint(equalTo: movieProductYearStackView.widthAnchor, multiplier: MovieDetailViewController.titleMultiplierConstant),
+            
+            movieOpenDateStackView.topAnchor.constraint(equalTo: movieProductYearStackView.bottomAnchor, constant: MovieDetailViewController.gapPaddingConstant),
+            movieOpenDateStackView.leadingAnchor.constraint(equalTo: detailContentView.leadingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
+            movieOpenDateStackView.trailingAnchor.constraint(equalTo: detailContentView.trailingAnchor, constant: MovieDetailViewController.trailingPaddingConstant),
+            
+            movieOpenDateTitleLabel.widthAnchor.constraint(equalTo: movieOpenDateStackView.widthAnchor, multiplier: MovieDetailViewController.titleMultiplierConstant),
+            
+            movieShowTimeStackView.topAnchor.constraint(equalTo: movieOpenDateStackView.bottomAnchor, constant: MovieDetailViewController.gapPaddingConstant),
+            movieShowTimeStackView.leadingAnchor.constraint(equalTo: detailContentView.leadingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
+            movieShowTimeStackView.trailingAnchor.constraint(equalTo: detailContentView.trailingAnchor, constant: MovieDetailViewController.trailingPaddingConstant),
+            
+            movieShowTimeTitleLabel.widthAnchor.constraint(equalTo: movieShowTimeStackView.widthAnchor, multiplier: MovieDetailViewController.titleMultiplierConstant),
+            
+            movieWatchGradeNameStackView.topAnchor.constraint(equalTo: movieShowTimeStackView.bottomAnchor, constant: MovieDetailViewController.gapPaddingConstant),
+            movieWatchGradeNameStackView.leadingAnchor.constraint(equalTo: detailContentView.leadingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
+            movieWatchGradeNameStackView.trailingAnchor.constraint(equalTo: detailContentView.trailingAnchor, constant: MovieDetailViewController.trailingPaddingConstant),
+            
+            movieWatchGradeNameTitleLabel.widthAnchor.constraint(equalTo: movieWatchGradeNameStackView.widthAnchor, multiplier: MovieDetailViewController.titleMultiplierConstant),
+            
+            movieNationNameStackView.topAnchor.constraint(equalTo: movieWatchGradeNameStackView.bottomAnchor, constant: MovieDetailViewController.gapPaddingConstant),
+            movieNationNameStackView.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
+            movieNationNameStackView.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor, constant: MovieDetailViewController.trailingPaddingConstant),
+            
+            movieNationNameTitleLabel.widthAnchor.constraint(equalTo: movieNationNameStackView.widthAnchor, multiplier: MovieDetailViewController.titleMultiplierConstant),
+            
+            movieGenreStackView.topAnchor.constraint(equalTo: movieNationNameStackView.bottomAnchor, constant: MovieDetailViewController.gapPaddingConstant),
+            movieGenreStackView.leadingAnchor.constraint(equalTo: detailContentView.leadingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
+            movieGenreStackView.trailingAnchor.constraint(equalTo: detailContentView.trailingAnchor, constant: MovieDetailViewController.trailingPaddingConstant),
+            
+            movieGenreTitleLabel.widthAnchor.constraint(equalTo: movieGenreStackView.widthAnchor, multiplier: MovieDetailViewController.titleMultiplierConstant),
+            
+            movieActorStackView.topAnchor.constraint(equalTo: movieGenreStackView.bottomAnchor, constant: MovieDetailViewController.gapPaddingConstant),
+            movieActorStackView.leadingAnchor.constraint(equalTo: detailContentView.leadingAnchor, constant: MovieDetailViewController.leadingPaddingConstant),
+            movieActorStackView.trailingAnchor.constraint(equalTo: detailContentView.trailingAnchor, constant: MovieDetailViewController.trailingPaddingConstant),
+            movieActorStackView.bottomAnchor.constraint(equalTo: detailContentView.bottomAnchor, constant: MovieDetailViewController.bottomPaddingConstant),
+            
+            movieActorTitleLabel.widthAnchor.constraint(equalTo: movieActorStackView.widthAnchor, multiplier: MovieDetailViewController.titleMultiplierConstant),
+        ])
+    }
+    
+    func configureUI() {
+        guard let movieInformation = movieInformation?.movieInformationResult.movieInformation else {
+            return
+        }
+        
+        self.navigationItem.title = movieInformation.movieName
+        
+        guard let movieInformationDirectors = movieInformation.directors,
+              let movieInformationProductYear = movieInformation.productYear,
+              let movieInformationOpenDate = movieInformation.openDate,
+              let movieInformationShowTime = movieInformation.showTime,
+              let movieInformationAudits = movieInformation.audits,
+              let movieInformationNations = movieInformation.nations,
+              let movieInformationGenres = movieInformation.genres,
+              let movieInformationActors = movieInformation.actors else {
+            return
+        }
+        
+        movieDirectorValueLabel.text = "\(movieInformationDirectors.map { $0.peopleName }.joined(separator: ", "))"
+        movieProductYearValueLabel.text = "\(movieInformationProductYear)"
+        movieOpenDateValueLabel.text = "\(movieInformationOpenDate)"
+        movieShowTimeValueLabel.text = "\(movieInformationShowTime)"
+        movieWatchGradeNameValueLabel.text = "\(movieInformationAudits.map { $0.watchGradeName }.joined(separator: ", "))"
+        movieNationNameValueLabel.text = "\(movieInformationNations.map { $0.nationName }.joined(separator: ", "))"
+        movieGenreValueLabel.text = "\(movieInformationGenres.map { $0.genreName }.joined(separator: ", "))"
+        movieActorValueLabel.text = "\(movieInformationActors.map { $0.peopleName }.joined(separator: ", "))"
+    }
+}

--- a/BoxOffice/ViewControllers/MovieDetailViewController.swift
+++ b/BoxOffice/ViewControllers/MovieDetailViewController.swift
@@ -18,7 +18,7 @@ class MovieDetailViewController: UIViewController {
     final let BODY_FONT: UIFont = FontConstants.BODY
     final let BODY_BOLD_FONT: UIFont = FontConstants.BODY_BOLD
     
-    var movieInformation: MovieInformation? = nil
+    var movieInformationData: MovieInformationDetailDTO? = nil
     
     let detailScrollView: UIScrollView = {
         let scrollView = UIScrollView()
@@ -334,8 +334,8 @@ class MovieDetailViewController: UIViewController {
         imageLoad()
     }
     
-    init(movieInformation: MovieInformation) {
-        self.movieInformation = movieInformation
+    init(movieInformationDTO: MovieInformationDetailDTO) {
+        movieInformationData = movieInformationDTO
         
         super.init(nibName: nil, bundle: nil)
     }
@@ -345,9 +345,11 @@ class MovieDetailViewController: UIViewController {
     }
     
     func imageLoad() {
-        guard let movieName = movieInformation?.movieInformationResult.movieInformation.movieName else {
+        guard let movieInformationData = movieInformationData else {
             return
         }
+        
+        let movieName = movieInformationData.movieName
         
         NetworkService().loadKakaoSearchAPI(searchType: KakaoSearchType.image, dataType: KakaoSearchData.self, searchOption: KakaoSearchOption(query: "\(movieName) 영화 포스터", page: 1, size: 1)) { result in
             switch result {
@@ -475,30 +477,19 @@ class MovieDetailViewController: UIViewController {
     }
     
     func configureUI() {
-        guard let movieInformation = movieInformation?.movieInformationResult.movieInformation else {
+        guard let movieInformationData = movieInformationData else {
             return
         }
         
-        self.navigationItem.title = movieInformation.movieName
+        navigationItem.title = movieInformationData.movieName
         
-        guard let movieInformationDirectors = movieInformation.directors,
-              let movieInformationProductYear = movieInformation.productYear,
-              let movieInformationOpenDate = movieInformation.openDate,
-              let movieInformationShowTime = movieInformation.showTime,
-              let movieInformationAudits = movieInformation.audits,
-              let movieInformationNations = movieInformation.nations,
-              let movieInformationGenres = movieInformation.genres,
-              let movieInformationActors = movieInformation.actors else {
-            return
-        }
-        
-        movieDirectorValueLabel.text = "\(movieInformationDirectors.map { $0.peopleName }.joined(separator: ", "))"
-        movieProductYearValueLabel.text = "\(movieInformationProductYear)"
-        movieOpenDateValueLabel.text = "\(movieInformationOpenDate)"
-        movieShowTimeValueLabel.text = "\(movieInformationShowTime)"
-        movieWatchGradeNameValueLabel.text = "\(movieInformationAudits.map { $0.watchGradeName }.joined(separator: ", "))"
-        movieNationNameValueLabel.text = "\(movieInformationNations.map { $0.nationName }.joined(separator: ", "))"
-        movieGenreValueLabel.text = "\(movieInformationGenres.map { $0.genreName }.joined(separator: ", "))"
-        movieActorValueLabel.text = "\(movieInformationActors.map { $0.peopleName }.joined(separator: ", "))"
+        movieDirectorValueLabel.text = "\(movieInformationData.directors.map { $0.peopleName }.joined(separator: ", "))"
+        movieProductYearValueLabel.text = "\(movieInformationData.productYear)"
+        movieOpenDateValueLabel.text = "\(movieInformationData.openDate)"
+        movieShowTimeValueLabel.text = "\(movieInformationData.showTime)"
+        movieWatchGradeNameValueLabel.text = "\(movieInformationData.audits.map { $0.watchGradeName }.joined(separator: ", "))"
+        movieNationNameValueLabel.text = "\(movieInformationData.nations.map { $0.nationName }.joined(separator: ", "))"
+        movieGenreValueLabel.text = "\(movieInformationData.genres.map { $0.genreName }.joined(separator: ", "))"
+        movieActorValueLabel.text = "\(movieInformationData.actors.map { $0.peopleName }.joined(separator: ", "))"
     }
 }

--- a/BoxOffice/ViewControllers/ViewController.swift
+++ b/BoxOffice/ViewControllers/ViewController.swift
@@ -70,7 +70,11 @@ class ViewController: UIViewController {
         NetworkService().startLoad(url: url, type: BoxOffice.self) { result in
             switch result {
             case .success(let data):
-                guard let boxOfficeData = data.boxOfficeResults.boxOffices else { return }
+                guard let boxOfficeData = data.boxOfficeResults?.boxOffices else { 
+                    self.activityIndicator.stopAnimating()
+                    self.errorAlert()
+                    return
+                }
                 self.boxOfficeData = boxOfficeData.map { $0.toDTO() }
                 completion()
             case .failure(let error):
@@ -116,7 +120,7 @@ class ViewController: UIViewController {
     func errorAlert() {
         DispatchQueue.main.async {
             self.activityIndicator.stopAnimating()
-            let alert = UIAlertController(title: "데이터 로딩 실패", message: nil, preferredStyle: .alert)
+            let alert = UIAlertController(title: "데이터 로딩 실패하였습니다. 재시도 할까요?", message: nil, preferredStyle: .alert)
             let ok = UIAlertAction(title: "OK", style: .default, handler: nil)
             alert.addAction(ok)
             self.present(alert, animated: true)

--- a/BoxOffice/ViewControllers/ViewController.swift
+++ b/BoxOffice/ViewControllers/ViewController.swift
@@ -278,7 +278,7 @@ extension ViewController: UICollectionViewDelegate {
             switch result {
             case .success(let data):
                 DispatchQueue.main.async {
-                    let vc = MovieDetailViewController(movieInformation: data)
+                    let vc = MovieDetailViewController(movieInformationDTO: data.movieInformationResult.movieInformation.toDTO())
                     self.navigationController?.pushViewController(vc, animated: true)
                 }
             case .failure(let error):

--- a/BoxOffice/ViewControllers/ViewController.swift
+++ b/BoxOffice/ViewControllers/ViewController.swift
@@ -124,7 +124,21 @@ class ViewController: UIViewController {
     }
     
     private func createCollectionViewIconLayout() -> UICollectionViewCompositionalLayout {
-        print("추가해주세요")
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.5), heightDimension: .fractionalWidth(0.5))
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalWidth(0.5))
+        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
+        group.interItemSpacing = .fixed(10)
+        
+        let section = NSCollectionLayoutSection(group: group)
+        section.interGroupSpacing = CGFloat(10)
+        section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 10, bottom: 0, trailing: 10)
+        
+        let configuration = UICollectionViewCompositionalLayout(section: section)
+        
+        return configuration
     }
     
     @objc private func selectCalendarDate(sender: AnyObject) {

--- a/BoxOffice/ViewControllers/ViewController.swift
+++ b/BoxOffice/ViewControllers/ViewController.swift
@@ -112,7 +112,8 @@ class ViewController: UIViewController {
     
     private func getBoxOfficeData(completion: @escaping() -> ()) {
         guard let url = URL(string: URLs.PREFIX + URLs.DAILY_BOX_OFFICE + DateFormatter.fetchYesterdayDate(dateFormatType: .api, dateComponents: self.selectedDateComponents)) else { return }
-        NetworkService().startLoad(url: url, type: BoxOffice.self) { result in
+        
+        NetworkService.shared.startLoad(url: url, type: BoxOffice.self) { result in
             switch result {
             case .success(let data):
                 guard let boxOfficeData = data.boxOfficeResults?.boxOffices else { 
@@ -137,7 +138,6 @@ class ViewController: UIViewController {
     private func createCollectionViewIconLayout() -> UICollectionViewCompositionalLayout {
         let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.5), heightDimension: .fractionalWidth(0.5))
         let item = NSCollectionLayoutItem(layoutSize: itemSize)
-        
         
         let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalWidth(0.5))
         let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
@@ -275,7 +275,7 @@ extension ViewController: UICollectionViewDelegate {
         
         guard let url = URL(string: encodedUrlString) else { return }
         
-        NetworkService().startLoad(url: url, type: MovieInformation.self) { result in
+        NetworkService.shared.startLoad(url: url, type: MovieInformation.self) { result in
             switch result {
             case .success(let data):
                 DispatchQueue.main.async {

--- a/BoxOffice/ViewControllers/ViewController.swift
+++ b/BoxOffice/ViewControllers/ViewController.swift
@@ -25,7 +25,8 @@ class ViewController: UIViewController {
     private var dataSource: UICollectionViewDiffableDataSource<Int, BoxOfficeInformationDTO>!
     private var boxOfficeData: [BoxOfficeInformationDTO] = []
     private var selectedDateComponents = Calendar.current.dateComponents([.year, .month, .day], from: Date.yesterday)
-    private var cellMode: CellMode = .list
+    private var defaults = UserDefaults.standard
+    private lazy var cellMode: CellMode = (defaults.value(forKey: "modeKey") as? String ?? "리스트" == "리스트") ? .list : .icon
     
     private lazy var collectionView: UICollectionView = {
         let collectionView = UICollectionView(frame: CGRect(x: 0,
@@ -73,10 +74,18 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationItem.rightBarButtonItem = calendarButton
+        switch self.cellMode {
+        case .list:
+            self.collectionView.collectionViewLayout = self.createCollectionViewListLayout()
+            self.configureDataSource(.list)
+            self.configureUI()
+        case .icon:
+            self.collectionView.collectionViewLayout = self.createCollectionViewIconLayout()
+            self.configureDataSource(.icon)
+            self.configureUI()
+        }
         configureCollectionView()
-        configureDataSource(cellMode)
         configureMain()
-        configureUI()
         
         collectionView.delegate = self
     }
@@ -152,10 +161,11 @@ class ViewController: UIViewController {
     }
     
     @objc private func changeMode(sender: AnyObject) {
-        cellMode = (cellMode == .list) ? .icon : .list
+        cellMode = (defaults.value(forKey: "modeKey") as? String == "리스트") ? .icon : .list
         
         let alert = UIAlertController(title: "화면모드 변경", message: nil, preferredStyle: .actionSheet)
         let action = UIAlertAction(title: "\(cellMode.name)", style: .default) { _ in
+            self.defaults.setValue(self.cellMode.name, forKey: "modeKey")
             switch self.cellMode {
             case .list:
                 self.collectionView.collectionViewLayout = self.createCollectionViewListLayout()

--- a/BoxOffice/ViewControllers/ViewController.swift
+++ b/BoxOffice/ViewControllers/ViewController.swift
@@ -8,9 +8,8 @@
 import UIKit
 
 class ViewController: UIViewController {
-    
-    private var dataSource: UICollectionViewDiffableDataSource<Int, BoxOfficeInformation>!
-    private var boxOfficeData: [BoxOfficeInformation] = []
+    private var dataSource: UICollectionViewDiffableDataSource<Int, BoxOfficeInformationDTO>!
+    private var boxOfficeData: [BoxOfficeInformationDTO] = []
     private var selectedDateComponents = Calendar.current.dateComponents([.year, .month, .day], from: Date.yesterday)
     
     private lazy var collectionView: UICollectionView = {
@@ -72,7 +71,7 @@ class ViewController: UIViewController {
             switch result {
             case .success(let data):
                 guard let boxOfficeData = data.boxOfficeResults.boxOffices else { return }
-                self.boxOfficeData = boxOfficeData
+                self.boxOfficeData = boxOfficeData.map { $0.toDTO() }
                 completion()
             case .failure(let error):
                 self.errorAlert()
@@ -81,7 +80,7 @@ class ViewController: UIViewController {
     }
     
     private func configureCollectionView() {
-        collectionView.register(BoxOfficeCell.self, forCellWithReuseIdentifier: BoxOfficeCell.reuseIdentifier)
+        collectionView.register(BoxOfficeCell.self, forCellWithReuseIdentifier: BoxOfficeCell.IDENTIFIER)
         view.addSubview(collectionView)
         view.addSubview(activityIndicator)
         configureRefreshControl()
@@ -127,10 +126,10 @@ class ViewController: UIViewController {
 
 extension ViewController {
     private func configureDataSource() {
-        dataSource = UICollectionViewDiffableDataSource<Int, BoxOfficeInformation>(collectionView: collectionView, cellProvider: { collectionView, indexPath, itemIdentifier in
+        dataSource = UICollectionViewDiffableDataSource<Int, BoxOfficeInformationDTO>(collectionView: collectionView, cellProvider: { collectionView, indexPath, itemIdentifier in
             let data = self.boxOfficeData[indexPath.row]
             
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: BoxOfficeCell.reuseIdentifier, for: indexPath) as? BoxOfficeCell else { return UICollectionViewListCell() }
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: BoxOfficeCell.IDENTIFIER, for: indexPath) as? BoxOfficeCell else { return UICollectionViewListCell() }
             
             cell.updateComponents(data: data)
             
@@ -141,7 +140,7 @@ extension ViewController {
     private func setSnapshot() {
         if dataSource == nil { return }
         
-        var snapShot = NSDiffableDataSourceSnapshot<Int, BoxOfficeInformation>()
+        var snapShot = NSDiffableDataSourceSnapshot<Int, BoxOfficeInformationDTO>()
         let section = Array(0...1)
         snapShot.appendSections(section)
         snapShot.appendItems(boxOfficeData, toSection: 0)

--- a/BoxOffice/ViewControllers/ViewController.swift
+++ b/BoxOffice/ViewControllers/ViewController.swift
@@ -32,7 +32,7 @@ class ViewController: UIViewController {
                                                             y: 0,
                                                             width: view.bounds.width,
                                                             height: view.bounds.height - 100),
-                                              collectionViewLayout: self.createCollectionViewLayout())
+                                              collectionViewLayout: self.createCollectionViewListLayout())
         return collectionView
     }()
     
@@ -74,7 +74,7 @@ class ViewController: UIViewController {
         super.viewDidLoad()
         navigationItem.rightBarButtonItem = calendarButton
         configureCollectionView()
-        configureDataSource()
+        configureDataSource(cellMode)
         configureMain()
         configureUI()
     }
@@ -117,10 +117,14 @@ class ViewController: UIViewController {
         }
     }
     
-    private func createCollectionViewLayout() -> UICollectionViewCompositionalLayout {
+    private func createCollectionViewListLayout() -> UICollectionViewCompositionalLayout {
         let configuration = UICollectionLayoutListConfiguration(appearance: .plain)
         
         return UICollectionViewCompositionalLayout.list(using: configuration)
+    }
+    
+    private func createCollectionViewIconLayout() -> UICollectionViewCompositionalLayout {
+        print("추가해주세요")
     }
     
     @objc private func selectCalendarDate(sender: AnyObject) {
@@ -136,7 +140,16 @@ class ViewController: UIViewController {
         
         let alert = UIAlertController(title: "화면모드 변경", message: nil, preferredStyle: .actionSheet)
         let action = UIAlertAction(title: "\(cellMode.name)", style: .default) { _ in
-            print(self.cellMode.name)
+            switch self.cellMode {
+            case .list:
+                self.collectionView.collectionViewLayout = self.createCollectionViewListLayout()
+                self.configureDataSource(.list)
+                self.configureUI()
+            case .icon:
+                self.collectionView.collectionViewLayout = self.createCollectionViewIconLayout()
+                self.configureDataSource(.icon)
+                self.configureUI()
+            }
         }
         
         let cancel = UIAlertAction(title: "취소", style: .cancel)
@@ -159,12 +172,13 @@ class ViewController: UIViewController {
 }
 
 extension ViewController {
-    private func configureDataSource() {
+    private func configureDataSource(_ mode: CellMode) {
         dataSource = UICollectionViewDiffableDataSource<Int, BoxOfficeInformationDTO>(collectionView: collectionView, cellProvider: { collectionView, indexPath, itemIdentifier in
             let data = self.boxOfficeData[indexPath.row]
             
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: BoxOfficeCell.IDENTIFIER, for: indexPath) as? BoxOfficeCell else { return UICollectionViewListCell() }
-            
+            cell.cellMode = self.cellMode
+            cell.configure()
             cell.updateComponents(data: data)
             
             return cell

--- a/BoxOffice/ViewControllers/ViewController.swift
+++ b/BoxOffice/ViewControllers/ViewController.swift
@@ -77,6 +77,8 @@ class ViewController: UIViewController {
         configureDataSource(cellMode)
         configureMain()
         configureUI()
+        
+        collectionView.delegate = self
     }
     
     private func configureUI() {
@@ -251,5 +253,27 @@ extension ViewController: SendDataDelegate {
         activityIndicator.startAnimating()
         selectedDateComponents = dateComponents
         configureUI()
+    }
+}
+
+extension ViewController: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        let data = self.boxOfficeData[indexPath.row]
+        
+        guard let url = URL(string: URLs.PREFIX + URLs.MOVIE_DETAIL + "\(data.movieRepresentCode)") else {
+            return
+        }
+        
+        NetworkService().startLoad(url: url, type: MovieInformation.self) { result in
+            switch result {
+            case .success(let data):
+                DispatchQueue.main.async {
+                    let vc = MovieDetailViewController(movieInformation: data)
+                    self.navigationController?.pushViewController(vc, animated: true)
+                }
+            case .failure(let error):
+                print(error)
+            }
+        }
     }
 }

--- a/BoxOffice/ViewControllers/ViewController.swift
+++ b/BoxOffice/ViewControllers/ViewController.swift
@@ -13,7 +13,11 @@ class ViewController: UIViewController {
     private var selectedDateComponents = Calendar.current.dateComponents([.year, .month, .day], from: Date.yesterday)
     
     private lazy var collectionView: UICollectionView = {
-        let collectionView = UICollectionView(frame: self.view.bounds, collectionViewLayout: self.createCollectionViewLayout())
+        let collectionView = UICollectionView(frame: CGRect(x: 0,
+                                                            y: 0,
+                                                            width: view.bounds.width,
+                                                            height: view.bounds.height - 100),
+                                              collectionViewLayout: self.createCollectionViewLayout())
         return collectionView
     }()
     
@@ -41,6 +45,16 @@ class ViewController: UIViewController {
         return activityIndicator
     }()
     
+    private lazy var modeButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("화면 모드 변경", for: .normal)
+        button.setTitleColor(.systemBlue, for: .normal)
+        button.backgroundColor = .clear
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(self, action: #selector(changeMode), for: .touchUpInside)
+        return button
+    }()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationItem.rightBarButtonItem = calendarButton
@@ -52,11 +66,27 @@ class ViewController: UIViewController {
     private func configureUI() {
         getBoxOfficeData {
             DispatchQueue.main.async {
+                self.configureMain()
                 self.updateNavigationBar()
                 self.setSnapshot()
                 self.activityIndicator.stopAnimating()
             }
         }
+    }
+    
+    private func configureMain() {
+        view.backgroundColor = .systemGray6
+    }
+    
+    private func configureModeButton() {
+        view.addSubview(modeButton)
+        
+        NSLayoutConstraint.activate([
+            modeButton.topAnchor.constraint(equalTo: collectionView.bottomAnchor),
+            modeButton.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            modeButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            modeButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        ])
     }
     
     private func updateNavigationBar() {
@@ -85,9 +115,12 @@ class ViewController: UIViewController {
     
     private func configureCollectionView() {
         collectionView.register(BoxOfficeCell.self, forCellWithReuseIdentifier: BoxOfficeCell.IDENTIFIER)
+        
         view.addSubview(collectionView)
         view.addSubview(activityIndicator)
+        
         configureRefreshControl()
+        configureModeButton()
     }
     
     private func createCollectionViewLayout() -> UICollectionViewCompositionalLayout {
@@ -102,6 +135,19 @@ class ViewController: UIViewController {
         vc.selectedDateComponents = selectedDateComponents
         
         present(vc, animated: true)
+    }
+    
+    @objc private func changeMode(sender: AnyObject) {
+        let alert = UIAlertController(title: "화면모드 변경", message: nil, preferredStyle: .actionSheet)
+        let action = UIAlertAction(title: "아이콘", style: .default) { _ in
+            print("Action Working")
+        }
+        let cancel = UIAlertAction(title: "취소", style: .cancel)
+        
+        alert.addAction(action)
+        alert.addAction(cancel)
+        
+        present(alert, animated: true)
     }
     
     private func configureRefreshControl() {

--- a/BoxOffice/ViewControllers/ViewController.swift
+++ b/BoxOffice/ViewControllers/ViewController.swift
@@ -270,9 +270,10 @@ extension ViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let data = self.boxOfficeData[indexPath.row]
         
-        guard let url = URL(string: URLs.PREFIX + URLs.MOVIE_DETAIL + "\(data.movieRepresentCode)") else {
-            return
-        }
+        let urlString = URLs.PREFIX + URLs.MOVIE_DETAIL + "\(data.movieRepresentCode)"
+        guard let encodedUrlString = urlString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else { return }
+        
+        guard let url = URL(string: encodedUrlString) else { return }
         
         NetworkService().startLoad(url: url, type: MovieInformation.self) { result in
             switch result {

--- a/README.md
+++ b/README.md
@@ -1,3 +1,241 @@
-## 박스오피스 프로젝트 저장소
+## 박스오피스 II
 
-이 저장소를 자신의 저장소로 fork하여 프로젝트를 진행합니다!
+### 목차
+- [1. 소개](#1-소개)
+- [2. 팀원](#2-팀원)
+- [3. 타임라인](#3-타임라인)
+- [4. 트러블 슈팅](#4-트러블-슈팅)
+- [5. 팀 회고](#5-팀-회고)
+- [6. 참고 자료](#6-참고-자료)
+
+---
+### 1. 소개
+- 박스오피스 앱은 영화진흥위원회의 일별 박스오피스와 영화 상세정보 OPEN API로부터 데이터를 받아와 어제의 박스오피스 순위를 출력해줍니다. 또한 해당 영화를 클릭하면 영화 상세정보를 볼 수 있습니다.
+
+### 2. 팀원
+| <img src="https://avatars.githubusercontent.com/u/154333967?v=4" width="200"> | <img src="https://avatars.githubusercontent.com/u/57698939?v=4" width="200"> | <img src="https://avatars.githubusercontent.com/u/96014314?v=4" width="200"> |
+| :-: | :-: | :-: |
+| Danny ([Github](https://github.com/dannykim1215)) | Diana ([Github](https://github.com/Diana-yjh)) | gama ([Github](https://github.com/forseaest))
+
+### 3. 타임라인
+| 날짜 | 제목 |
+| --- | --- |
+| 24.04.15(월) ~ 04.16(화) | 1. `CollectionView` 기초 구현(UICollectionCompositionalLayout 이용) 2.`BoxOfficeCell` 구현<br/> 3.`RefreshControl` 추가 구현<br/>4.`CalenderViewController` 구현<br/> 5.`UIActivityIndicatorView`를 활용하여 앱 시작할 때, 날짜 변경했을 때의 로딩뷰 구현<br/>6. 재사용 셀 관련해서 `prepareForReuse()` 메소드를 통한 초기화   |
+| 24.04.17(수) | 1. `StackView` 중첩 제거<br/>2. 접근제어자 키워드 활용하여 외부에서 보지 않아도 되는 프로퍼티 및 메소드를 캡슐화 |
+| 24.04.18(목) ~ 04.19(금) | 1. CalendarViewController 내부의 Delegate 메소드 extension으로 분리<br/>2. BoxOffice에 대한 `BoxOfficeDTO` 모델 구현<br/>3. 화면모드변경 버튼 구현 및 Alert 추가 |
+| 24.04.22(월) | 1. 화면모드변경에 따른 아이콘, 리스트 분기<br/>2. 아이콘 화면모드에 맞는 레이아웃 추가 구현<br/>3. 카카오API와 네트워킹을 위한 `KaKaOSearchData` 모델 구현, 카카오 API 추가<br/>4. `MovieDetailViewController` 화면 구현 |
+| 24.04.23(화) | 1. `Dynamic Type` 구현<br/>2. `UserDefaults`를 사용하여 이전에 사용했던 화면모드를 이어서 보여주기 구현<br/>3. KaKaoSearchData의 DTO 모델 구현, 카카오 검색 API를 위한 `loadKakaoSearchAPI()` 함수 구현 |
+| 24.04.24(수) | 1. `MovieInformation`의 DTO 모델 구현, List에 다이내믹 타입 적용 |
+| 24.04.25(목) | 1. 영화 상세 화면에서 제목 라벨들이 다이나믹 타입에 의해 잘리거나 줄어드는 현상 해결 |
+| 24.04.26(금) | 1. NetworkService 싱글톤 적용 및 코드 리팩토링<br/> 2. 리드미 작성<br/> 3. STEP 2 PR 작성 |
+
+
+### 4. 트러블 슈팅
+#### 1. ❗️**BoxOffice 앱을 종료하고 실행했을 때, 이전 화면모드(List, Icon) 유지하는 방법**
+##### 📌 문제 상황
+- 사용자가 `BoxOffice` 앱을 종료하고 실행했일 때, 마지막으로 사용했던 화면모드를 유지하고 싶었습니다. 해당 기능을 구현하기 위해 고민한 결과, `cellMode` 값을 앱이 종료되더라도 저장이 되어야 한다고 생각했습니다. 해당 값을 저장하는 방법을 생각해야했습니다.
+
+##### 🛠️ 해결 방법
+- `cellMode`값을 저장하는 방법으로 `UserDefaults` 를 사용하기로 했습니다. `UserDefaults` 를 사용해도 된다고 판단한 이유는 화면모드 자체는 중요한 정보는 아니라고 생각했고, 앱이 종료되더라도 저장된 값이 그대로 갖고 있어야 했기 때문입니다.
+- 먼저, 앱을 실행했을 때 `UserDefaults` 를 통해 저장되어 있는 cellMode 값을 불러와 레이아웃을 구성하게 하였습니다. 
+```swift
+class ViewController: UIViewController {
+	...
+	private var defaults = UserDefaults.standard
+	private lazy var cellMode: CellMode = (defaults.value(forKey: "modeKey") as? String ?? "리스트" == "리스트") ? .list : .icon
+	...
+	override func viewDidLoad() {
+		switch self.cellMode {
+		case .list:
+			self.collectionView.collectionViewLayout = self.createCollectionViewListLayout()
+			self.configureDataSource(.list)
+			self.configureUI()
+		case .icon:
+			self.collectionView.collectionViewLayout = self.createCollectionViewIconLayout()
+			self.configureDataSource(.icon)
+			self.configureUI()
+		}	
+		
+	}
+	
+}
+```
+- Key 값은 `modeKey`로 세팅하였으며, `defaults.value(forKey: "modeKey")` 메소드를 통해서 만약 nil 이라면 "리스트" 값을 무조건 불러오게 하였습니다. 삼항연산자를 통해서 값이 "리스트" 라면 cellMode 변수에 `.list`로 할당했고, "리스트"가 아니라면 "아이콘"이므로 cellMode 변수에 `.icon`을 할당했습니다.
+
+- 그렇다면, 사용자가 앱을 종료하기 직전에 보고있던 화면모드 값을 UserDefaults 에 저장해야한다고 생각했습니다. 화면모드를 변경하는 changeMode 메소드 내부에서 분기처리 할 때 `defaults.setValue(, forKey:)` 메소드를 활용해서 해당 `cellMode` 값을 저장하도록 하였습니다.
+```swift
+@objc private func changeMode(sender: AnyObject) {
+	...
+	let action = UIAlertAction(title: "\(cellMode.name)", style: .default) { _ in
+	    self.defaults.setValue(self.cellMode.name, forKey: "modeKey")
+            switch self.cellMode {
+            case .list:
+                self.collectionView.collectionViewLayout = self.createCollectionViewListLayout()
+                self.configureDataSource(.list)
+                self.configureUI()
+            case .icon:
+                self.collectionView.collectionViewLayout = self.createCollectionViewIconLayout()
+                self.configureDataSource(.icon)
+                self.configureUI()
+        }
+																		   }
+}
+```
+
+
+#### 2. ❗️Icon 뷰의 ContentView와 GridStackView의 레이아웃 관련 문제
+##### 📌 문제 상황
+- Icon 뷰의 GridStackView가 상위 뷰인 ContentView와 레이아웃이 일치하기 때문에 GridStackView가 리소스를 가중시키는 문제가 있었습니다.
+```swift
+[gridStackView].forEach {
+	self.contentView.addSubview($0)
+}
+
+[rankNumberLabel, movieTitleLabel, rankChangeLabel, audienceLabel].forEach {
+	self.gridStackView.addArrangedSubview($0)
+}
+
+NSLayoutConstraint.activate([
+	gridStackView.topAnchor.constraint(equalTo: contentView.topAnchor),
+	gridStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+	gridStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+	gridStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+])
+```
+##### 🛠️ 해결 방법
+- GridStackView를 제거하고, contentView에 해당 컴포넌트들(rankNumberLabel, movieTitleLabel, rankChangeLabel, audienceLabel)를 직접 서브뷰에 할당을하고 레이아웃을 잡아줬습니다. 그리하여, 불필요한 StackView를 제거할 수 있었습니다.
+```swift
+[rankNumberLabel, movieTitleLabel, rankChangeLabel, audienceLabel].forEach {
+	$0.numberOfLines = 0
+	$0.textAlignment = .center
+	self.contentView.addSubview($0)
+}
+
+NSLayoutConstraint.activate([
+	rankNumberLabel.widthAnchor.constraint(equalTo: contentView.widthAnchor),
+	movieTitleLabel.widthAnchor.constraint(equalTo: contentView.widthAnchor),
+	rankChangeLabel.widthAnchor.constraint(equalTo: contentView.widthAnchor),
+	audienceLabel.widthAnchor.constraint(equalTo: contentView.widthAnchor),
+
+	rankNumberLabel.heightAnchor.constraint(equalTo: contentView.heightAnchor, multiplier: 0.25),
+	movieTitleLabel.heightAnchor.constraint(equalTo: contentView.heightAnchor, multiplier: 0.25),
+	rankChangeLabel.heightAnchor.constraint(equalTo: contentView.heightAnchor, multiplier: 0.25),
+	audienceLabel.heightAnchor.constraint(equalTo: contentView.heightAnchor, multiplier: 0.25),
+
+	rankNumberLabel.topAnchor.constraint(equalTo: contentView.topAnchor),
+	movieTitleLabel.topAnchor.constraint(equalTo: rankNumberLabel.bottomAnchor),
+	rankChangeLabel.topAnchor.constraint(equalTo: movieTitleLabel.bottomAnchor),
+	audienceLabel.topAnchor.constraint(equalTo: rankChangeLabel.bottomAnchor)
+])
+```
+
+#### 3. ❗️**카카오 검색 API와 통신하는 함수**
+
+##### 📌 문제 상황
+
+영화 상세 화면에서 영화 포스터의 이미지를ㅌ₩ 띄워주기 위한 카카오 검색 API를 보다 범용적으로 네트워킹하는 메소드를 구현하려고 했습니다.
+
+##### 🛠️ 해결 방법
+
+먼저, 카카오 검색 API의 검색 파라미터들은 공통적으로 원하는 검색어와 이외의 검색 옵션들을 선택적으로 추가할 수 있습니다.
+
+| 이름 | 타입 | 설명 | 필수 |
+| --- | --- | --- | --- |
+| query | String | 검색을 원하는 질의어 | O |
+| sort | String | 결과 문서 정렬 방식, accuracy(정확도순) 또는 recency(최신순), 기본 값 accuracy | X |
+| page | Integer | 결과 페이지 번호, 1~50 사이의 값, 기본 값 1 | X |
+| size | Integer | 한 페이지에 보여질 문서 수, 1~80 사이의 값, 기본 값 80 | X |
+
+함수의 파라미터들에 이 검색 옵션들을 개별적으로 설정하게 하거나 튜플을 사용하는 것보다, 하나의 데이터로 표현하는 것이 한데 모아 보다 코드를 이해하고 읽기 쉬울 것으로 판단하여, 구조체로 구현했습니다.
+
+```swift
+struct KakaoSearchOption {
+    var query: String
+    var sort: searchResultSortingOption?
+    var page: Int?
+    var size: Int?
+    
+    enum searchResultSortingOption: String {
+        case accuracy
+        case recency
+    }
+}
+```
+
+그리고 함수의 파라미터로 받은 검색 옵션은 URLComponents의 queryItems을 통해 URL로 구성되게 만들어줬습니다. accuracy이 기본값이므로, 만약에 sort로 입력 받은 값이 nil일 때를 대비해 닐 코어레싱으로 accuracy를 지정시켰습니다.
+
+```swift
+urlComponents.queryItems = [
+    URLQueryItem(name: "query", value: searchOption.query),
+    URLQueryItem(name: "sort", value: searchOption.sort?.rawValue ?? KakaoSearchOption.searchResultSortingOption.accuracy.rawValue),
+    URLQueryItem(name: "page", value: String(searchOption.page ?? 1)),
+    URLQueryItem(name: "size", value: String(searchOption.page ?? 1)),
+]
+```
+
+API 키를 헤더에 담아 GET으로 요청하고, task를 만든 후 resume()으로 네트워크 작업을 시작하게 했습니다.
+
+```swift
+var urlRequest = URLRequest(url: url)
+urlRequest.httpMethod = "GET"
+urlRequest.setValue("KakaoAK \(URLs.kakaoApiKey)", forHTTPHeaderField: "Authorization")
+```
+
+카카오 검색 API에는 현재 프로젝트에서 필요한 이미지뿐만 아니라 웹문서, 동영상, 블로그 등을 검색할 수 있습니다. 다른 분야들을 검색하고 싶다면 해당 분야의 케이스와 URL 문자열과 분기 처리를 추가하고, 네트워킹 타입을 구현하기만 하면 되도록 함수를 구현했습니다.
+
+```swift
+enum KakaoSearchType {
+    case image
+    
+    var urlString: String {
+        switch self {
+        case .image:
+            return "\(URLs.KAKAO_IMAGE_SEARCH)"
+        }
+    }
+}
+```
+
+#### 4. ❗️**다이나믹 타입 변경에 따른 오토 레이아웃 적용**
+
+##### 📌 문제 상황
+
+폰트에 다이타믹 타입을 적용함에 따라 영화 상세 화면에서 상세 정보들의 타이틀 라벨들의 너비가 일정하지 않아 말줄임표로 내용이 보이지 않거나 잘리는 상황이 발생했습니다. 
+
+##### 🛠️ 해결 방법
+
+스크린샷을 살펴본 결과, 타이틀 라벨들의 각 너비가 가장 긴 상영등급 라벨의 너비에 맞춰져 있는 것을 확인했습니다. 따라서 `movieWatchGradeNameTitleLabel.intrinsicContentSize.width`를 변수로 빼놓고 타이틀 라벨들의 widthAnchor를 상영등급 라벨의 width와 맞춰지도록 하는 함수를 만들어, viewDidLoad와 viewWillAppear에서 호출되도록 해주었습니다. 그러나 width가 2개가 설정되므로 충돌되는 에러가 발생하여 원하는 화면으로 구현되지 않았습니다.
+
+NotificationCenter에 시스템에서 폰트 카테고리가 변경되었을 때 post를 주는 채널인 `UIContentSizeCategory.didChangeNotification`을 등록하고, 알림을 받았을 때 widthAnchor를 업데이트하는 함수를 호출되게 만들었습니다. 다이나믹 타입을 적용하는 것을 감지하지만 여전히 타이틀 라벨들의 너비는 알맞게 적용되지 못하고 있었습니다.
+
+혹시 카테고리화를 위해 타이틀 라벨과 내용값 라벨을 하나의 스택뷰로 묶어주고 개별적인 오토 레이아웃들을 적용시키지 않아서가 아닐까 생각하고, 스택뷰들을 삭제하고 타이틀 라벨들의 trailingAnchor를 너비가 가장 긴 상영등급 라벨의 trailingAnchor와 맞춰주었습니다. 그 결과 다이나믹 타입을 적용할 때마다 타이틀 라벨들의 너비가 해당 다이나믹 타입의 크기에 맞게 설정되고, 라벨의 내용물이 줄어들지 않는 것을 확인하고 해결했습니다.
+
+
+### 5. 팀 회고
+#### 우리팀이 잘한 점 😍
+- Danny
+  - 각자 맡은 부분을 포기하지 않고 끝까지 최선을 다해 구현한 부분과 이해가 안되는 부분을 물어봤을 때 서로가 설명해주고자 했던 부분이 잘한 것 같습니다. 코딩 컨벤션도 잘 지켰다고 생각합니다.
+- Diana 
+  - 추후 작성 예정
+- gama 
+  - 자신이 맡은 코드에 대해 필수적으로 설명하여 팀 프로젝트를 진행하여 코드의 이유에 대해 사유할 수 있었던 좋은 기회였습니다.
+
+#### 우리팀 개선할 점 🥲
+- Danny
+  - 프로젝트와 관련된 내용들을 모두 이해하기에 많은 시간이 필요하기 때문에, 완벽하게 다 이해는 하지 못하고 프로젝트를 수행했었던 것 같습니다. 각자 시간을 더 투자해서 개념이나 코드를 리팩토링 하는 등 노력이 필요할 것으로 보입니다.
+- Diana
+  - 추후 작성 예정
+- gama
+  - 네트워킹과 모던 콜렉션뷰의 사용이 미숙하였고, 다이나믹 타입 적용에 따른 레이아웃 변화가 매우 어려워 시간이 오래 걸린 점이 아쉽습니다.
+
+### 6. 참고 자료
+- [Apple 공식문서 - URLSession](https://developer.apple.com/documentation/foundation/urlsession)
+- [Apple 공식문서 - Fetching website data into memory](https://developer.apple.com/documentation/foundation/url_loading_system/fetching_website_data_into_memory)
+- [Apple 공식문서 - UICollectionViewCompositionalLayout](https://developer.apple.com/documentation/uikit/uicollectionviewcompositionallayout)
+- [Apple 공식문서 - UICollectionViewFlowLayout](https://developer.apple.com/documentation/uikit/uicollectionviewflowlayout)
+- [Apple 샘플 코드 - Implementing Modern Collection Views](https://developer.apple.com/documentation/uikit/views_and_controls/collection_views/implementing_modern_collection_views)
+- [WWDC-Modern cell configuration](https://developer.apple.com/videos/play/wwdc2020/10027/)
+- [WWDC-Lists in UICollectionView](https://developer.apple.com/videos/play/wwdc2020/10026)
+- [Swift - 특정 문자열의 속성 변경](https://ios-development.tistory.com/654)
+- [Apple 공식문서 - UIRefreshControl](https://developer.apple.com/documentation/uikit/uirefreshcontrol)
+- [Apple 공식문서 - UICalendarView](https://developer.apple.com/documentation/uikit/uicalendarview)


### PR DESCRIPTION
안녕하세요🤩 @stevenkim18!
박스오피스 II [STEP 2] PR 드립니다~!🙏

# 🤔 고민했던 점
### **1. BoxOffice 앱을 종료하고 실행했을 때, 이전 화면모드(List, Icon) 유지하는 방법 고민**
- 사용자가 `BoxOffice` 앱을 종료하고 실행했일 때, 마지막으로 사용했던 화면모드를 유지하고 싶었습니다. 해당 기능을 구현하기 위해 고민한 결과, `cellMode` 값을 앱이 종료되더라도 저장이 되어야 한다고 생각했습니다. 그래서 `UserDefaults` 를 사용하기로 했습니다. `UserDefaults` 를 사용해도 된다고 판단한 이유는 화면모드 자체는 중요한 정보는 아니라고 생각했고, 앱이 종료되더라도 저장된 값이 그대로 갖고 있어야 했기 때문입니다.
- 먼저, 앱을 실행했을 때 `UserDefaults` 를 통해 저장되어 있는 cellMode 값을 불러와 레이아웃을 구성하게 하였습니다. 
```swift
class ViewController: UIViewController {
	...
	private var defaults = UserDefaults.standard
	private lazy var cellMode: CellMode = (defaults.value(forKey: "modeKey") as? String ?? "리스트" == "리스트") ? .list : .icon
	...
	override func viewDidLoad() {
		switch self.cellMode {
		case .list:
			self.collectionView.collectionViewLayout = self.createCollectionViewListLayout()
			self.configureDataSource(.list)
			self.configureUI()
		case .icon:
			self.collectionView.collectionViewLayout = self.createCollectionViewIconLayout()
			self.configureDataSource(.icon)
			self.configureUI()
		}	
		
	}
	
}
```
- Key 값은 `modeKey`로 세팅하였으며, `defaults.value(forKey: "modeKey")` 메소드를 통해서 만약 nil 이라면 "리스트" 값을 무조건 불러오게 하였습니다. 삼항연산자를 통해서 값이 "리스트" 라면 cellMode 변수에 `.list`로 할당했고, "리스트"가 아니라면 "아이콘"이므로 cellMode 변수에 `.icon`을 할당했습니다.

- 그렇다면, 사용자가 앱을 종료하기 직전에 보고있던 화면모드 값을 UserDefaults 에 저장해야한다고 생각했습니다. 화면모드를 변경하는 changeMode 메소드 내부에서 분기처리 할 때 `defaults.setValue(, forKey:)` 메소드를 활용해서 해당 `cellMode` 값을 저장하도록 하였습니다.
```swift
@objc private func changeMode(sender: AnyObject) {
	...
	let action = UIAlertAction(title: "\(cellMode.name)", style: .default) { _ in
	    self.defaults.setValue(self.cellMode.name, forKey: "modeKey")
            switch self.cellMode {
            case .list:
                self.collectionView.collectionViewLayout = self.createCollectionViewListLayout()
                self.configureDataSource(.list)
                self.configureUI()
            case .icon:
                self.collectionView.collectionViewLayout = self.createCollectionViewIconLayout()
                self.configureDataSource(.icon)
                self.configureUI()
        }
																		   }
}
```

### **2. 엔티티 타입과 DTO 타입의 분리**  
- 신작 영화인지 판별하거나 순위 등락에 대해 다르게 표기해주는 함수 등을 뷰 컨트롤러보다 해당 모델 안에서 구현하는 것이 보다 적절하다고 판단하였고, 모든 데이터 타입에 대해 그 결과 API로부터 네트워크 통신을 통해 받아오는 엔티티와 실제 사용되는 값들만 모은 DTO를 만들었습니다. 엔티티 타입에는 DTO 타입으로 변환하는 함수를 추가했고, 뷰 컨트롤러에서 네트워크 통신 후 받아온 엔티티 형태의 데이터를 이 함수를 통해 DTO로 변환시켜 화면에 적용되도록 하였습니다. b4edcba1056bb46c9307a5c53eaf55244ff9b9e7 2ffe7bcf6e69b8f7b96950e00bb79839104a48e5 35a46686072bfcee8f63b0c55f31989078b9b02c

### **3. `Icon` 화면모드에서 Dynamic Type 모드로 적용할 때 자연스럽게 보여주기 위한 고민**
- `Icon` 화면모드의 경우, 1개의 Group 안에 2개의 item으로 구성되어 레이아웃을 보여줍니다. 하지만, 구성 컴포넌트들에 Dynamic Type을 적용하고 폰트 크기를 최대로 설정할 경우, 폰트가 잘리는 것을 볼 수 있었습니다.
- DDG 조에서는 2가지 방법을 고민해보고자 하였습니다.
	- 첫째, 폰트 크기가 커져서 Cell 범위를 벗어날 경우, 폰트의 크기에 맞기 Group과 item의 크기와 개수도 동적으로 변경하는 방법 → 해당 방법의 경우, 폰트 크기에 따른 Group과 item의 크기와 개수를 설정하는 것이 어려웠던 부분이었습니다. 그래서 해당 방법은 채택하지 않았습니다.
	- 둘째, Cell 범위를 벗어날 경우, ... 이 나오게 하여 사용자에게 내용이 더 있지만 폰트가 너무 커서 보여줄 수 있다는 것을 인지할 수 있도록 하는 방법 → 해당 방법의 경우, `BoxOfficeCell` 클래스 타입에서 해당 컴포넌트들의 레이아웃 수정을 통해 구현이 가능했기 때문에 해당 방법을 채택하였습니다.

### **4. 카카오 검색 API와 통신하는 함수**
영화 상세 화면에서 영화 포스터의 이미지를 띄워주기 위해서 카카오 검색 API를 사용해야 했습니다. 카카오 검색 서비스에서 이미지를 검색하는 API에 영화 이름 + 포스터에 대한 검색의 첫번째 이미지를 출력해줘야 했습니다. 라이브러리를 사용하지 않고, URLSession만을 통한 메소드를 만들려고 시도했습니다.

먼저, 카카오 검색 API의 검색 파라미터들은 공통적으로 원하는 검색어와 이외의 검색 옵션들을 선택적으로 추가할 수 있게 되어 있었습니다.

| 이름 | 타입 | 설명 | 필수 |
| --- | --- | --- | --- |
| query | String | 검색을 원하는 질의어 | O |
| sort | String | 결과 문서 정렬 방식, accuracy(정확도순) 또는 recency(최신순), 기본 값 accuracy | X |
| page | Integer | 결과 페이지 번호, 1~50 사이의 값, 기본 값 1 | X |
| size | Integer | 한 페이지에 보여질 문서 수, 1~80 사이의 값, 기본 값 80 | X |

그렇다면 이 검색 파라미터들을 하나의 데이터로 표현하는 것이 보다 코드를 이해하고 읽기 쉬울 것으로 판단하여, 구조체로 구현했습니다. 그리고 함수의 파라미터로 받은 검색 옵션은 URLComponents의 queryItems을 통해 URL로 구성되게 만들어줬습니다. 

```swift
struct KakaoSearchOption {
    var query: String
    var sort: searchResultSortingOption?
    var page: Int?
    var size: Int?
    
    enum searchResultSortingOption: String {
        case accuracy
        case recency
    }
}
```

```swift
urlComponents.queryItems = [
    URLQueryItem(name: "query", value: searchOption.query),
    URLQueryItem(name: "sort", value: searchOption.sort?.rawValue ?? KakaoSearchOption.searchResultSortingOption.accuracy.rawValue),
    URLQueryItem(name: "page", value: String(searchOption.page ?? 1)),
    URLQueryItem(name: "size", value: String(searchOption.page ?? 1)),
]
```

API 키를 헤더에 담아 GET으로 요청하고, task를 만든 후 resume()으로 네트워크 작업을 시작하게 했습니다.

```swift
var urlRequest = URLRequest(url: url)
urlRequest.httpMethod = "GET"
urlRequest.setValue("KakaoAK \(URLs.kakaoApiKey)", forHTTPHeaderField: "Authorization")
```

또한 이 함수를 카카오 검색 API에 대해서 보다 범용적으로 만들고 싶다고 생각했습니다. 카카오 검색 API에는 현재 프로젝트에서 필요한 이미지뿐만 아니라 웹문서, 동영상, 블로그 등을 검색할 수 있습니다. 다른 분야들을 검색하고 싶다면 해당 분야의 케이스와 URL 문자열을 추가하고, 네트워킹 타입을 구현하기만 하면 되도록 함수를 구현했습니다.

```swift
enum KakaoSearchType {
    case image
    
    var urlString: String {
        switch self {
        case .image:
            return "\(URLs.KAKAO_IMAGE_SEARCH)"
        }
    }
}
```

# 🙏 조언을 얻고 싶은 점
**1. Constant 값의 위치**
```swift
class MovieDetailViewController: UIViewController {
    static let topPaddingConstant: CGFloat = 20
    static let bottomPaddingConstant: CGFloat = -20
    static let leadingPaddingConstant: CGFloat = 20
    static let trailingPaddingConstant: CGFloat = -20
    static let gapPaddingConstant: CGFloat = 10
    static let titleMultiplierConstant: CGFloat = 0.2
    
    final let BODY_FONT: UIFont = FontConstants.BODY
    final let BODY_BOLD_FONT: UIFont = FontConstants.BODY_BOLD
}
```

현재 프로젝트에서는 뷰 컨트롤러 안에 UI에 필요한 Constant 값을 타입 프로퍼티로 구현하고, `MovieDetailViewController.topPaddingConstant`처럼 사용하고 있습니다.

```swift
enum Constant {
    struct MovieDetail {
        static let topPaddingConstant: CGFloat = 20
        static let bottomPaddingConstant: CGFloat = -20
        static let leadingPaddingConstant: CGFloat = 20
        static let trailingPaddingConstant: CGFloat = -20
        static let gapPaddingConstant: CGFloat = 10
        static let titleMultiplierConstant: CGFloat = 0.2
    }
}
```

그러나, 이렇게 별도의 파일을 생성하고 Constant 구조체나 열거형을 구현하고, 내부에서 뷰 컨트롤러 이름으로 중첩 타입을 구성하고 Constant 값을 타입 프로퍼티로 하여 `Constant.MovieDetail.topPaddingConstant`처럼 사용하는 방식이 보다 보편적으로 보았습니다.

저희가 프로젝트에서 사용한 방식은 사용하는 뷰 컨트롤러 안에 정의한만큼 추적이 쉽다는 장점이 있으나, Constant가 아닌 프로퍼티가 많을 경우 복잡할 수 있는 점이 단점이라고 생각합니다. 한편으로는 별도의 파일로 관리하는 것 또한 추적이 쉽다고 생각합니다. 어느 점에 주안점을 두고 방식을 채택해야할지 모르겠습니다.. 어떤 식으로 Constant 값을 관리해야 좋을지 스티븐의 조언을 얻고 싶습니다!

**2. SendDataDelegate 네이밍과 위치**

코드로 화면을 구현할 때에는 이전 화면으로 돌아가면서 데이터를 전달하기 위해서는 Delegate 패턴을 사용한다는 것을 알게 되었고, 다음과 같이 구현하여 캘린더 화면에서 선택한 날짜를 박스오피스 순위 리스트 화면으로 돌아갈 때 전달하도록 해주었습니다.

```swift
protocol SendDataDelegate: AnyObject {
    func updateDate(dateComponents: DateComponents)
}

class CalendarViewController: UIViewController {
    weak var delegate: SendDataDelegate?
}

extension CalendarViewController: UICalendarSelectionSingleDateDelegate {
    func dateSelection(_ selection: UICalendarSelectionSingleDate, didSelectDate dateComponents: DateComponents?) {
        delegate?.updateDate(dateComponents: safeDateComponents)
        dismiss(animated: true)
    }
}
```

이렇게 SendDataDelegate를 CalendarViewController가 있는 한 파일 안에서 CalendarViewController 앞에 선언해주었는데, 이런 데이터 전송 용으로 만든 프로토콜의 경우에는 위치를 어느 곳에 놓아야 할지가 고민입니다. 또한 네이밍 또한 적절한지 궁금합니다!

**3. 네트워크 객체의 싱글톤 패턴 적용**
본 프로젝트는 모든 화면에서 API와 네트워크하여 데이터를 가져와 화면에 보여주고 있기에, 뷰 컨트롤러마다 NetworkService를 사용합니다. 매번 인스턴스화 하여 사용하고 있기 때문에, 매번 메모리를 할당하고 초기화하는 과정과 비용이 든다고 생각합니다. 그래서 NetworkService를 싱글톤 객체로 만들어서, 단 하나만을 한번만 생성되도록 하여 메모리 초기화 과정과 비용을 줄이도록 했습니다. 싱글톤의 단점으로는 전역적으로 접근할 수 있기 때문에 관리가 어렵다는 단점이 있으나, NetworkService는 영화진흥위원회 API와 카카오 검색 API로부터 데이터를 일방적으로 받아오는 기능만 있기 때문에 이 단점은 작용되지 않는다고 생각했습니다.

아직 싱글톤 패턴을 언제 사용해야 할지 결정에 미숙하고, 판단 근거가 적절한지에 대한 의구심이 있습니다. 네트워크 객체를 싱글톤으로 적용하는 것에 대해 조언을 얻고 싶습니다..!